### PR TITLE
Remove part of the rocket trail

### DIFF
--- a/src/cgame/default/cg_entity_trail.c
+++ b/src/cgame/default/cg_entity_trail.c
@@ -295,33 +295,6 @@ static void Cg_RocketTrail(cl_entity_t *ent, const vec3_t start, const vec3_t en
 
 	Cg_SmokeTrail(ent, start, end);
 
-	if (time < ent->time) { // time to add new particles
-		vec3_t delta;
-
-		VectorSubtract(end, start, delta);
-		const vec_t dist = VectorNormalize(delta);
-
-		vec_t d = 0.0;
-		while (d < dist) {
-			cg_particle_t *p;
-
-			if (!(p = Cg_AllocParticle(PARTICLE_NORMAL, cg_particles_flame)))
-				break;
-
-			cgi.ColorFromPalette(EFFECT_COLOR_ORANGE + (Random() & 5), p->part.color);
-			Vector4Set(p->color_vel, 1.0, 1.0, 1.0, -2.0);
-
-			p->part.scale = 4.0;
-			p->scale_vel = -6.0;
-
-			VectorMA(start, d, delta, p->part.org);
-			VectorScale(delta, 800.0, p->vel);
-			VectorScale(delta, -1200.0, p->accel);
-
-			d += 1.0;
-		}
-	}
-
 	r_corona_t c;
 	VectorCopy(end, c.origin);
 	c.radius = 3.0;


### PR DESCRIPTION
The effect is really hard to see (at least for me), but it has the significant problem where the effect shoots through a wall a large distance. (Shoot a rocket against a near corner and keep moving around it quickly and you can see it shoot through).
