### PR TITLE
Ensure every server update is fully processed by the client.

### DIFF
--- a/Quetoo.xcodeproj/xcshareddata/xcschemes/quetoo.xcscheme
+++ b/Quetoo.xcodeproj/xcshareddata/xcschemes/quetoo.xcscheme
@@ -63,7 +63,7 @@
       </BuildableProductRunnable>
       <CommandLineArguments>
          <CommandLineArgument
-            argument = "+set r_fullscreen 1 +set sv_max_clients 1 +map aerowalk +set g_cheats 1 +give all"
+            argument = "+set threads -1 +set r_fullscreen 1 +set sv_max_clients 1 +map edge +set g_cheats 1 +give all"
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>

--- a/src/cgame/cgame.h
+++ b/src/cgame/cgame.h
@@ -754,7 +754,6 @@ typedef struct cg_export_s {
 	_Bool (*ParseMessage)(int32_t cmd);
 	void (*PredictMovement)(const GList *cmds);
 	void (*UpdateView)(const cl_frame_t *frame);
-	void (*PopulateView)(const cl_frame_t *frame);
 	void (*DrawFrame)(const cl_frame_t *frame);
 
 } cg_export_t;

--- a/src/cgame/default/cg_client.c
+++ b/src/cgame/default/cg_client.c
@@ -335,23 +335,9 @@ static void Cg_AnimateClientEntity_(const r_md3_t *md3, cl_entity_animation_t *a
  * indexes and interpolation fractions for the specified renderer entities.
  */
 void Cg_AnimateClientEntity(cl_entity_t *e, r_entity_t *torso, r_entity_t *legs) {
+
 	const r_md3_t *md3 = (r_md3_t *) torso->model->mesh->data;
 
-	// do the torso animation
-	if (e->current.animation1 != e->prev.animation1 || !e->animation1.time) {
-		//cgi.Debug("Torso: %d -> %d\n", e->current.animation1, e->prev.animation1);
-		e->animation1.animation = e->current.animation1 & ~ANIM_TOGGLE_BIT;
-		e->animation1.time = cgi.client->ticks;
-	}
-
 	Cg_AnimateClientEntity_(md3, &e->animation1, torso);
-
-	// and then the legs
-	if (e->current.animation2 != e->prev.animation2 || !e->animation2.time) {
-		//cgi.Debug("Legs: %d -> %d\n", e->current.animation2, e->prev.animation2);
-		e->animation2.animation = e->current.animation2 & ~ANIM_TOGGLE_BIT;
-		e->animation2.time = cgi.client->ticks;
-	}
-
 	Cg_AnimateClientEntity_(md3, &e->animation2, legs);
 }

--- a/src/cgame/default/cg_entity.c
+++ b/src/cgame/default/cg_entity.c
@@ -53,109 +53,15 @@ _Bool Cg_IsSelf(const cl_entity_t *ent) {
 /**
  * @return True if the entity is ducking, false otherwise.
  */
-_Bool Cg_IsDucking(const entity_state_t *ent) {
+_Bool Cg_IsDucking(const cl_entity_t *ent) {
 
 	vec3_t mins, maxs;
-	UnpackBounds(ent->bounds, mins, maxs);
+	UnpackBounds(ent->current.bounds, mins, maxs);
 
 	const vec_t standing_height = (PM_MAXS[2] - PM_MINS[2]) * PM_SCALE;
 	const vec_t height = maxs[2] - mins[2];
 
 	return standing_height - height > PM_STOP_EPSILON;
-}
-
-/**
- * @brief Adds client-side player effects such as breath puffs in rain or snow
- */
-static void Cg_AddBreathPuffs(cl_entity_t *ent) {
-
-	if (ent->animation1.animation < ANIM_TORSO_GESTURE) { // death animations
-		return;
-	}
-
-	if (cgi.client->ticks < ent->breath_puff_time) {
-		return;
-	}
-
-	cg_particle_t *p;
-
-	vec3_t pos;
-	VectorCopy(ent->origin, pos);
-
-	if (Cg_IsDucking(&ent->current)) {
-		pos[2] += 18.0;
-	} else {
-		pos[2] += 30.0;
-	}
-
-	vec3_t forward;
-	AngleVectors(ent->angles, forward, NULL, NULL);
-
-	VectorMA(pos, 8.0, forward, pos);
-
-	const int32_t contents = cgi.PointContents(pos);
-
-	if (contents & MASK_LIQUID) {
-		if ((contents & MASK_LIQUID) == CONTENTS_WATER) {
-
-			if (!(p = Cg_AllocParticle(PARTICLE_BUBBLE, cg_particles_bubble))) {
-				return;
-			}
-
-			p->lifetime = 1000 - (Randomf() * 100);
-			p->effects |= PARTICLE_EFFECT_COLOR | PARTICLE_EFFECT_SCALE;
-
-			cgi.ColorFromPalette(6 + (Random() & 3), p->color_start);
-			p->color_start[3] = 1.0;
-
-			Vector4Copy(p->color_start, p->color_end);
-			p->color_end[3] = 0;
-
-			p->scale_start = 3.0;
-			p->scale_end = p->scale_start - (0.4 + Randomf() * 0.2);
-
-			VectorScale(forward, 2.0, p->vel);
-
-			for (int32_t j = 0; j < 3; j++) {
-				p->part.org[j] = pos[j] + Randomc() * 2.0;
-				p->vel[j] += Randomc() * 5.0;
-			}
-
-			p->vel[2] += 6.0;
-			p->accel[2] = 10.0;
-
-			ent->breath_puff_time = cgi.client->ticks + 3000;
-		}
-	} else if (cgi.view->weather & WEATHER_RAIN || cgi.view->weather & WEATHER_SNOW) {
-
-		if (!(p = Cg_AllocParticle(PARTICLE_ROLL, cg_particles_steam))) {
-			return;
-		}
-
-		p->lifetime = 4000 - (Randomf() * 100);
-		p->effects |= PARTICLE_EFFECT_COLOR | PARTICLE_EFFECT_SCALE;
-
-		cgi.ColorFromPalette(6 + (Random() & 7), p->color_start);
-		p->color_start[3] = 0.7;
-
-		Vector4Copy(p->color_start, p->color_end);
-		p->color_end[3] = 0;
-
-		p->scale_start = 1.5;
-		p->scale_end = 8.0;
-
-		p->part.roll = Randomc() * 20.0;
-
-		VectorCopy(pos, p->part.org);
-
-		VectorScale(forward, 5.0, p->vel);
-
-		for (int32_t i = 0; i < 3; i++) {
-			p->vel[i] += 2.0 * Randomc();
-		}
-
-		ent->breath_puff_time = cgi.client->ticks + 3000;
-	}
 }
 
 /**
@@ -182,8 +88,7 @@ static void Cg_AddClientEntity(cl_entity_t *ent, r_entity_t *e) {
 		e->origin[0] = cgi.view->origin[0];
 		e->origin[1] = cgi.view->origin[1];
 	} else {
-		// add breathing puffs in rain or snow, and bubbles while underwater
-		Cg_AddBreathPuffs(ent);
+		Cg_BreathTrail(ent);
 	}
 
 	r_entity_t head, torso, legs;
@@ -399,14 +304,13 @@ static void Cg_AddEntity(cl_entity_t *ent) {
  * several.
  */
 void Cg_AddEntities(const cl_frame_t *frame) {
-	uint16_t i;
 
 	if (!cg_add_entities->value) {
 		return;
 	}
 
 	// resolve any models, animations, interpolations, rotations, bobbing, etc..
-	for (i = 0; i < frame->num_entities; i++) {
+	for (uint16_t i = 0; i < frame->num_entities; i++) {
 
 		const uint32_t snum = (frame->entity_state + i) & ENTITY_STATE_MASK;
 		const entity_state_t *s = &cgi.client->entity_states[snum];

--- a/src/cgame/default/cg_entity.h
+++ b/src/cgame/default/cg_entity.h
@@ -26,7 +26,7 @@
 
 #ifdef __CG_LOCAL_H__
 	_Bool Cg_IsSelf(const cl_entity_t *ent);
-	_Bool Cg_IsDucking(const entity_state_t *ent);
+	_Bool Cg_IsDucking(const cl_entity_t *ent);
 	void Cg_AddEntities(const cl_frame_t *frame);
 #endif /* __CG_ENTITY_H__ */
 

--- a/src/cgame/default/cg_entity_trail.c
+++ b/src/cgame/default/cg_entity_trail.c
@@ -772,7 +772,7 @@ void Cg_EntityTrail(cl_entity_t *ent, r_entity_t *e) {
 	const entity_state_t *s = &ent->current;
 
 	vec3_t start, end;
-	VectorCopy(ent->trail_origin, start);
+	VectorCopy(ent->previous_origin, start);
 
 	// beams have two origins, most entities have just one
 	if (s->effects & EF_BEAM) {
@@ -840,9 +840,5 @@ void Cg_EntityTrail(cl_entity_t *ent, r_entity_t *e) {
 			break;
 		default:
 			break;
-	}
-
-	if (!(s->effects & EF_BEAM)) {
-		VectorCopy(ent->origin, ent->trail_origin);
 	}
 }

--- a/src/cgame/default/cg_entity_trail.h
+++ b/src/cgame/default/cg_entity_trail.h
@@ -25,6 +25,7 @@
 #include "cg_types.h"
 
 #ifdef __CG_LOCAL_H__
+	void Cg_BreathTrail(cl_entity_t *ent);
 	void Cg_BubbleTrail(const vec3_t start, const vec3_t end, vec_t density);
 	void Cg_SmokeTrail(cl_entity_t *ent, const vec3_t start, const vec3_t end);
 	void Cg_FlameTrail(cl_entity_t *ent, const vec3_t start, const vec3_t end);

--- a/src/cgame/default/cg_main.c
+++ b/src/cgame/default/cg_main.c
@@ -283,7 +283,6 @@ cg_export_t *Cg_LoadCgame(cg_import_t *import) {
 	cge.ParseMessage = Cg_ParseMessage;
 	cge.PredictMovement = Cg_PredictMovement;
 	cge.UpdateView = Cg_UpdateView;
-	cge.PopulateView = Cg_PopulateView;
 	cge.DrawFrame = Cg_DrawFrame;
 
 	return &cge;

--- a/src/cgame/default/cg_muzzle_flash.c
+++ b/src/cgame/default/cg_muzzle_flash.c
@@ -24,7 +24,7 @@
 /**
  * @brief
  */
-static void Cg_EnergyFlash(const entity_state_t *ent, uint8_t color) {
+static void Cg_EnergyFlash(const cl_entity_t *ent, uint8_t color) {
 	r_sustained_light_t s;
 	vec3_t forward, right, org, org2;
 
@@ -61,7 +61,7 @@ static void Cg_EnergyFlash(const entity_state_t *ent, uint8_t color) {
 /**
  * @brief
  */
-static void Cg_SmokeFlash(const entity_state_t *ent) {
+static void Cg_SmokeFlash(const cl_entity_t *ent) {
 	cg_particle_t *p;
 	r_sustained_light_t s;
 	vec3_t forward, right, org, org2;
@@ -127,8 +127,8 @@ static void Cg_SmokeFlash(const entity_state_t *ent) {
 /**
  * @brief FIXME: This should be a tentity instead; would make more sense.
  */
-static void Cg_LogoutFlash(const vec3_t org) {
-	Cg_GibEffect(org, 12);
+static void Cg_LogoutFlash(const cl_entity_t *ent) {
+	Cg_GibEffect(ent->origin, 12);
 }
 
 /**
@@ -145,7 +145,7 @@ void Cg_ParseMuzzleFlash(void) {
 		return;
 	}
 
-	const cl_entity_t *cent = &cgi.client->entities[ent_num];
+	const cl_entity_t *ent = &cgi.client->entities[ent_num];
 	const uint8_t flash = cgi.ReadByte();
 
 	const s_sample_t *sample;
@@ -154,33 +154,33 @@ void Cg_ParseMuzzleFlash(void) {
 		case MZ_BLASTER:
 			c = cgi.ReadByte();
 			sample = cg_sample_blaster_fire;
-			Cg_EnergyFlash(&cent->current, c ? c : EFFECT_COLOR_ORANGE);
+			Cg_EnergyFlash(ent, c ? c : EFFECT_COLOR_ORANGE);
 			break;
 		case MZ_SHOTGUN:
 			sample = cg_sample_shotgun_fire;
-			Cg_SmokeFlash(&cent->current);
+			Cg_SmokeFlash(ent);
 			break;
 		case MZ_SSHOTGUN:
 			sample = cg_sample_supershotgun_fire;
-			Cg_SmokeFlash(&cent->current);
+			Cg_SmokeFlash(ent);
 			break;
 		case MZ_MACHINEGUN:
 			sample = cg_sample_machinegun_fire[Random() % 4];
 			if (Random() & 1) {
-				Cg_SmokeFlash(&cent->current);
+				Cg_SmokeFlash(ent);
 			}
 			break;
 		case MZ_ROCKET:
 			sample = cg_sample_rocketlauncher_fire;
-			Cg_SmokeFlash(&cent->current);
+			Cg_SmokeFlash(ent);
 			break;
 		case MZ_GRENADE:
 			sample = cg_sample_grenadelauncher_fire;
-			Cg_SmokeFlash(&cent->current);
+			Cg_SmokeFlash(ent);
 			break;
 		case MZ_HYPERBLASTER:
 			sample = cg_sample_hyperblaster_fire;
-			Cg_EnergyFlash(&cent->current, 105);
+			Cg_EnergyFlash(ent, 105);
 			break;
 		case MZ_LIGHTNING:
 			sample = cg_sample_lightning_fire;
@@ -190,11 +190,11 @@ void Cg_ParseMuzzleFlash(void) {
 			break;
 		case MZ_BFG:
 			sample = cg_sample_bfg_fire;
-			Cg_EnergyFlash(&cent->current, 200);
+			Cg_EnergyFlash(ent, 200);
 			break;
 		case MZ_LOGOUT:
 			sample = cg_sample_teleport;
-			Cg_LogoutFlash(cent->current.origin);
+			Cg_LogoutFlash(ent);
 			break;
 		default:
 			sample = NULL;

--- a/src/cgame/default/cg_particle.c
+++ b/src/cgame/default/cg_particle.c
@@ -209,21 +209,25 @@ static _Bool Cg_UpdateParticle_Spark(cg_particle_t *p, const vec_t delta, const 
  * Particles that fade or shrink beyond visibility are freed.
  */
 void Cg_AddParticles(void) {
-	static uint32_t last_particle_time;
+	static uint32_t ticks;
 
 	if (!cg_add_particles->value) {
 		return;
 	}
 
-	if (last_particle_time > cgi.client->ticks) {
-		last_particle_time = 0;
+	if (ticks == cgi.client->ticks) {
+		return;
 	}
 
-	const vec_t delta = (cgi.client->ticks - last_particle_time) * 0.001;
+	if (ticks > cgi.client->ticks) {
+		ticks = 0;
+	}
+
+	const vec_t delta = (cgi.client->ticks - ticks) * 0.001;
 	const vec_t delta_squared = delta * delta;
 	_Bool cull;
 
-	last_particle_time = cgi.client->ticks;
+	ticks = cgi.client->ticks;
 
 	cg_particles_t *ps = cg_active_particles;
 	while (ps) {

--- a/src/cgame/default/cg_predict.c
+++ b/src/cgame/default/cg_predict.c
@@ -64,7 +64,7 @@ void Cg_PredictMovement(const GList *cmds) {
 	while (e) {
 		const cl_cmd_t *cmd = (cl_cmd_t *) e->data;
 
-		if (cmd->cmd.msec) {
+		if (cmd->cmd.msec) { // if the command has time, simulate the movement
 
 			pm.cmd = cmd->cmd;
 			Pm_Move(&pm);
@@ -88,11 +88,11 @@ void Cg_PredictMovement(const GList *cmds) {
 
 				pr->step.interval = 128.0 * (fabs(pr->step.step) / PM_STEP_HEIGHT);
 			}
-
-			// save for error detection
-			const uint32_t frame = (uint32_t) (uintptr_t) (cmd - cgi.client->cmds);
-			VectorCopy(pm.s.origin, pr->origins[frame]);
 		}
+
+		// save for error detection
+		const uint32_t frame = (uint32_t) (uintptr_t) (cmd - cgi.client->cmds);
+		VectorCopy(pm.s.origin, pr->origins[frame]);
 
 		e = e->next;
 	}

--- a/src/cgame/default/cg_view.c
+++ b/src/cgame/default/cg_view.c
@@ -235,24 +235,12 @@ void Cg_UpdateView(const cl_frame_t *frame) {
 	Cg_UpdateThirdPerson(&frame->ps);
 
 	Cg_UpdateBob(&frame->ps);
-}
 
-/**
- * @brief Processes all entities, particles, emits, etc.. adding them to the view.
- * This is called once per frame by the engine, after Cg_UpdateView, and is run
- * in a separate thread while the renderer begins drawing the world.
- */
-void Cg_PopulateView(const cl_frame_t *frame) {
-
-	// add entities
 	Cg_AddEntities(frame);
 
-	// and client side emits
 	Cg_AddEmits();
 
-	// and client side effects
 	Cg_AddEffects();
 
-	// and finally particles
 	Cg_AddParticles();
 }

--- a/src/cgame/default/cg_view.h
+++ b/src/cgame/default/cg_view.h
@@ -26,7 +26,6 @@
 
 #ifdef __CG_LOCAL_H__
 	void Cg_UpdateView(const cl_frame_t *frame);
-	void Cg_PopulateView(const cl_frame_t *frame);
 #endif /* __CG_LOCAL_H__ */
 
 #endif /* __CG_VIEW_H__ */

--- a/src/client/cl_cmd.c
+++ b/src/client/cl_cmd.c
@@ -112,7 +112,7 @@ void Cl_SendCommands(void) {
 
 	const uint32_t delta = quetoo.ticks - cls.net_chan.last_sent;
 
-	if (delta < 8) {
+	if (delta < 8 && !r_swap_interval->value) {
 		return;
 	}
 

--- a/src/client/cl_entity.c
+++ b/src/client/cl_entity.c
@@ -383,6 +383,16 @@ void Cl_Interpolate(void) {
 		} else {
 			VectorCopy(ent->current.angles, ent->angles);
 		}
+
+		if (ent->current.animation1 != ent->prev.animation1 || !ent->animation1.time) {
+			ent->animation1.animation = ent->current.animation1 & ~ANIM_TOGGLE_BIT;
+			ent->animation1.time = cl.ticks;
+		}
+
+		if (ent->current.animation2 != ent->prev.animation2 || !ent->animation2.time) {
+			ent->animation2.animation = ent->current.animation2 & ~ANIM_TOGGLE_BIT;
+			ent->animation2.time = cl.ticks;
+		}
 	}
 
 	Cl_UpdateView();

--- a/src/client/cl_entity.c
+++ b/src/client/cl_entity.c
@@ -305,11 +305,6 @@ void Cl_ParseFrame(void) {
 		// getting a valid frame message ends the connection process
 		if (cls.state == CL_LOADING) {
 			cls.state = CL_ACTIVE;
-
-			VectorCopy(cl.frame.ps.pm_state.origin, cl.predicted_state.view.origin);
-
-			UnpackVector(cl.frame.ps.pm_state.view_offset, cl.predicted_state.view.offset);
-			UnpackAngles(cl.frame.ps.pm_state.view_angles, cl.predicted_state.view.angles);
 		}
 
 		Cl_CheckPredictionError();
@@ -350,25 +345,18 @@ static void Cl_UpdateLerp(void) {
 }
 
 /**
- * @brief Interpolates the simulation over all new client frames.
- * @remarks This can be called multiple times per client frame, in the event that the client has
- * received multiple server updates at once. This happens somewhat frequently, especially at higher
- * server tick rates.
+ * @brief Interpolates the simulation for the most recently parsed server frame.
+ * @remarks This can be called multiple times per frame, in the event that the client has received 
+ * multiple server updates at once. This happens somewhat frequently, especially at higher server 
+ * tick rates, or with significant network jitter.
  */
 void Cl_Interpolate(void) {
-	static uint32_t last_time;
 
 	if (!cl.frame.valid && !r_view.update) {
 		return;
 	}
 
 	Cl_UpdateLerp();
-
-	if (cl.time == last_time) {
-		return;
-	}
-
-	last_time = cl.time;
 
 	for (uint16_t i = 0; i < cl.frame.num_entities; i++) {
 

--- a/src/client/cl_entity.c
+++ b/src/client/cl_entity.c
@@ -259,7 +259,7 @@ void Cl_ParseFrame(void) {
 
 	cl.frame.delta_frame_num = Net_ReadLong(&net_message);
 
-	cl.suppress_count = Net_ReadByte(&net_message);
+	cl.suppress_count += Net_ReadByte(&net_message);
 
 	if (cl_show_net_messages->integer == 3) {
 		Com_Print("   frame:%i  delta:%i\n", cl.frame.frame_num, cl.frame.delta_frame_num);

--- a/src/client/cl_entity.c
+++ b/src/client/cl_entity.c
@@ -152,7 +152,7 @@ static void Cl_ParseEntities(const cl_frame_t *delta_frame, cl_frame_t *frame) {
 			break;
 		}
 
-		// before dealing with the new entity, copy unchanged entities into the frame
+		// before dealing with new entities, copy unchanged entities into the frame
 		while (delta_number < number) {
 
 			if (cl_show_net_messages->integer == 3) {

--- a/src/client/cl_entity.c
+++ b/src/client/cl_entity.c
@@ -78,8 +78,7 @@ static void Cl_ReadDeltaEntity(cl_frame_t *frame, entity_state_t *from, uint16_t
 		ent->prev = *to; // copy the current state to the previous
 		ent->animation1.time = ent->animation2.time = 0;
 		ent->animation1.frame = ent->animation2.frame = -1;
-	
-		VectorCopy(ent->prev.origin, ent->trail_origin);
+		VectorCopy(to->origin, ent->previous_origin);
 	} else { // shuffle the last state to previous
 		ent->prev = ent->current;
 	}
@@ -368,6 +367,7 @@ void Cl_Interpolate(void) {
 		cl_entity_t *ent = &cl.entities[cl.entity_states[snum].number];
 
 		if (!VectorCompare(ent->prev.origin, ent->current.origin)) {
+			VectorCopy(ent->origin, ent->previous_origin);
 			VectorLerp(ent->prev.origin, ent->current.origin, cl.lerp, ent->origin);
 			ent->lighting.state = LIGHTING_DIRTY;
 		} else {

--- a/src/client/cl_main.c
+++ b/src/client/cl_main.c
@@ -618,9 +618,6 @@ void Cl_Frame(const uint32_t msec) {
 	// fetch updates from server
 	Cl_ReadPackets();
 
-	// and interpolate them
-	Cl_Interpolate();
-
 	// fetch input from user
 	Cl_HandleEvents();
 
@@ -632,6 +629,9 @@ void Cl_Frame(const uint32_t msec) {
 
 	// predict all unacknowledged movements
 	Cl_PredictMovement();
+
+	// advance the simulation
+	Cl_Interpolate();
 
 	// update the screen
 	Cl_UpdateScreen();

--- a/src/client/cl_parse.c
+++ b/src/client/cl_parse.c
@@ -417,7 +417,9 @@ void Cl_ParseServerMessage(void) {
 		Com_Print("------------------\n");
 	}
 
-	cmd = 0;
+	cl.suppress_count = 0;
+
+	cmd = SV_CMD_BAD;
 
 	// parse the message
 	while (true) {
@@ -453,6 +455,7 @@ void Cl_ParseServerMessage(void) {
 
 			case SV_CMD_DISCONNECT:
 				Com_Error(ERR_DROP, "Server disconnected\n");
+				break;
 
 			case SV_CMD_DOWNLOAD:
 				Cl_ParseDownload();
@@ -472,9 +475,7 @@ void Cl_ParseServerMessage(void) {
 				if (cls.download.file) {
 					if (cls.download.http) { // clean up http downloads
 						Cl_HttpDownload_Complete();
-					} else
-						// or just stop legacy ones
-					{
+					} else { // or just stop legacy ones
 						Fs_Close(cls.download.file);
 					}
 					cls.download.name[0] = '\0';

--- a/src/client/cl_predict.h
+++ b/src/client/cl_predict.h
@@ -32,7 +32,6 @@ cm_trace_t Cl_Trace(const vec3_t start, const vec3_t end, const vec3_t mins, con
 	_Bool Cl_UsePrediction(void);
 	void Cl_PredictMovement(void);
 	void Cl_CheckPredictionError(void);
-	void Cl_PredictionError(vec3_t error);
 	void Cl_UpdatePrediction(void);
 #endif /* __CL_LOCAL_H__ */
 

--- a/src/client/cl_screen.c
+++ b/src/client/cl_screen.c
@@ -343,8 +343,6 @@ void Cl_UpdateScreen(void) {
 
 	if (cls.state == CL_ACTIVE) {
 
-		Cl_UpdateView();
-
 		R_Setup3D();
 
 		R_DrawView();

--- a/src/client/cl_types.h
+++ b/src/client/cl_types.h
@@ -42,7 +42,6 @@ typedef struct {
 	uint32_t entity_state; // non-masked index into cl.entity_states array
 	_Bool valid; // false if delta parsing failed
 	uint32_t time; // simulation time for which the frame is valid
-	vec3_t prediction_error;
 } cl_frame_t;
 
 typedef struct {
@@ -127,6 +126,8 @@ typedef struct {
 	struct g_entity_s *ground_entity;
 
 	vec3_t origins[CMD_BACKUP]; // for reconciling with the server
+
+	vec3_t error; // the prediction error, interpolated over the current server frame
 } cl_predicted_state_t;
 
 /**

--- a/src/client/cl_types.h
+++ b/src/client/cl_types.h
@@ -63,8 +63,6 @@ typedef struct {
 	uint32_t timestamp; // for intermittent effects
 	vec3_t trail_origin; // for trails
 
-	uint32_t breath_puff_time; // time breath puffs should be drawn next
-
 	cl_entity_animation_t animation1; // torso animation
 	cl_entity_animation_t animation2; // legs animation
 

--- a/src/client/cl_types.h
+++ b/src/client/cl_types.h
@@ -152,6 +152,7 @@ typedef struct {
 	cl_frame_t frame; // the most recent frame received from server
 	cl_frame_t frames[PACKET_BACKUP]; // for calculating delta compression
 
+	cl_frame_t *render_frame; // the most recently rendered frame
 	cl_frame_t *delta_frame; // the delta frame for the current frame
 
 	cl_entity_t entities[MAX_ENTITIES]; // client entities

--- a/src/client/cl_types.h
+++ b/src/client/cl_types.h
@@ -41,6 +41,7 @@ typedef struct {
 	uint16_t num_entities; // the number of entities in the frame
 	uint32_t entity_state; // non-masked index into cl.entity_states array
 	_Bool valid; // false if delta parsing failed
+	_Bool interpolated; // true if this frame has been interpolated one or more times
 	uint32_t time; // simulation time for which the frame is valid
 } cl_frame_t;
 

--- a/src/client/cl_types.h
+++ b/src/client/cl_types.h
@@ -62,12 +62,12 @@ typedef struct {
 	int32_t frame_num; // the last frame in which this entity was seen
 
 	uint32_t timestamp; // for intermittent effects
-	vec3_t trail_origin; // for trails
 
 	cl_entity_animation_t animation1; // torso animation
 	cl_entity_animation_t animation2; // legs animation
 
 	vec3_t origin; // interpolated origin
+	vec3_t previous_origin; // the previous interpolated origin
 	vec3_t termination; // and termination
 	vec3_t angles; // and angles
 

--- a/src/client/cl_types.h
+++ b/src/client/cl_types.h
@@ -34,14 +34,14 @@ typedef struct {
 } cl_cmd_t;
 
 typedef struct {
-	uint32_t time; // simulation time for which the frame is valid
 	int32_t frame_num; // sequential identifier, used for delta
 	int32_t delta_frame_num; // negatives indicate no delta
 	byte area_bits[MAX_BSP_AREAS >> 3]; // portal area visibility bits
-	player_state_t ps;
-	uint16_t num_entities;
+	player_state_t ps; // the player state
+	uint16_t num_entities; // the number of entities in the frame
 	uint32_t entity_state; // non-masked index into cl.entity_states array
 	_Bool valid; // false if delta parsing failed
+	uint32_t time; // simulation time for which the frame is valid
 	vec3_t prediction_error;
 } cl_frame_t;
 
@@ -59,7 +59,7 @@ typedef struct {
 	entity_state_t current;
 	entity_state_t prev; // will always be valid, but might just be a copy of current
 
-	int32_t frame_num; // if not current, this entity isn't in the frame
+	int32_t frame_num; // the last frame in which this entity was seen
 
 	uint32_t timestamp; // for intermittent effects
 
@@ -152,7 +152,6 @@ typedef struct {
 	cl_frame_t frame; // the most recent frame received from server
 	cl_frame_t frames[PACKET_BACKUP]; // for calculating delta compression
 
-	cl_frame_t *render_frame; // the most recently rendered frame
 	cl_frame_t *delta_frame; // the delta frame for the current frame
 
 	cl_entity_t entities[MAX_ENTITIES]; // client entities
@@ -167,7 +166,7 @@ typedef struct {
 	uint32_t time; // clamped simulation time that the client is rendering at
 	uint32_t ticks; // unclamped simulation time, useful for absolute durations
 
-	vec_t lerp; // linear interpolation between frames
+	vec_t lerp; // linear interpolation fraction between frames
 
 	// the client maintains its own idea of view angles, which are
 	// sent to the server each frame. It is cleared to 0 upon entering each level.

--- a/src/client/cl_view.c
+++ b/src/client/cl_view.c
@@ -83,14 +83,12 @@ static void Cl_UpdateOrigin(const player_state_t *from, const player_state_t *to
 
 	if (Cl_UsePrediction()) {
 		const cl_predicted_state_t *pr = &cl.predicted_state;
-		vec3_t error;
 
 		// use client sided prediction
 		VectorAdd(pr->view.origin, pr->view.offset, r_view.origin);
 
 		// add the interpolated prediction error
 		VectorMA(r_view.origin, -(1.0 - cl.lerp), pr->error, r_view.origin);
-
 
 		// interpolate stair traversal
 		const uint32_t step_delta = cl.ticks - pr->step.timestamp;

--- a/src/client/cl_view.c
+++ b/src/client/cl_view.c
@@ -177,14 +177,9 @@ static void Cl_UpdateAngles(const player_state_t *from, const player_state_t *to
 }
 
 /**
- * @brief Updates the r_view_t for the renderer. Origin, angles, etc are calculated.
- * Scene population is then delegated (asynchronously) to the client game.
+ * @brief Updates the view definition for the renderer. Origin, angles, etc are calculated.
  */
 void Cl_UpdateView(void) {
-
-	if (!cl.frame.valid && !r_view.update) {
-		return; // not a valid frame, and no forced update
-	}
 
 	Cl_ClearView();
 
@@ -194,20 +189,15 @@ void Cl_UpdateView(void) {
 	// set area bits to mark visible leafs
 	r_view.area_bits = cl.frame.area_bits;
 
-	const cl_frame_t *frame = &cl.frames[(cl.frame.frame_num - 1) & PACKET_MASK];
-	const player_state_t *from = frame->frame_num == cl.frame.frame_num - 1 ? &frame->ps : &cl.frame.ps;
+	const player_state_t *ps = cl.delta_frame ? &cl.delta_frame->ps : &cl.frame.ps;
 
-	Cl_UpdateOrigin(from, &cl.frame.ps);
+	Cl_UpdateOrigin(ps, &cl.frame.ps);
 
-	Cl_UpdateAngles(from, &cl.frame.ps);
+	Cl_UpdateAngles(ps, &cl.frame.ps);
 
 	Cl_UpdateViewSize();
 
-	// allow client game to modify view (bob, third person, etc)
 	cls.cgame->UpdateView(&cl.frame);
-
-	// create the thread which populates the view
-	r_view.thread = Thread_Create((ThreadRunFunc) cls.cgame->PopulateView, &cl.frame);
 }
 
 /**

--- a/src/client/renderer/r_main.c
+++ b/src/client/renderer/r_main.c
@@ -158,9 +158,6 @@ void R_DrawView(void) {
 
 	R_DrawSkyBox();
 
-	// wait for the client to fully populate the scene
-	Thread_Wait(r_view.thread);
-
 	R_AddSustainedLights();
 
 	R_AddFlares();

--- a/src/client/renderer/r_types.h
+++ b/src/client/renderer/r_types.h
@@ -1108,8 +1108,6 @@ typedef struct {
 
 	r_sustained_light_t sustained_lights[MAX_LIGHTS];
 
-	thread_t *thread; // client thread which populates view
-
 	const r_entity_t *current_entity; // entity being rendered
 	const r_shadow_t *current_shadow; // shadow being rendered
 

--- a/src/common.h
+++ b/src/common.h
@@ -41,7 +41,7 @@
  * of core net messages or serialized data types change. The game and client
  * game maintain PROTOCOL_MINOR as well.
  */
-#define PROTOCOL_MAJOR		1018
+#define PROTOCOL_MAJOR		1019
 
 /**
  * @brief The IP address of the master server, where the authoritative list of

--- a/src/quetoo.h
+++ b/src/quetoo.h
@@ -180,7 +180,7 @@ typedef enum {
 /**
  * @brief The server, game and player movement frame rate.
  */
-#define QUETOO_TICK_RATE	40
+#define QUETOO_TICK_RATE	60
 #define QUETOO_TICK_SECONDS	(1.0 / QUETOO_TICK_RATE)
 #define QUETOO_TICK_MILLIS	(1000 / QUETOO_TICK_RATE)
 

--- a/src/quetoo.h
+++ b/src/quetoo.h
@@ -532,13 +532,13 @@ typedef enum {
 	SOLID_BSP, // inline models interact just like the static world
 } solid_t;
 
-/*
- * Entity states are transmitted by the server to the client using delta
+/**
+ * @brief Entity states are transmitted by the server to the client using delta
  * compression. The client parses these states and adds or removes entities
  * from the scene as needed.
  */
 typedef struct {
-	uint16_t number; // edict index
+	uint16_t number; // entity index
 
 	vec3_t origin;
 	vec3_t termination; // beams (lightning, grapple, lasers, ..)


### PR DESCRIPTION
This change is to fix the scenario where the client receives multiple updates from the server in a single client frame iteration (Cl_ReadPackets). This scenario is increasingly common at high server tick rates, but it's entirely possible even at 30Hz, depending on client framerate and network connection quality. A temporary dip in client framerate, or a jittery network connection, can both produce this scenario even at 30Hz, and so we should deal with it.

The solution is to call Cl_Interpolate from within Cl_ParseFrame. Cl_Interpolate has been refactored to loop over all new frames from the last one that it saw. It fully populates the view at each iteration, tho only the last iteration will be rendered. Populating the view is not very expensive, since all we do is delta the entity state, and copy entities, particles, etc.. into the view. So while there is some "throw-away" work with this approach, it's minimal.

This actually fixes a lot of issues:

 * Animation changes falling through the cracks because a server frame was never seen by the cgame.
 * Sounds, explosions and other events simply falling through the cracks and never being heard or seen.
 * This *should* enable an elegant fix for prediction error interpolation, altho right now this is not yet corrected.

One very obvious glitch with this change as-is, is that particles flicker for some reason. If you could help me understand that one, that'd be great!