### PR TITLE
Fix console linewrap colors

### DIFF
--- a/src/console.c
+++ b/src/console.c
@@ -256,7 +256,6 @@ size_t Con_Wrap(const char *chars, size_t line_width, char **lines, size_t max_l
 				lines[count][0] = COLOR_ESC;
 				lines[count][1] = wrap_color + '0';
 				lines[count][2] = '\0';
-				lines[count][0] = 0;
 				strncat(lines[count], line, eol - line);
 			} else {
 				break;


### PR DESCRIPTION
This fixes the linewrapping color issues in the chat log and the console.