### PR TITLE
Fix #201 by disabling TextInput until it's absolutely necessary

### DIFF
--- a/src/client/cl_keys.c
+++ b/src/client/cl_keys.c
@@ -79,7 +79,8 @@ void Cl_SetKeyDest(cl_key_dest_t dest) {
  */
 static void Cl_KeyConsole(const SDL_Event *event) {
 
-	SDL_StartTextInput();
+	if (SDL_GetEventState(SDL_TEXTINPUT) != SDL_ENABLE)
+		SDL_StartTextInput();
 
 	if (event->type == SDL_KEYUP) // don't care
 		return;
@@ -252,7 +253,8 @@ static void Cl_KeyGame(const SDL_Event *event) {
  */
 static void Cl_KeyChat(const SDL_Event *event) {
 
-	SDL_StartTextInput();
+	if (SDL_GetEventState(SDL_TEXTINPUT) != SDL_ENABLE)
+		SDL_StartTextInput();
 
 	if (event->type == SDL_KEYUP) // don't care
 		return;

--- a/src/client/cl_keys.c
+++ b/src/client/cl_keys.c
@@ -58,10 +58,6 @@ void Cl_SetKeyDest(cl_key_dest_t dest) {
 	SDL_FlushEvent(SDL_TEXTINPUT);
 
 	switch (dest) {
-		case KEY_CONSOLE:
-		case KEY_CHAT:
-			SDL_StartTextInput();
-			break;
 		case KEY_UI:
 			SDL_StopTextInput();
 		{
@@ -82,6 +78,8 @@ void Cl_SetKeyDest(cl_key_dest_t dest) {
  * @brief Interactive line editing and console scrollback.
  */
 static void Cl_KeyConsole(const SDL_Event *event) {
+
+	SDL_StartTextInput();
 
 	if (event->type == SDL_KEYUP) // don't care
 		return;
@@ -253,6 +251,8 @@ static void Cl_KeyGame(const SDL_Event *event) {
  * @brief
  */
 static void Cl_KeyChat(const SDL_Event *event) {
+
+	SDL_StartTextInput();
 
 	if (event->type == SDL_KEYUP) // don't care
 		return;

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -177,6 +177,9 @@ static void Init(void) {
 		Cbuf_AddText("map edge\n");
 		Cbuf_Execute();
 	}
+
+	// Eliminate garbage filling input buffer until it's needed
+	SDL_StopTextInput();
 }
 
 /**


### PR DESCRIPTION
What a little bug.

While trying to debug this, I've found out that SDL_StopTextInput() doesn't necessarily work. Somewhere along the Init() sequence it gets undone eventhough there are no explicit SDL_StartTextInput() calls and that SDL is already initialized.