### PR TITLE
Added server-side voting control for server admins. Fixes #19

### DIFF
--- a/src/game/default/g_cmd.h
+++ b/src/game/default/g_cmd.h
@@ -25,7 +25,8 @@
 #include "g_types.h"
 
 #ifdef __GAME_LOCAL_H__
-void G_CreateVoteCVars();
+void G_InitVote();
+void G_ShutdownVote();
 _Bool G_AddClientToTeam(g_entity_t *ent, const char *team_name);
 void G_ClientCommand(g_entity_t *ent);
 void G_Score_f(g_entity_t *ent);

--- a/src/game/default/g_cmd.h
+++ b/src/game/default/g_cmd.h
@@ -25,6 +25,7 @@
 #include "g_types.h"
 
 #ifdef __GAME_LOCAL_H__
+void G_CreateVoteCVars();
 _Bool G_AddClientToTeam(g_entity_t *ent, const char *team_name);
 void G_ClientCommand(g_entity_t *ent);
 void G_Score_f(g_entity_t *ent);

--- a/src/game/default/g_main.c
+++ b/src/game/default/g_main.c
@@ -921,6 +921,7 @@ void G_Init(void) {
 
 	dedicated = gi.Cvar("dedicated", "0", CVAR_NO_SET, NULL);
 
+	G_CreateVoteCVars();
 
 	// initialize entities and clients for this game
 	g_game.entities = gi.Malloc(g_max_entities->integer * sizeof(g_entity_t), MEM_TAG_GAME);

--- a/src/game/default/g_main.c
+++ b/src/game/default/g_main.c
@@ -921,7 +921,7 @@ void G_Init(void) {
 
 	dedicated = gi.Cvar("dedicated", "0", CVAR_NO_SET, NULL);
 
-	G_CreateVoteCVars();
+	G_InitVote();
 
 	// initialize entities and clients for this game
 	g_game.entities = gi.Malloc(g_max_entities->integer * sizeof(g_entity_t), MEM_TAG_GAME);
@@ -960,6 +960,8 @@ void G_Shutdown(void) {
 	G_MySQL_Shutdown();
 	G_MapList_Shutdown();
 	G_Ai_Shutdown();
+
+	G_ShutdownVote();
 
 	gi.FreeTag(MEM_TAG_GAME_LEVEL);
 	gi.FreeTag(MEM_TAG_GAME);


### PR DESCRIPTION
As the title says. This just creates a server-side CVar for each votable option in the form of `g_voting_allow_<vote>`.