### PR TITLE
Increase MAX_MSG_SIZE to 16KB

### DIFF
--- a/src/client/cl_main.c
+++ b/src/client/cl_main.c
@@ -510,7 +510,7 @@ static void Cl_InitLocal(void) {
 	message_level = Cvar_Get("message_level", "0", CVAR_USER_INFO | CVAR_ARCHIVE, NULL);
 	name = Cvar_Get("name", Cl_Username(), CVAR_USER_INFO | CVAR_ARCHIVE, NULL);
 	password = Cvar_Get("password", "", CVAR_USER_INFO, NULL);
-	rate = Cvar_Get("rate", va("%d", CLIENT_RATE), CVAR_USER_INFO | CVAR_ARCHIVE, NULL);
+	rate = Cvar_Get("rate", "0", CVAR_USER_INFO | CVAR_ARCHIVE, NULL);
 	skin = Cvar_Get("skin", "qforcer/default", CVAR_USER_INFO | CVAR_ARCHIVE, NULL);
 
 	qport = Cvar_Get("qport", va("%d", Random() & 0xff), 0, NULL);

--- a/src/client/ui/ui_controls.c
+++ b/src/client/ui/ui_controls.c
@@ -70,7 +70,7 @@ TwBar *Ui_Controls(void) {
 	Ui_Bind(bar, "Toggle fullscreen", "r_toggle_fullscreen", "group=System");
 	Ui_Bind(bar, "Take screenshot", "r_screenshot", "group=System");
 
-	TwDefine("Controls size='400 610' alpha=200 iconifiable=false valueswidth=180 visible=false");
+	TwDefine("Controls size='400 630' alpha=200 iconifiable=false valueswidth=180 visible=false");
 
 	return bar;
 }

--- a/src/client/ui/ui_system.c
+++ b/src/client/ui/ui_system.c
@@ -58,11 +58,25 @@ TwBar *Ui_System(void) {
 	Ui_CvarDecimal(bar, "Volume", s_volume, "min=0.0 max=1.0 step=0.1 group=Audio");
 	Ui_CvarDecimal(bar, "Music volume", s_music_volume, "min=0.0 max=1.0 step=0.1 group=Audio");
 
+	TwAddSeparator(bar, NULL, "group=Network");
+
+	static TwType Rate;
+	if (!Rate) {
+		const TwEnumVal RateEnum[] = {
+			{ 16384, "DSL" },
+			{ 131072, "Cable" },
+			{ 0, "LAN" },
+		};
+		Rate = TwDefineEnum("Rate", RateEnum, lengthof(RateEnum));
+	}
+
+	Ui_CvarEnum(bar, "Connection", rate, Rate, "group=Network");
+
 	TwAddSeparator(bar, NULL, NULL);
 
 	TwAddButton(bar, "Apply", Ui_Command, "r_restart; s_restart;", NULL);
 
-	TwDefine("System size='400 420' alpha=200 iconifiable=false valueswidth=100 visible=false");
+	TwDefine("System size='400 460' alpha=200 iconifiable=false valueswidth=100 visible=false");
 
 	return bar;
 }

--- a/src/common.h
+++ b/src/common.h
@@ -76,7 +76,7 @@
 /*
  * @brief The maximum number of entities to be referenced in a single message.
  */
-#define MAX_PACKET_ENTITIES	64
+#define MAX_PACKET_ENTITIES	128
 
 /*
  * @brief Client bandwidth throttling thresholds, in bytes per second. Clients

--- a/src/common.h
+++ b/src/common.h
@@ -82,14 +82,9 @@
  * @brief Client bandwidth throttling thresholds, in bytes per second. Clients
  * may actually request that the server drops messages for them above a certain
  * bandwidth saturation point in order to maintain some level of connectivity.
+ * However, they must accept at least 8KB/s.
  */
 #define CLIENT_RATE_MIN		8192
-#define CLIENT_RATE_MAX		65536
-
-/*
- * @brief Default client bandwidth rate threshold.
- */
-#define CLIENT_RATE			16384
 
 /*
  * Disallow dangerous downloads for both the client and server.

--- a/src/common.h
+++ b/src/common.h
@@ -41,7 +41,7 @@
  * of core net messages or serialized data types change. The game and client
  * game maintain PROTOCOL_MINOR as well.
  */
-#define PROTOCOL_MAJOR		1012
+#define PROTOCOL_MAJOR		1013
 
 /*
  * @brief The IP address of the master server, where the authoritative list of

--- a/src/common.h
+++ b/src/common.h
@@ -84,7 +84,7 @@
  * bandwidth saturation point in order to maintain some level of connectivity.
  */
 #define CLIENT_RATE_MIN		8192
-#define CLIENT_RATE_MAX		32768
+#define CLIENT_RATE_MAX		65536
 
 /*
  * @brief Default client bandwidth rate threshold.

--- a/src/game/default/g_client.c
+++ b/src/game/default/g_client.c
@@ -263,13 +263,13 @@ static void G_ClientCorpse_Think(g_entity_t *self) {
 		}
 	}
 
-	if (age > 13000) {
+	if (age > 33000) {
 		G_FreeEntity(self);
 		return;
 	}
 
 	// sink into the floor after a few seconds
-	if (age > 10000) {
+	if (age > 30000) {
 
 		self->s.effects |= EF_DESPAWN;
 
@@ -359,7 +359,7 @@ static void G_ClientCorpse_Die(g_entity_t *self, g_entity_t *attacker __attribut
 
 		gi.LinkEntity(self);
 	} else {
-		G_FreeEntity(self);
+		//G_FreeEntity(self);
 	}
 }
 

--- a/src/game/default/g_client.c
+++ b/src/game/default/g_client.c
@@ -263,13 +263,13 @@ static void G_ClientCorpse_Think(g_entity_t *self) {
 		}
 	}
 
-	if (age > 33000) {
+	if (age > 13000) {
 		G_FreeEntity(self);
 		return;
 	}
 
 	// sink into the floor after a few seconds
-	if (age > 30000) {
+	if (age > 10000) {
 
 		self->s.effects |= EF_DESPAWN;
 
@@ -359,7 +359,7 @@ static void G_ClientCorpse_Die(g_entity_t *self, g_entity_t *attacker __attribut
 
 		gi.LinkEntity(self);
 	} else {
-		//G_FreeEntity(self);
+		G_FreeEntity(self);
 	}
 }
 

--- a/src/net/net_types.h
+++ b/src/net/net_types.h
@@ -52,7 +52,7 @@ typedef uint16_t in_port_t;
  * net message can exceed this length. However, large frames can be split
  * into multiple messages and sent in series. See Sv_SendClientDatagram.
  */
-#define MAX_MSG_SIZE 1400
+#define MAX_MSG_SIZE 16384
 
 typedef enum {
 	NA_LOOP,

--- a/src/net/net_types.h
+++ b/src/net/net_types.h
@@ -48,9 +48,9 @@ typedef uint16_t in_port_t;
 #include "common.h"
 
 /*
- * @brief Max length of a single packet, due to UDP fragmentation. No single
- * net message can exceed this length. However, large frames can be split
- * into multiple messages and sent in series. See Sv_SendClientDatagram.
+ * @brief Max length of a single packet. No individual message can exceed
+ * this length. However, large server frames can be split into multiple
+ * messages and sent in series. See Sv_SendClientDatagram.
  */
 #define MAX_MSG_SIZE 16384
 

--- a/src/quetoo.h
+++ b/src/quetoo.h
@@ -88,9 +88,9 @@ typedef dvec_t dvec4_t[4];
  * @brief Protocol limits.
  */
 #define MIN_CLIENTS			1 // duh
-#define MAX_CLIENTS			256 // absolute limit
+#define MAX_CLIENTS			64 // absolute limit
 #define MIN_ENTITIES		128 // necessary for even the simplest game
-#define MAX_ENTITIES		1024 // must change protocol to increase more
+#define MAX_ENTITIES		1024 // this can be increased with minimal effort
 #define MAX_MODELS			256 // these are sent over the net as uint8_t
 #define MAX_SOUNDS			256 // so they cannot be blindly increased
 #define MAX_MUSICS			8 // per level

--- a/src/server/sv_entity.c
+++ b/src/server/sv_entity.c
@@ -258,7 +258,7 @@ void Sv_BuildClientFrame(sv_client_t *client) {
 			}
 		}
 
-		// add it to the circular entity_state_t array
+		// copy it to the circular entity_state_t array
 		entity_state_t *s = &svs.entity_states[svs.next_entity_state % svs.num_entity_states];
 		if (ent->s.number != e) {
 			Com_Warn("Fixing entity number: %d -> %d\n", ent->s.number, e);

--- a/src/server/sv_main.c
+++ b/src/server/sv_main.c
@@ -661,9 +661,6 @@ const char *Sv_NetaddrToString(const sv_client_t *cl) {
 	return Net_NetaddrToString(&cl->net_chan.remote_address);
 }
 
-#define MIN_RATE 8000
-#define DEFAULT_RATE 20000
-
 /*
  * @brief Enforces safe user_info data before passing onto game module.
  */
@@ -702,7 +699,9 @@ void Sv_UserInfoChanged(sv_client_t *cl) {
 	val = GetUserInfo(cl->user_info, "rate");
 	if (*val != '\0') {
 		cl->rate = strtoul(val, NULL, 10);
-		cl->rate = Clamp(cl->rate, CLIENT_RATE_MIN, CLIENT_RATE_MAX);
+		if (cl->rate > 0 && cl->rate < CLIENT_RATE_MIN) {
+			cl->rate = CLIENT_RATE_MIN;
+		}
 	}
 
 	// limit the print messages the client receives

--- a/src/server/sv_types.h
+++ b/src/server/sv_types.h
@@ -145,11 +145,9 @@ typedef enum {
 } sv_client_state_t;
 
 /*
- * The absolute maximum size of a frame (packet entities). Large frames are
- * buffered and packetized for network transmission in smaller envelopes. See
- * MAX_MSG_SIZE.
+ * @brief The maximum size of a client's datagram buffer.
  */
-#define MAX_FRAME_SIZE 8192
+#define MAX_DATAGRAM_SIZE (MAX_MSG_SIZE * 4)
 
 /*
  * @brief Represents the bounds of an individual client message within the
@@ -167,7 +165,7 @@ typedef struct {
  */
 typedef struct {
 	mem_buf_t buffer; // the managed size buffer
-	byte data[MAX_FRAME_SIZE]; // the raw message buffer
+	byte data[MAX_MSG_SIZE]; // the raw message buffer
 	GList *messages; // message segmentation
 } sv_client_datagram_t;
 

--- a/src/server/sv_types.h
+++ b/src/server/sv_types.h
@@ -165,7 +165,7 @@ typedef struct {
  */
 typedef struct {
 	mem_buf_t buffer; // the managed size buffer
-	byte data[MAX_MSG_SIZE]; // the raw message buffer
+	byte data[MAX_DATAGRAM_SIZE]; // the raw message buffer
 	GList *messages; // message segmentation
 } sv_client_datagram_t;
 

--- a/src/server/sv_types.h
+++ b/src/server/sv_types.h
@@ -197,7 +197,7 @@ typedef struct {
 
 	uint32_t frame_latency[SV_CLIENT_LATENCY_COUNT]; // used to calculate ping
 
-	uint32_t message_size[SV_HZ_MAX]; // used to rate drop packets
+	uint32_t frame_size[SV_HZ_MAX]; // used to rate drop packets
 	uint32_t rate;
 	uint32_t surpress_count; // number of messages rate suppressed
 


### PR DESCRIPTION
With moving to 32bit floating point coordinates for entity state and player state, it's pretty easy to exhaust the 20-year-old MAX_MSG_SIZE value of 1400 bytes. IP transport layers are supposed to transparently handle fragmenting packets larger than MTU, and after some experimentation from my home network (IPV4/V6 + NAT) to a dedicated server on Rackspace, it does appear to do so. I was able to create 12KB datagrams in-game and things hummed right along smoothly.

I actually have to wonder what's the harm in _trying_ large packets, anyway? The old code would error out as soon as packets become large. Might as well at least try, right?