### PR TITLE
#237 Flip a bit on shadow-impacted frames, use this to govern stencil…

### DIFF
--- a/src/client/renderer/r_bsp.c
+++ b/src/client/renderer/r_bsp.c
@@ -156,7 +156,7 @@ static void R_DrawBspInlineModel_(const r_entity_t *e) {
 	surf = &r_model_state.world->bsp->surfaces[e->model->bsp_inline->first_surface];
 
 	for (i = 0; i < e->model->bsp_inline->num_surfaces; i++, surf++) {
-		const cm_bsp_plane_t *plane = surf->plane;
+		const r_bsp_plane_t *plane = surf->plane;
 		vec_t dot;
 
 		// find which side of the surf we are on
@@ -256,7 +256,7 @@ static void R_AddBspInlineModelFlares_(const r_entity_t *e) {
 	r_bsp_surface_t *surf = &r_model_state.world->bsp->surfaces[e->model->bsp_inline->first_surface];
 
 	for (uint32_t i = 0; i < e->model->bsp_inline->num_surfaces; i++, surf++) {
-		const cm_bsp_plane_t *plane = surf->plane;
+		const r_bsp_plane_t *plane = surf->plane;
 		vec_t dot;
 
 		// find which side of the surf we are on
@@ -506,6 +506,9 @@ static void R_MarkBspSurfaces_(r_bsp_node_t *node) {
 		side_bit = R_SURF_PLANE_BACK;
 	}
 
+	// reset the per-frame flags on the node's plane
+	node->plane->flags = 0;
+
 	// recurse down the children, front side first
 	R_MarkBspSurfaces_(node->children[side]);
 
@@ -545,6 +548,7 @@ void R_MarkBspSurfaces(void) {
 	// flag all visible world surfaces
 	R_MarkBspSurfaces_(r_model_state.world->bsp->nodes);
 }
+
 
 /**
  * @brief Returns the leaf for the specified point.

--- a/src/client/renderer/r_bsp_model.c
+++ b/src/client/renderer/r_bsp_model.c
@@ -645,7 +645,7 @@ static void R_LoadBspPlanes(r_bsp_model_t *bsp, const d_bsp_lump_t *l) {
 	}
 
 	const int32_t count = l->file_len / sizeof(*in);
-	cm_bsp_plane_t *out = Mem_LinkMalloc(count * sizeof(*out), bsp);
+	r_bsp_plane_t *out = Mem_LinkMalloc(count * sizeof(*out), bsp);
 
 	bsp->planes = out;
 	bsp->num_planes = count;
@@ -658,8 +658,8 @@ static void R_LoadBspPlanes(r_bsp_model_t *bsp, const d_bsp_lump_t *l) {
 
 		out->dist = LittleFloat(in->dist);
 		out->type = LittleLong(in->type);
-		out->sign_bits = Cm_SignBitsForPlane(out);
-		out->num = (i >> 1) + 1;
+		out->sign_bits = Cm_SignBitsForPlane((cm_bsp_plane_t *) out);
+		out->index = i, out->num = (i >> 1) + 1;
 	}
 }
 

--- a/src/client/renderer/r_bsp_surface.c
+++ b/src/client/renderer/r_bsp_surface.c
@@ -65,7 +65,11 @@ static void R_SetBspSurfaceState_default(const r_bsp_surface_t *surf) {
 	}
 
 	if (r_state.stencil_test_enabled) { // write to stencil buffer to clip shadows
-		R_StencilFunc(GL_ALWAYS, (surf->plane->num % 0xff) + 1, ~0);
+		if (surf->plane->flags & R_PLANE_SHADOW) {
+			R_StencilFunc(GL_ALWAYS, (surf->plane->num % 0xff) + 1, ~0);
+		} else {
+			R_StencilFunc(GL_ALWAYS, 0, 0);
+		}
 	}
 }
 

--- a/src/client/renderer/r_lighting.c
+++ b/src/client/renderer/r_lighting.c
@@ -367,7 +367,7 @@ static void R_CastShadows(r_lighting_t *l, const r_illumination_t *il) {
 		r_shadow_t *s = l->shadows;
 		while (s->illumination) {
 
-			if (s->illumination == il && s->plane.num == tr.plane.num) {
+			if (s->illumination == il && s->plane->num == tr.plane.num) {
 				s->shadow = MAX(s->shadow, shadow);
 				break;
 			}
@@ -385,7 +385,8 @@ static void R_CastShadows(r_lighting_t *l, const r_illumination_t *il) {
 		}
 
 		s->illumination = il;
-		s->plane = tr.plane;
+		s->plane = &r_model_state.world->bsp->planes[tr.plane.index];
+		s->plane->flags |= R_PLANE_SHADOW;
 		s->shadow = shadow;
 	}
 }

--- a/src/client/renderer/r_mesh_shadow.c
+++ b/src/client/renderer/r_mesh_shadow.c
@@ -51,7 +51,7 @@ static void R_RotateForMeshShadow_default(const r_entity_t *e, const r_shadow_t 
 		return;
 	}
 
-	const cm_bsp_plane_t *p = &s->plane;
+	const r_bsp_plane_t *p = s->plane;
 
 	// project the entity onto the shadow plane
 	vec3_t vx, vy, vz, t;
@@ -88,7 +88,7 @@ static void R_CalculateShadowMatrix_default(const r_entity_t *e, const r_shadow_
 	Matrix4x4_Transform(&e->inverse_matrix, s->illumination->light.origin, light);
 	light[3] = 1.0;
 
-	Matrix4x4_TransformQuakePlane(&e->inverse_matrix, s->plane.normal, s->plane.dist, r_view.current_shadow_plane);
+	Matrix4x4_TransformQuakePlane(&e->inverse_matrix, s->plane->normal, s->plane->dist, plane);
 	plane[3] = -plane[3];
 
 	// calculate the perspective-shearing matrix
@@ -115,7 +115,7 @@ static void R_CalculateShadowMatrix_default(const r_entity_t *e, const r_shadow_
 	Matrix4x4_Transform(&r_view.matrix, s->illumination->light.origin, light);
 	light[3] = s->illumination->light.radius;
 
-	Matrix4x4_TransformQuakePlane(&r_view.matrix, s->plane.normal, s->plane.dist, plane);
+	Matrix4x4_TransformQuakePlane(&r_view.matrix, s->plane->normal, s->plane->dist, plane);
 	plane[3] = -plane[3];
 }
 
@@ -138,7 +138,7 @@ static void R_SetMeshShadowState_default(const r_entity_t *e, const r_shadow_t *
 		R_UseInterpolation(e->lerp);
 	}
 
-	R_StencilFunc(GL_EQUAL, (s->plane.num % 0xff) + 1, ~0);
+	R_StencilFunc(GL_EQUAL, (s->plane->num % 0xff) + 1, ~0);
 }
 
 /**

--- a/src/client/renderer/r_types.h
+++ b/src/client/renderer/r_types.h
@@ -367,6 +367,24 @@ typedef struct {
 	uint16_t first_surface, num_surfaces;
 } r_bsp_inline_model_t;
 
+/**
+ * @brief BSP plane flag indicating that a shadow impacted this plane.
+ */
+#define R_PLANE_SHADOW (1 << 0)
+
+/**
+ * @brief BSP planes are an extended `cm_bsp_plane_t`, with an additional flags bitmask.
+ */
+typedef struct {
+	vec3_t normal;
+	vec_t dist;
+	uint16_t type;
+	uint16_t sign_bits;
+	uint16_t index;
+	uint16_t num;
+	uint32_t flags;
+} r_bsp_plane_t;
+
 typedef struct {
 	uint16_t v[2];
 } r_bsp_edge_t;
@@ -400,7 +418,7 @@ typedef struct {
 	int16_t light_frame; // dynamic lighting frame
 	uint64_t light_mask; // bit mask of dynamic light sources
 
-	cm_bsp_plane_t *plane;
+	r_bsp_plane_t *plane;
 	uint16_t flags; // R_SURF flags
 
 	int32_t first_edge; // look up in model->surf_edges, negative numbers
@@ -491,7 +509,7 @@ typedef struct r_bsp_node_s {
 	struct r_model_s *model;
 
 	// node specific
-	cm_bsp_plane_t *plane;
+	r_bsp_plane_t *plane;
 	struct r_bsp_node_s *children[2];
 
 	uint16_t first_surface;
@@ -664,7 +682,7 @@ typedef struct {
 	r_bsp_inline_model_t *inline_models;
 
 	uint16_t num_planes;
-	cm_bsp_plane_t *planes;
+	r_bsp_plane_t *planes;
 
 	uint16_t num_leafs;
 	r_bsp_leaf_t *leafs;
@@ -801,7 +819,7 @@ typedef struct {
  */
 typedef struct {
 	const r_illumination_t *illumination;
-	cm_bsp_plane_t plane;
+	r_bsp_plane_t *plane;
 	vec_t shadow;
 } r_shadow_t;
 

--- a/src/collision/cm_model.c
+++ b/src/collision/cm_model.c
@@ -70,7 +70,7 @@ static void Cm_LoadBspPlanes(const d_bsp_lump_t *l) {
 		out->dist = LittleFloat(in->dist);
 		out->type = LittleLong(in->type);
 		out->sign_bits = Cm_SignBitsForPlane(out);
-		out->num = (i >> 1) + 1;
+		out->index = i, out->num = (i >> 1) + 1;
 	}
 }
 

--- a/src/collision/cm_types.h
+++ b/src/collision/cm_types.h
@@ -57,7 +57,8 @@ typedef struct {
 	vec_t dist;
 	uint16_t type; // for fast side tests
 	uint16_t sign_bits; // sign_x + (sign_y << 1) + (sign_z << 2)
-	uint16_t num; // for aligning collision model and rendering
+	uint16_t index; // the plane index, for aligning collision and rendering
+	uint16_t num; // the plane number, shared by both instances (sides) of a given plane
 } cm_bsp_plane_t;
 
 /**


### PR DESCRIPTION
This addresses a limitation of an 8 bit stencil buffer, and using the stencil test to apply shadows to planes in the map. Because of the 8 bit limitation, every 256 planes share the same stencil mask. This can cause shadows to "jump" to seemingly random planes across the map, as the stencil test will yield a positive result.

A new type was introduced for renderer planes (`r_bsp_plane_t`), which extends `cm_bsp_plane_t` to include a bit mask of renderer-specific flags. A flag indicating that a mesh shadow impacted a plane is flipped in `R_CastShadows`. The flag is consulted as surfaces are drawn: if set, the plane number is written to the stencil buffer as before; if not set, `0` is written so that the subsequent stencil tests will always fail.

This should (and seems to) prevent shadows from jumping across the map. I have not yet explored optimizing the stencil state management, so that perhaps the stencil write is disable by default, and only enabled when we're dealing with a shadowed plane. @Paril if you wanted to experiment there.. you have better profiling tools than I do.

Also, I'll concede that the "index" trick to align collision and renderer planes is a bit ugly, but it was simple and efficient. Because the collision model trace structure (`cm_trace_t`) works with _copies_ of planes, and not pointers to them, simple pointer arithmetic would not work -- and so the `index` field was necessary.

