### PR TITLE
Issue/262 shadows flicker

### DIFF
--- a/Quetoo.xcodeproj/xcshareddata/xcschemes/quetoo.xcscheme
+++ b/Quetoo.xcodeproj/xcshareddata/xcschemes/quetoo.xcscheme
@@ -63,7 +63,7 @@
       </BuildableProductRunnable>
       <CommandLineArguments>
          <CommandLineArgument
-            argument = "+set verbose 1 +set r_fullscreen 1 +map edge +give all"
+            argument = "+set r_fullscreen 1 +map edge +give all"
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>

--- a/src/client/renderer/r_bsp.c
+++ b/src/client/renderer/r_bsp.c
@@ -156,15 +156,14 @@ static void R_DrawBspInlineModel_(const r_entity_t *e) {
 	surf = &r_model_state.world->bsp->surfaces[e->model->bsp_inline->first_surface];
 
 	for (i = 0; i < e->model->bsp_inline->num_surfaces; i++, surf++) {
-		const cm_bsp_plane_t *plane = (cm_bsp_plane_t *) surf->plane;
 
 		vec_t dot;
 
 		// find which side of the surf we are on
-		if (AXIAL(plane)) {
-			dot = r_bsp_model_org[plane->type] - plane->dist;
+		if (AXIAL(surf->plane)) {
+			dot = r_bsp_model_org[surf->plane->type] - surf->plane->dist;
 		} else {
-			dot = DotProduct(r_bsp_model_org, plane->normal) - plane->dist;
+			dot = DotProduct(r_bsp_model_org, surf->plane->normal) - surf->plane->dist;
 		}
 
 		if (surf->flags & R_SURF_PLANE_BACK) {
@@ -257,15 +256,14 @@ static void R_AddBspInlineModelFlares_(const r_entity_t *e) {
 	r_bsp_surface_t *surf = &r_model_state.world->bsp->surfaces[e->model->bsp_inline->first_surface];
 
 	for (uint32_t i = 0; i < e->model->bsp_inline->num_surfaces; i++, surf++) {
-		const cm_bsp_plane_t *plane = (cm_bsp_plane_t *) surf->plane;
 
 		vec_t dot;
 
 		// find which side of the surf we are on
-		if (AXIAL(plane)) {
-			dot = r_bsp_model_org[plane->type] - plane->dist;
+		if (AXIAL(surf->plane)) {
+			dot = r_bsp_model_org[surf->plane->type] - surf->plane->dist;
 		} else {
-			dot = DotProduct(r_bsp_model_org, plane->normal) - plane->dist;
+			dot = DotProduct(r_bsp_model_org, surf->plane->normal) - surf->plane->dist;
 		}
 
 		if (surf->flags & R_SURF_PLANE_BACK) {
@@ -494,11 +492,10 @@ static void R_MarkBspSurfaces_(r_bsp_node_t *node) {
 
 	// otherwise, traverse down the appropriate sides of the node
 
-	const cm_bsp_plane_t *plane = (cm_bsp_plane_t *) node->plane;
-	if (AXIAL(plane)) {
-		dot = r_view.origin[plane->type] - plane->dist;
+	if (AXIAL(node->plane)) {
+		dot = r_view.origin[node->plane->type] - node->plane->dist;
 	} else {
-		dot = DotProduct(r_view.origin, plane->normal) - plane->dist;
+		dot = DotProduct(r_view.origin, node->plane->normal) - node->plane->dist;
 	}
 
 	if (dot > SIDE_EPSILON) {

--- a/src/client/renderer/r_bsp.c
+++ b/src/client/renderer/r_bsp.c
@@ -156,7 +156,7 @@ static void R_DrawBspInlineModel_(const r_entity_t *e) {
 	surf = &r_model_state.world->bsp->surfaces[e->model->bsp_inline->first_surface];
 
 	for (i = 0; i < e->model->bsp_inline->num_surfaces; i++, surf++) {
-		const r_bsp_plane_t *plane = surf->plane;
+		const cm_bsp_plane_t *plane = (cm_bsp_plane_t *) surf->plane;
 		vec_t dot;
 
 		// find which side of the surf we are on
@@ -256,7 +256,7 @@ static void R_AddBspInlineModelFlares_(const r_entity_t *e) {
 	r_bsp_surface_t *surf = &r_model_state.world->bsp->surfaces[e->model->bsp_inline->first_surface];
 
 	for (uint32_t i = 0; i < e->model->bsp_inline->num_surfaces; i++, surf++) {
-		const r_bsp_plane_t *plane = surf->plane;
+		const cm_bsp_plane_t *plane = (cm_bsp_plane_t *) surf->plane;
 		vec_t dot;
 
 		// find which side of the surf we are on
@@ -492,10 +492,11 @@ static void R_MarkBspSurfaces_(r_bsp_node_t *node) {
 
 	// otherwise, traverse down the appropriate sides of the node
 
-	if (AXIAL(node->plane)) {
-		dot = r_view.origin[node->plane->type] - node->plane->dist;
+	const cm_bsp_plane_t *plane = (cm_bsp_plane_t *) node->plane;
+	if (AXIAL(plane)) {
+		dot = r_view.origin[plane->type] - plane->dist;
 	} else {
-		dot = DotProduct(r_view.origin, node->plane->normal) - node->plane->dist;
+		dot = DotProduct(r_view.origin, plane->normal) - plane->dist;
 	}
 
 	if (dot > SIDE_EPSILON) {
@@ -505,9 +506,6 @@ static void R_MarkBspSurfaces_(r_bsp_node_t *node) {
 		side = 1;
 		side_bit = R_SURF_PLANE_BACK;
 	}
-
-	// reset the per-frame flags on the node's plane
-	node->plane->flags = 0;
 
 	// recurse down the children, front side first
 	R_MarkBspSurfaces_(node->children[side]);

--- a/src/client/renderer/r_bsp.c
+++ b/src/client/renderer/r_bsp.c
@@ -156,14 +156,14 @@ static void R_DrawBspInlineModel_(const r_entity_t *e) {
 	surf = &r_model_state.world->bsp->surfaces[e->model->bsp_inline->first_surface];
 
 	for (i = 0; i < e->model->bsp_inline->num_surfaces; i++, surf++) {
-
+		const cm_bsp_plane_t *plane = surf->plane;
 		vec_t dot;
 
 		// find which side of the surf we are on
-		if (AXIAL(surf->plane)) {
-			dot = r_bsp_model_org[surf->plane->type] - surf->plane->dist;
+		if (AXIAL(plane)) {
+			dot = r_bsp_model_org[plane->type] - plane->dist;
 		} else {
-			dot = DotProduct(r_bsp_model_org, surf->plane->normal) - surf->plane->dist;
+			dot = DotProduct(r_bsp_model_org, plane->normal) - plane->dist;
 		}
 
 		if (surf->flags & R_SURF_PLANE_BACK) {
@@ -256,14 +256,14 @@ static void R_AddBspInlineModelFlares_(const r_entity_t *e) {
 	r_bsp_surface_t *surf = &r_model_state.world->bsp->surfaces[e->model->bsp_inline->first_surface];
 
 	for (uint32_t i = 0; i < e->model->bsp_inline->num_surfaces; i++, surf++) {
-
+		const cm_bsp_plane_t *plane = surf->plane;
 		vec_t dot;
 
 		// find which side of the surf we are on
-		if (AXIAL(surf->plane)) {
-			dot = r_bsp_model_org[surf->plane->type] - surf->plane->dist;
+		if (AXIAL(plane)) {
+			dot = r_bsp_model_org[plane->type] - plane->dist;
 		} else {
-			dot = DotProduct(r_bsp_model_org, surf->plane->normal) - surf->plane->dist;
+			dot = DotProduct(r_bsp_model_org, plane->normal) - plane->dist;
 		}
 
 		if (surf->flags & R_SURF_PLANE_BACK) {
@@ -545,7 +545,6 @@ void R_MarkBspSurfaces(void) {
 	// flag all visible world surfaces
 	R_MarkBspSurfaces_(r_model_state.world->bsp->nodes);
 }
-
 
 /**
  * @brief Returns the leaf for the specified point.

--- a/src/client/renderer/r_bsp.c
+++ b/src/client/renderer/r_bsp.c
@@ -156,7 +156,7 @@ static void R_DrawBspInlineModel_(const r_entity_t *e) {
 	surf = &r_model_state.world->bsp->surfaces[e->model->bsp_inline->first_surface];
 
 	for (i = 0; i < e->model->bsp_inline->num_surfaces; i++, surf++) {
-		const cm_bsp_plane_t *plane = surf->plane;
+		const r_bsp_plane_t *plane = surf->plane;
 		vec_t dot;
 
 		// find which side of the surf we are on
@@ -256,7 +256,7 @@ static void R_AddBspInlineModelFlares_(const r_entity_t *e) {
 	r_bsp_surface_t *surf = &r_model_state.world->bsp->surfaces[e->model->bsp_inline->first_surface];
 
 	for (uint32_t i = 0; i < e->model->bsp_inline->num_surfaces; i++, surf++) {
-		const cm_bsp_plane_t *plane = surf->plane;
+		const r_bsp_plane_t *plane = surf->plane;
 		vec_t dot;
 
 		// find which side of the surf we are on
@@ -506,6 +506,9 @@ static void R_MarkBspSurfaces_(r_bsp_node_t *node) {
 		side_bit = R_SURF_PLANE_BACK;
 	}
 
+	// reset the per-frame flags on the node's plane
+	node->plane->flags = 0;
+
 	// recurse down the children, front side first
 	R_MarkBspSurfaces_(node->children[side]);
 
@@ -545,6 +548,7 @@ void R_MarkBspSurfaces(void) {
 	// flag all visible world surfaces
 	R_MarkBspSurfaces_(r_model_state.world->bsp->nodes);
 }
+
 
 /**
  * @brief Returns the leaf for the specified point.

--- a/src/client/renderer/r_bsp_model.c
+++ b/src/client/renderer/r_bsp_model.c
@@ -662,7 +662,7 @@ static void R_LoadBspPlanes(r_bsp_model_t *bsp, const d_bsp_lump_t *l) {
 		out->num = (i >> 1) + 1;
 	}
 
-	bsp->plane_shadows = Mem_LinkMalloc(((count >> 1) + 1) * sizeof(int16_t), bsp);
+	r_shadow_state.plane_shadow_counts = Mem_LinkMalloc(((count >> 1) + 1) * sizeof(int16_t), bsp);
 }
 
 #define BSP_VERTEX_INDEX_FOR_KEY(ptr) ((GLuint) (ptr))

--- a/src/client/renderer/r_bsp_model.c
+++ b/src/client/renderer/r_bsp_model.c
@@ -645,7 +645,7 @@ static void R_LoadBspPlanes(r_bsp_model_t *bsp, const d_bsp_lump_t *l) {
 	}
 
 	const int32_t count = l->file_len / sizeof(*in);
-	r_bsp_plane_t *out = Mem_LinkMalloc(count * sizeof(*out), bsp);
+	cm_bsp_plane_t *out = Mem_LinkMalloc(count * sizeof(*out), bsp);
 
 	bsp->planes = out;
 	bsp->num_planes = count;
@@ -658,7 +658,7 @@ static void R_LoadBspPlanes(r_bsp_model_t *bsp, const d_bsp_lump_t *l) {
 
 		out->dist = LittleFloat(in->dist);
 		out->type = LittleLong(in->type);
-		out->sign_bits = Cm_SignBitsForPlane((cm_bsp_plane_t *) out);
+		out->sign_bits = Cm_SignBitsForPlane(out);
 		out->num = (i >> 1) + 1;
 	}
 

--- a/src/client/renderer/r_bsp_model.c
+++ b/src/client/renderer/r_bsp_model.c
@@ -443,9 +443,9 @@ static void R_LoadBspSurfaces(r_bsp_model_t *bsp, const d_bsp_lump_t *l) {
 		const int16_t side = LittleShort(in->side);
 		if (side) {
 			out->flags |= R_SURF_PLANE_BACK;
-			VectorNegate(out->plane->normal, out->normal);
+			VectorNegate(out->plane->plane.normal, out->normal);
 		} else {
-			VectorCopy(out->plane->normal, out->normal);
+			VectorCopy(out->plane->plane.normal, out->normal);
 		}
 
 		// then texinfo
@@ -653,13 +653,14 @@ static void R_LoadBspPlanes(r_bsp_model_t *bsp, const d_bsp_lump_t *l) {
 	for (int32_t i = 0; i < count; i++, in++, out++) {
 
 		for (int32_t j = 0; j < 3; j++) {
-			out->normal[j] = LittleFloat(in->normal[j]);
+			out->plane.normal[j] = LittleFloat(in->normal[j]);
 		}
 
-		out->dist = LittleFloat(in->dist);
-		out->type = LittleLong(in->type);
-		out->sign_bits = Cm_SignBitsForPlane((cm_bsp_plane_t *) out);
-		out->index = i, out->num = (i >> 1) + 1;
+		out->plane.dist = LittleFloat(in->dist);
+		out->plane.type = LittleLong(in->type);
+		out->plane.sign_bits = Cm_SignBitsForPlane((cm_bsp_plane_t *) out);
+		out->plane.index = i, out->plane.num = (i >> 1) + 1;
+		out->shadow_ref = (out->plane.num % 0xff) + 1;
 	}
 }
 

--- a/src/client/renderer/r_bsp_model.c
+++ b/src/client/renderer/r_bsp_model.c
@@ -645,7 +645,7 @@ static void R_LoadBspPlanes(r_bsp_model_t *bsp, const d_bsp_lump_t *l) {
 	}
 
 	const int32_t count = l->file_len / sizeof(*in);
-	cm_bsp_plane_t *out = Mem_LinkMalloc(count * sizeof(*out), bsp);
+	r_bsp_plane_t *out = Mem_LinkMalloc(count * sizeof(*out), bsp);
 
 	bsp->planes = out;
 	bsp->num_planes = count;
@@ -658,8 +658,8 @@ static void R_LoadBspPlanes(r_bsp_model_t *bsp, const d_bsp_lump_t *l) {
 
 		out->dist = LittleFloat(in->dist);
 		out->type = LittleLong(in->type);
-		out->sign_bits = Cm_SignBitsForPlane(out);
-		out->num = (i >> 1) + 1;
+		out->sign_bits = Cm_SignBitsForPlane((cm_bsp_plane_t *) out);
+		out->index = i, out->num = (i >> 1) + 1;
 	}
 }
 

--- a/src/client/renderer/r_bsp_model.c
+++ b/src/client/renderer/r_bsp_model.c
@@ -443,9 +443,9 @@ static void R_LoadBspSurfaces(r_bsp_model_t *bsp, const d_bsp_lump_t *l) {
 		const int16_t side = LittleShort(in->side);
 		if (side) {
 			out->flags |= R_SURF_PLANE_BACK;
-			VectorNegate(out->plane->plane.normal, out->normal);
+			VectorNegate(out->plane->normal, out->normal);
 		} else {
-			VectorCopy(out->plane->plane.normal, out->normal);
+			VectorCopy(out->plane->normal, out->normal);
 		}
 
 		// then texinfo
@@ -653,15 +653,16 @@ static void R_LoadBspPlanes(r_bsp_model_t *bsp, const d_bsp_lump_t *l) {
 	for (int32_t i = 0; i < count; i++, in++, out++) {
 
 		for (int32_t j = 0; j < 3; j++) {
-			out->plane.normal[j] = LittleFloat(in->normal[j]);
+			out->normal[j] = LittleFloat(in->normal[j]);
 		}
 
-		out->plane.dist = LittleFloat(in->dist);
-		out->plane.type = LittleLong(in->type);
-		out->plane.sign_bits = Cm_SignBitsForPlane((cm_bsp_plane_t *) out);
-		out->plane.index = i, out->plane.num = (i >> 1) + 1;
-		out->shadow_ref = (out->plane.num % 0xff) + 1;
+		out->dist = LittleFloat(in->dist);
+		out->type = LittleLong(in->type);
+		out->sign_bits = Cm_SignBitsForPlane((cm_bsp_plane_t *) out);
+		out->num = (i >> 1) + 1;
 	}
+
+	bsp->plane_shadows = Mem_LinkMalloc(((count >> 1) + 1) * sizeof(int16_t), bsp);
 }
 
 #define BSP_VERTEX_INDEX_FOR_KEY(ptr) ((GLuint) (ptr))

--- a/src/client/renderer/r_bsp_surface.c
+++ b/src/client/renderer/r_bsp_surface.c
@@ -65,8 +65,8 @@ static void R_SetBspSurfaceState_default(const r_bsp_surface_t *surf) {
 	}
 
 	if (r_state.stencil_test_enabled) { // write to stencil buffer to clip shadows
-		if (surf->plane->flags & R_PLANE_SHADOW) {
-			R_StencilFunc(GL_ALWAYS, (surf->plane->num % 0xff) + 1, ~0);
+		if (surf->plane->num_shadows) {
+			R_StencilFunc(GL_ALWAYS, surf->plane->shadow_ref, ~0);
 		} else {
 			R_StencilFunc(GL_ALWAYS, 0, 0);
 		}

--- a/src/client/renderer/r_bsp_surface.c
+++ b/src/client/renderer/r_bsp_surface.c
@@ -65,7 +65,11 @@ static void R_SetBspSurfaceState_default(const r_bsp_surface_t *surf) {
 	}
 
 	if (r_state.stencil_test_enabled) { // write to stencil buffer to clip shadows
-		R_StencilFunc(GL_ALWAYS, (surf->plane->num % 0xff) + 1, ~0);
+		if (surf->plane->flags & R_PLANE_SHADOW) {
+			R_StencilFunc(GL_ALWAYS, (surf->plane->num % 0xff) + 1, ~0);
+		} else {
+			R_StencilFunc(GL_ALWAYS, 0, 0);
+		}
 	}
 }
 

--- a/src/client/renderer/r_bsp_surface.c
+++ b/src/client/renderer/r_bsp_surface.c
@@ -65,7 +65,7 @@ static void R_SetBspSurfaceState_default(const r_bsp_surface_t *surf) {
 	}
 
 	if (r_state.stencil_test_enabled) { // write to stencil buffer to clip shadows
-		if (r_model_state.world->bsp->plane_shadows[surf->plane->num]) {
+		if (r_shadow_state.plane_shadow_counts[surf->plane->num]) {
 			R_StencilFunc(GL_ALWAYS, R_STENCIL_REF(surf->plane), ~0);
 		} else {
 			R_StencilFunc(GL_ALWAYS, 0, 0);

--- a/src/client/renderer/r_bsp_surface.c
+++ b/src/client/renderer/r_bsp_surface.c
@@ -65,8 +65,8 @@ static void R_SetBspSurfaceState_default(const r_bsp_surface_t *surf) {
 	}
 
 	if (r_state.stencil_test_enabled) { // write to stencil buffer to clip shadows
-		if (surf->plane->num_shadows) {
-			R_StencilFunc(GL_ALWAYS, surf->plane->shadow_ref, ~0);
+		if (r_model_state.world->bsp->plane_shadows[surf->plane->num]) {
+			R_StencilFunc(GL_ALWAYS, R_STENCIL_REF(surf->plane), ~0);
 		} else {
 			R_StencilFunc(GL_ALWAYS, 0, 0);
 		}

--- a/src/client/renderer/r_light.c
+++ b/src/client/renderer/r_light.c
@@ -113,7 +113,9 @@ void R_MarkLight(const r_light_t *l, const r_bsp_node_t *node) {
 		}
 	}
 
-	const vec_t dist = DotProduct(l->origin, node->plane->normal) - node->plane->dist;
+	const cm_bsp_plane_t *plane = (cm_bsp_plane_t *) node->plane;
+	
+	const vec_t dist = DotProduct(l->origin, plane->normal) - plane->dist;
 
 	if (dist > l->radius) { // front only
 		R_MarkLight(l, node->children[0]);

--- a/src/client/renderer/r_light.c
+++ b/src/client/renderer/r_light.c
@@ -65,7 +65,7 @@ void R_AddSustainedLight(const r_sustained_light_t *s) {
 /**
  * @brief
  */
-static void R_AddSustainedLights(void) {
+void R_AddSustainedLights(void) {
 	r_sustained_light_t *s;
 	int32_t i;
 
@@ -152,8 +152,6 @@ void R_MarkLight(const r_light_t *l, const r_bsp_node_t *node) {
 void R_MarkLights(void) {
 	const r_bsp_model_t *bsp = r_model_state.world->bsp;
 	const r_light_t *l = r_view.lights;
-
-	R_AddSustainedLights();
 
 	r_locals.light_frame++;
 

--- a/src/client/renderer/r_light.c
+++ b/src/client/renderer/r_light.c
@@ -112,10 +112,8 @@ void R_MarkLight(const r_light_t *l, const r_bsp_node_t *node) {
 			return;
 		}
 	}
-
-	const cm_bsp_plane_t *plane = (cm_bsp_plane_t *) node->plane;
 	
-	const vec_t dist = DotProduct(l->origin, plane->normal) - plane->dist;
+	const vec_t dist = DotProduct(l->origin, node->plane->normal) - node->plane->dist;
 
 	if (dist > l->radius) { // front only
 		R_MarkLight(l, node->children[0]);

--- a/src/client/renderer/r_light.h
+++ b/src/client/renderer/r_light.h
@@ -28,6 +28,7 @@ void R_AddLight(const r_light_t *l);
 void R_AddSustainedLight(const r_sustained_light_t *s);
 
 #ifdef __R_LOCAL_H__
+	void R_AddSustainedLights(void);
 	void R_ResetLights(void);
 	void R_MarkLight(const r_light_t *l, const r_bsp_node_t *node);
 	void R_MarkLights(void);

--- a/src/client/renderer/r_lighting.c
+++ b/src/client/renderer/r_lighting.c
@@ -367,7 +367,7 @@ static void R_CastShadows(r_lighting_t *l, const r_illumination_t *il) {
 		r_shadow_t *s = l->shadows;
 		while (s->illumination) {
 
-			if (s->illumination == il && s->plane.num == tr.plane.num) {
+			if (s->illumination == il && s->plane->num == tr.plane.num) {
 				s->shadow = MAX(s->shadow, shadow);
 				break;
 			}
@@ -385,7 +385,8 @@ static void R_CastShadows(r_lighting_t *l, const r_illumination_t *il) {
 		}
 
 		s->illumination = il;
-		s->plane = tr.plane;
+		s->plane = &r_model_state.world->bsp->planes[tr.plane.index];
+		s->plane->flags |= R_PLANE_SHADOW;
 		s->shadow = shadow;
 	}
 }

--- a/src/client/renderer/r_lighting.c
+++ b/src/client/renderer/r_lighting.c
@@ -22,7 +22,8 @@
 #include "r_local.h"
 #include "client.h"
 
-// Max illuminations for the whole scene
+r_shadow_state_t r_shadow_state;
+
 #define LIGHTING_MAX_ILLUMINATIONS (MAX_ILLUMINATIONS * 16)
 
 /**
@@ -388,7 +389,7 @@ static void R_CastShadows(r_lighting_t *l, const r_illumination_t *il) {
 		s->plane = tr.plane;
 		s->shadow = shadow;
 
-		r_model_state.world->bsp->plane_shadows[s->plane.num]++;
+		r_shadow_state.plane_shadow_counts[s->plane.num]++;
 	}
 }
 
@@ -413,7 +414,9 @@ static void R_UpdateShadows(r_lighting_t *l) {
 	r_shadow_t *s = l->shadows;
 	for (size_t i = 0; i < lengthof(l->shadows); i++, s++) {
 		if (s->plane.num) {
-			r_model_state.world->bsp->plane_shadows[s->plane.num]--;
+			if (r_shadow_state.plane_shadow_counts[s->plane.num]) {
+				r_shadow_state.plane_shadow_counts[s->plane.num]--;
+			}
 		}
 	}
 

--- a/src/client/renderer/r_lighting.c
+++ b/src/client/renderer/r_lighting.c
@@ -367,7 +367,7 @@ static void R_CastShadows(r_lighting_t *l, const r_illumination_t *il) {
 		r_shadow_t *s = l->shadows;
 		while (s->illumination) {
 
-			if (s->illumination == il && s->plane->plane.num == tr.plane.num) {
+			if (s->illumination == il && s->plane.num == tr.plane.num) {
 				s->shadow = MAX(s->shadow, shadow);
 				break;
 			}
@@ -385,24 +385,11 @@ static void R_CastShadows(r_lighting_t *l, const r_illumination_t *il) {
 		}
 
 		s->illumination = il;
-		s->plane = &r_model_state.world->bsp->planes[tr.plane.index];
-		s->plane->num_shadows++;
+		s->plane = tr.plane;
 		s->shadow = shadow;
+
+		r_model_state.world->bsp->plane_shadows[s->plane.num]++;
 	}
-}
-
-/**
- * @brief Frees the specified shadow, decrementing its plane's shadow count.
- */
-static void R_FreeShadow(r_shadow_t *s) {
-
-	if (s->plane) {
-		if (s->plane->num_shadows) {
-			s->plane->num_shadows--;
-		}
-	}
-
-	memset(s, 0, sizeof(*s));
 }
 
 /**
@@ -423,9 +410,14 @@ static void R_UpdateShadows(r_lighting_t *l) {
 	}
 
 	// otherwise, refresh all shadow information based on the new illuminations
-	for (size_t i = 0; i < lengthof(l->shadows); i++) {
-		R_FreeShadow(&l->shadows[i]);
+	r_shadow_t *s = l->shadows;
+	for (size_t i = 0; i < lengthof(l->shadows); i++, s++) {
+		if (s->plane.num) {
+			r_model_state.world->bsp->plane_shadows[s->plane.num]--;
+		}
 	}
+
+	memset(l->shadows, 0, sizeof(l->shadows));
 
 	const r_illumination_t *il = l->illuminations;
 	for (size_t i = 0; i < r_state.max_active_lights; i++, il++) {

--- a/src/client/renderer/r_lighting.h
+++ b/src/client/renderer/r_lighting.h
@@ -23,7 +23,15 @@
 #define __R_LIGHTING_H__
 
 #ifdef __R_LOCAL_H__
-	void R_UpdateLighting(r_lighting_t *lighting);
+
+typedef struct {
+	uint16_t *plane_shadow_counts;
+} r_shadow_state_t;
+
+extern r_shadow_state_t r_shadow_state;
+
+void R_UpdateLighting(r_lighting_t *lighting);
+
 #endif /* __R_LOCAL_H__ */
 
 #endif /* __R_LIGHTING_H__ */

--- a/src/client/renderer/r_main.c
+++ b/src/client/renderer/r_main.c
@@ -161,6 +161,8 @@ void R_DrawView(void) {
 	// wait for the client to fully populate the scene
 	Thread_Wait(r_view.thread);
 
+	R_AddSustainedLights();
+
 	// dispatch threads to cull entities and sort elements while we draw the world
 	thread_t *cull_entities = Thread_Create(R_CullEntities, NULL);
 

--- a/src/client/renderer/r_mesh_shadow.c
+++ b/src/client/renderer/r_mesh_shadow.c
@@ -51,7 +51,7 @@ static void R_RotateForMeshShadow_default(const r_entity_t *e, const r_shadow_t 
 		return;
 	}
 
-	const cm_bsp_plane_t *p = (cm_bsp_plane_t *) s->plane;
+	const r_bsp_plane_t *p = &s->plane;
 
 	// project the entity onto the shadow plane
 	vec3_t vx, vy, vz, t;
@@ -88,7 +88,7 @@ static void R_CalculateShadowMatrix_default(const r_entity_t *e, const r_shadow_
 	Matrix4x4_Transform(&e->inverse_matrix, s->illumination->light.origin, light);
 	light[3] = 1.0;
 
-	const cm_bsp_plane_t *p = (cm_bsp_plane_t *) s->plane;
+	const r_bsp_plane_t *p = &s->plane;
 
 	Matrix4x4_TransformQuakePlane(&e->inverse_matrix, p->normal, p->dist, plane);
 	plane[3] = -plane[3];
@@ -140,7 +140,7 @@ static void R_SetMeshShadowState_default(const r_entity_t *e, const r_shadow_t *
 		R_UseInterpolation(e->lerp);
 	}
 
-	R_StencilFunc(GL_EQUAL, s->plane->shadow_ref, ~0);
+	R_StencilFunc(GL_EQUAL, R_STENCIL_REF(&s->plane), ~0);
 }
 
 /**

--- a/src/client/renderer/r_mesh_shadow.c
+++ b/src/client/renderer/r_mesh_shadow.c
@@ -51,7 +51,7 @@ static void R_RotateForMeshShadow_default(const r_entity_t *e, const r_shadow_t 
 		return;
 	}
 
-	const r_bsp_plane_t *p = &s->plane;
+	const cm_bsp_plane_t *p = &s->plane;
 
 	// project the entity onto the shadow plane
 	vec3_t vx, vy, vz, t;
@@ -88,7 +88,7 @@ static void R_CalculateShadowMatrix_default(const r_entity_t *e, const r_shadow_
 	Matrix4x4_Transform(&e->inverse_matrix, s->illumination->light.origin, light);
 	light[3] = 1.0;
 
-	const r_bsp_plane_t *p = &s->plane;
+	const cm_bsp_plane_t *p = &s->plane;
 
 	Matrix4x4_TransformQuakePlane(&e->inverse_matrix, p->normal, p->dist, plane);
 	plane[3] = -plane[3];

--- a/src/client/renderer/r_mesh_shadow.c
+++ b/src/client/renderer/r_mesh_shadow.c
@@ -51,7 +51,7 @@ static void R_RotateForMeshShadow_default(const r_entity_t *e, const r_shadow_t 
 		return;
 	}
 
-	const cm_bsp_plane_t *p = &s->plane;
+	const r_bsp_plane_t *p = s->plane;
 
 	// project the entity onto the shadow plane
 	vec3_t vx, vy, vz, t;
@@ -88,7 +88,7 @@ static void R_CalculateShadowMatrix_default(const r_entity_t *e, const r_shadow_
 	Matrix4x4_Transform(&e->inverse_matrix, s->illumination->light.origin, light);
 	light[3] = 1.0;
 
-	Matrix4x4_TransformQuakePlane(&e->inverse_matrix, s->plane.normal, s->plane.dist, r_view.current_shadow_plane);
+	Matrix4x4_TransformQuakePlane(&e->inverse_matrix, s->plane->normal, s->plane->dist, plane);
 	plane[3] = -plane[3];
 
 	// calculate the perspective-shearing matrix
@@ -115,7 +115,7 @@ static void R_CalculateShadowMatrix_default(const r_entity_t *e, const r_shadow_
 	Matrix4x4_Transform(&r_view.matrix, s->illumination->light.origin, light);
 	light[3] = s->illumination->light.radius;
 
-	Matrix4x4_TransformQuakePlane(&r_view.matrix, s->plane.normal, s->plane.dist, plane);
+	Matrix4x4_TransformQuakePlane(&r_view.matrix, s->plane->normal, s->plane->dist, plane);
 	plane[3] = -plane[3];
 }
 
@@ -138,7 +138,7 @@ static void R_SetMeshShadowState_default(const r_entity_t *e, const r_shadow_t *
 		R_UseInterpolation(e->lerp);
 	}
 
-	R_StencilFunc(GL_EQUAL, (s->plane.num % 0xff) + 1, ~0);
+	R_StencilFunc(GL_EQUAL, (s->plane->num % 0xff) + 1, ~0);
 }
 
 /**

--- a/src/client/renderer/r_mesh_shadow.c
+++ b/src/client/renderer/r_mesh_shadow.c
@@ -51,7 +51,7 @@ static void R_RotateForMeshShadow_default(const r_entity_t *e, const r_shadow_t 
 		return;
 	}
 
-	const r_bsp_plane_t *p = s->plane;
+	const cm_bsp_plane_t *p = (cm_bsp_plane_t *) s->plane;
 
 	// project the entity onto the shadow plane
 	vec3_t vx, vy, vz, t;
@@ -88,7 +88,9 @@ static void R_CalculateShadowMatrix_default(const r_entity_t *e, const r_shadow_
 	Matrix4x4_Transform(&e->inverse_matrix, s->illumination->light.origin, light);
 	light[3] = 1.0;
 
-	Matrix4x4_TransformQuakePlane(&e->inverse_matrix, s->plane->normal, s->plane->dist, plane);
+	const cm_bsp_plane_t *p = (cm_bsp_plane_t *) s->plane;
+
+	Matrix4x4_TransformQuakePlane(&e->inverse_matrix, p->normal, p->dist, plane);
 	plane[3] = -plane[3];
 
 	// calculate the perspective-shearing matrix
@@ -115,7 +117,7 @@ static void R_CalculateShadowMatrix_default(const r_entity_t *e, const r_shadow_
 	Matrix4x4_Transform(&r_view.matrix, s->illumination->light.origin, light);
 	light[3] = s->illumination->light.radius;
 
-	Matrix4x4_TransformQuakePlane(&r_view.matrix, s->plane->normal, s->plane->dist, plane);
+	Matrix4x4_TransformQuakePlane(&r_view.matrix, p->normal, p->dist, plane);
 	plane[3] = -plane[3];
 }
 
@@ -138,7 +140,7 @@ static void R_SetMeshShadowState_default(const r_entity_t *e, const r_shadow_t *
 		R_UseInterpolation(e->lerp);
 	}
 
-	R_StencilFunc(GL_EQUAL, (s->plane->num % 0xff) + 1, ~0);
+	R_StencilFunc(GL_EQUAL, s->plane->shadow_ref, ~0);
 }
 
 /**

--- a/src/client/renderer/r_types.h
+++ b/src/client/renderer/r_types.h
@@ -733,8 +733,6 @@ typedef struct {
 	r_buffer_t vertex_buffer;
 	r_buffer_t element_buffer;
 
-	// active shadow counts, indexed by plane number
-	uint16_t *plane_shadows;
 } r_bsp_model_t;
 
 /**

--- a/src/client/renderer/r_types.h
+++ b/src/client/renderer/r_types.h
@@ -369,13 +369,11 @@ typedef struct {
 } r_bsp_inline_model_t;
 
 /**
- * @brief BSP planes are extended `cm_bsp_plane_t`, with an additional renderer members.
+ * @brief Resolves a unique(ish) stencil reference value for the given plane.
  */
-typedef struct {
-	cm_bsp_plane_t plane;
-	uint16_t num_shadows;
-	uint16_t shadow_ref;
-} r_bsp_plane_t;
+#define R_STENCIL_REF(p) (((p)->num % 0xff) + 1)
+
+typedef cm_bsp_plane_t r_bsp_plane_t;
 
 typedef struct {
 	uint16_t v[2];
@@ -718,6 +716,9 @@ typedef struct {
 	// buffers
 	r_buffer_t vertex_buffer;
 	r_buffer_t element_buffer;
+
+	// active shadow counts, indexed by plane number
+	uint16_t *plane_shadows;
 } r_bsp_model_t;
 
 /**
@@ -818,7 +819,7 @@ typedef struct {
  */
 typedef struct {
 	const r_illumination_t *illumination;
-	r_bsp_plane_t *plane;
+	r_bsp_plane_t plane;
 	vec_t shadow;
 } r_shadow_t;
 

--- a/src/client/renderer/r_types.h
+++ b/src/client/renderer/r_types.h
@@ -367,6 +367,24 @@ typedef struct {
 	uint16_t first_surface, num_surfaces;
 } r_bsp_inline_model_t;
 
+/**
+ * @brief BSP plane flag indicating that a shadow impacted this plane.
+ */
+#define R_PLANE_SHADOW (1 << 0)
+
+/**
+ * @brief BSP planes are an extended `cm_bsp_plane_t`, with an additional flags bitmask.
+ */
+typedef struct {
+	vec3_t normal;
+	vec_t dist;
+	uint16_t type;
+	uint16_t sign_bits;
+	uint16_t index;
+	uint16_t num;
+	uint32_t flags;
+} r_bsp_plane_t;
+
 typedef struct {
 	uint16_t v[2];
 } r_bsp_edge_t;
@@ -400,7 +418,7 @@ typedef struct {
 	int16_t light_frame; // dynamic lighting frame
 	uint64_t light_mask; // bit mask of dynamic light sources
 
-	cm_bsp_plane_t *plane;
+	r_bsp_plane_t *plane;
 	uint16_t flags; // R_SURF flags
 
 	int32_t first_edge; // look up in model->surf_edges, negative numbers
@@ -491,7 +509,7 @@ typedef struct r_bsp_node_s {
 	struct r_model_s *model;
 
 	// node specific
-	cm_bsp_plane_t *plane;
+	r_bsp_plane_t *plane;
 	struct r_bsp_node_s *children[2];
 
 	uint16_t first_surface;
@@ -664,7 +682,7 @@ typedef struct {
 	r_bsp_inline_model_t *inline_models;
 
 	uint16_t num_planes;
-	cm_bsp_plane_t *planes;
+	r_bsp_plane_t *planes;
 
 	uint16_t num_leafs;
 	r_bsp_leaf_t *leafs;
@@ -801,7 +819,7 @@ typedef struct {
  */
 typedef struct {
 	const r_illumination_t *illumination;
-	cm_bsp_plane_t plane;
+	r_bsp_plane_t *plane;
 	vec_t shadow;
 } r_shadow_t;
 

--- a/src/client/renderer/r_types.h
+++ b/src/client/renderer/r_types.h
@@ -368,21 +368,12 @@ typedef struct {
 } r_bsp_inline_model_t;
 
 /**
- * @brief BSP plane flag indicating that a shadow impacted this plane.
- */
-#define R_PLANE_SHADOW (1 << 0)
-
-/**
- * @brief BSP planes are an extended `cm_bsp_plane_t`, with an additional flags bitmask.
+ * @brief BSP planes are extended `cm_bsp_plane_t`, with an additional renderer members.
  */
 typedef struct {
-	vec3_t normal;
-	vec_t dist;
-	uint16_t type;
-	uint16_t sign_bits;
-	uint16_t index;
-	uint16_t num;
-	uint32_t flags;
+	cm_bsp_plane_t plane;
+	uint16_t num_shadows;
+	uint16_t shadow_ref;
 } r_bsp_plane_t;
 
 typedef struct {

--- a/src/client/renderer/r_types.h
+++ b/src/client/renderer/r_types.h
@@ -391,8 +391,6 @@ typedef struct {
  */
 #define R_STENCIL_REF(p) (((p)->num % 0xff) + 1)
 
-typedef cm_bsp_plane_t r_bsp_plane_t;
-
 typedef struct {
 	uint16_t v[2];
 } r_bsp_edge_t;
@@ -426,7 +424,7 @@ typedef struct {
 	int16_t light_frame; // dynamic lighting frame
 	uint64_t light_mask; // bit mask of dynamic light sources
 
-	r_bsp_plane_t *plane;
+	cm_bsp_plane_t *plane;
 	uint16_t flags; // R_SURF flags
 
 	int32_t first_edge; // look up in model->surf_edges, negative numbers
@@ -517,7 +515,7 @@ typedef struct r_bsp_node_s {
 	struct r_model_s *model;
 
 	// node specific
-	r_bsp_plane_t *plane;
+	cm_bsp_plane_t *plane;
 	struct r_bsp_node_s *children[2];
 
 	uint16_t first_surface;
@@ -690,7 +688,7 @@ typedef struct {
 	r_bsp_inline_model_t *inline_models;
 
 	uint16_t num_planes;
-	r_bsp_plane_t *planes;
+	cm_bsp_plane_t *planes;
 
 	uint16_t num_leafs;
 	r_bsp_leaf_t *leafs;
@@ -837,7 +835,7 @@ typedef struct {
  */
 typedef struct {
 	const r_illumination_t *illumination;
-	r_bsp_plane_t plane;
+	cm_bsp_plane_t plane;
 	vec_t shadow;
 } r_shadow_t;
 

--- a/src/collision/cm_model.c
+++ b/src/collision/cm_model.c
@@ -70,7 +70,7 @@ static void Cm_LoadBspPlanes(const d_bsp_lump_t *l) {
 		out->dist = LittleFloat(in->dist);
 		out->type = LittleLong(in->type);
 		out->sign_bits = Cm_SignBitsForPlane(out);
-		out->num = (i >> 1) + 1;
+		out->index = i, out->num = (i >> 1) + 1;
 	}
 }
 

--- a/src/collision/cm_model.c
+++ b/src/collision/cm_model.c
@@ -70,7 +70,7 @@ static void Cm_LoadBspPlanes(const d_bsp_lump_t *l) {
 		out->dist = LittleFloat(in->dist);
 		out->type = LittleLong(in->type);
 		out->sign_bits = Cm_SignBitsForPlane(out);
-		out->index = i, out->num = (i >> 1) + 1;
+		out->num = (i >> 1) + 1;
 	}
 }
 

--- a/src/collision/cm_types.h
+++ b/src/collision/cm_types.h
@@ -57,7 +57,8 @@ typedef struct {
 	vec_t dist;
 	uint16_t type; // for fast side tests
 	uint16_t sign_bits; // sign_x + (sign_y << 1) + (sign_z << 2)
-	uint16_t num; // for aligning collision model and rendering
+	uint16_t index; // the plane index, for aligning collision and rendering
+	uint16_t num; // the plane number, shared by both instances (sides) of a given plane
 } cm_bsp_plane_t;
 
 /**

--- a/src/collision/cm_types.h
+++ b/src/collision/cm_types.h
@@ -57,7 +57,6 @@ typedef struct {
 	vec_t dist;
 	uint16_t type; // for fast side tests
 	uint16_t sign_bits; // sign_x + (sign_y << 1) + (sign_z << 2)
-	uint16_t index; // the plane index, for aligning collision and rendering
 	uint16_t num; // the plane number, shared by both instances (sides) of a given plane
 } cm_bsp_plane_t;
 

--- a/src/thread.c
+++ b/src/thread.c
@@ -27,7 +27,7 @@ typedef struct thread_pool_s {
 	SDL_mutex *mutex;
 
 	thread_t *threads;
-	uint16_t num_threads;
+	size_t num_threads;
 } thread_pool_t;
 
 static thread_pool_t thread_pool;
@@ -64,10 +64,12 @@ static int32_t Thread_Run(void *data) {
 /**
  * @brief Initializes the threads backing the thread pool.
  */
-static void Thread_Init_(uint16_t num_threads) {
+static void Thread_Init_(ssize_t num_threads) {
 
 	if (num_threads == 0) {
 		num_threads = SDL_GetCPUCount();
+	} else if (num_threads == -1) {
+		num_threads = 0;
 	}
 
 	thread_pool.num_threads = MIN(num_threads, MAX_THREADS);
@@ -189,7 +191,7 @@ uint16_t Thread_Count(void) {
 /**
  * @brief Initializes the thread pool.
  */
-void Thread_Init(uint16_t num_threads) {
+void Thread_Init(ssize_t num_threads) {
 
 	memset(&thread_pool, 0, sizeof(thread_pool));
 

--- a/src/thread.h
+++ b/src/thread.h
@@ -50,7 +50,7 @@ thread_t *Thread_Create_(const char *name, ThreadRunFunc run, void *data);
 #define Thread_Create(f, d) Thread_Create_(#f, f, d)
 void Thread_Wait(thread_t *t);
 uint16_t Thread_Count(void);
-void Thread_Init(uint16_t num_threads);
+void Thread_Init(ssize_t num_threads);
 void Thread_Shutdown(void);
 
 #endif /*__THREAD_H__ */


### PR DESCRIPTION
@Paril I have to get busy with work-work, but I could use your help on this one.

The change refactors r_bsp_plane_t to include a cm_bsp_plane_t, like we discussed previously. So there's some "noise" in the PR about that. But the "fix" here to eliminate the shadow flickering is to change how the "plane was impacted by a shadow" state is managed per frame.

In the initial commit for #237, I flipped the R_PLANE_SHADOW bit off in R_MarkBspSurfaces_. However, static lighting is cached over multiple frames. So I was effectively discarding the shadow each frame, and it would not be cast again until the entity's lighting cache was marked dirty.

The fix in this commit is to instead keep a count of shadows on r_bsp_plane_t, and decrement that count when recalculating shadows. This all seems to work correctly; however, there is a crash that I couldn't get my head around this morning.

Spawn into Edge, take the hyperblaster, and go fire it at a wall near some mesh entities. You'll get a crash in R_FreeShadow. It will be for the torso entity of your player model -- which shares a lighting struct with the other player model segments. Still, I don't understand the crash. HALP PLZ.