### PR TITLE
Issue/63 quemap materials

### DIFF
--- a/Quetoo.xcodeproj/project.pbxproj
+++ b/Quetoo.xcodeproj/project.pbxproj
@@ -293,6 +293,7 @@
 		CEA936671DBCD89000A12B79 /* r_program_corona.h in Headers */ = {isa = PBXBuildFile; fileRef = CEA936631DBCD87400A12B79 /* r_program_corona.h */; };
 		CEB8D6271E00B73200043814 /* cg_input.c in Sources */ = {isa = PBXBuildFile; fileRef = CEB8D6231E00B72100043814 /* cg_input.c */; };
 		CEC986941D3835420002B714 /* libmysqlclient.18.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = CEC986931D3835420002B714 /* libmysqlclient.18.dylib */; };
+		CECA8CB01E50B5F1005E97E8 /* materials.c in Sources */ = {isa = PBXBuildFile; fileRef = CECA8CAE1E50B5F1005E97E8 /* materials.c */; };
 		CED4381E1D9D33AF0052BAFA /* libpmove.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = CEFC7B8A1D9D2E71000FA6B2 /* libpmove.dylib */; };
 		CED4381F1D9D33E80052BAFA /* PrimaryButton.c in Sources */ = {isa = PBXBuildFile; fileRef = CEFC79421D9BE432000FA6B2 /* PrimaryButton.c */; };
 		CED438381D9D34450052BAFA /* r_array.c in Sources */ = {isa = PBXBuildFile; fileRef = CE12D5B01C5C58C300CD0B13 /* r_array.c */; };
@@ -1383,6 +1384,9 @@
 		CEB8D6231E00B72100043814 /* cg_input.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = cg_input.c; sourceTree = "<group>"; };
 		CEB8D6241E00B72100043814 /* cg_input.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = cg_input.h; sourceTree = "<group>"; };
 		CEC986931D3835420002B714 /* libmysqlclient.18.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libmysqlclient.18.dylib; path = ../../../../opt/local/lib/mysql56/mysql/libmysqlclient.18.dylib; sourceTree = "<group>"; };
+		CECA8CAD1E4EC027005E97E8 /* qmat.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = qmat.h; sourceTree = "<group>"; };
+		CECA8CAE1E50B5F1005E97E8 /* materials.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = materials.c; sourceTree = "<group>"; };
+		CECA8CAF1E50B5F1005E97E8 /* materials.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = materials.h; sourceTree = "<group>"; };
 		CED438AD1D9D34450052BAFA /* librenderer.dylib */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; path = librenderer.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
 		CED4393B1D9D344E0052BAFA /* libsound.dylib */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; path = libsound.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
 		CEDB4BB01D404D9D009921B6 /* libObjectivelyMVC.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libObjectivelyMVC.dylib; path = "../../Library/Developer/Xcode/DerivedData/Quetoo-eijmznjiunzbaafulkyjapfulhqz/Build/Products/Debug/libObjectivelyMVC.dylib"; sourceTree = "<group>"; };
@@ -2521,6 +2525,8 @@
 				CE12D6ED1C5C58C300CD0B13 /* lightmap.c */,
 				CE12D6EE1C5C58C300CD0B13 /* main.c */,
 				CE12D6F11C5C58C300CD0B13 /* map.c */,
+				CECA8CAE1E50B5F1005E97E8 /* materials.c */,
+				CECA8CAF1E50B5F1005E97E8 /* materials.h */,
 				CE12D6F21C5C58C300CD0B13 /* monitor.c */,
 				CE12D6F31C5C58C300CD0B13 /* monitor.h */,
 				CE12D6F41C5C58C300CD0B13 /* patches.c */,
@@ -2534,6 +2540,7 @@
 				CE12D6FC1C5C58C300CD0B13 /* qlight.c */,
 				CE12D6FD1C5C58C300CD0B13 /* qlight.h */,
 				CE12D6FE1C5C58C300CD0B13 /* qmat.c */,
+				CECA8CAD1E4EC027005E97E8 /* qmat.h */,
 				CE12D6FF1C5C58C300CD0B13 /* quemap.h */,
 				CE92B3A91D2FF72200E9153A /* quemap-icon.rc */,
 				CE92B3AA1D2FF77800E9153A /* quemap.ico */,
@@ -3965,6 +3972,7 @@
 			files = (
 				CE80FFE31C5E4D1800A21A51 /* brush.c in Sources */,
 				CE80FFE41C5E4D1800A21A51 /* bspfile.c in Sources */,
+				CECA8CB01E50B5F1005E97E8 /* materials.c in Sources */,
 				CE80FFE51C5E4D1800A21A51 /* csg.c in Sources */,
 				CE80FFE61C5E4D1800A21A51 /* faces.c in Sources */,
 				CE80FFE71C5E4D1800A21A51 /* flow.c in Sources */,

--- a/Quetoo.xcodeproj/xcshareddata/xcschemes/quemap.xcscheme
+++ b/Quetoo.xcodeproj/xcshareddata/xcschemes/quemap.xcscheme
@@ -63,7 +63,11 @@
       </BuildableProductRunnable>
       <CommandLineArguments>
          <CommandLineArgument
-            argument = "-bsp -vis -fast -light maps/dreams.map"
+            argument = "-mat maps/lighttest.map"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "-bsp -vis -light maps/lighttest.map"
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>

--- a/Quetoo.xcodeproj/xcshareddata/xcschemes/quetoo.xcscheme
+++ b/Quetoo.xcodeproj/xcshareddata/xcschemes/quetoo.xcscheme
@@ -71,7 +71,7 @@
             isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
-            argument = "+set r_fullscreen 0 +set sv_max_clients 24 +map aerowalk +set g_cheats 1 +give all +god"
+            argument = "+set r_fullscreen 1 +set sv_max_clients 24 +map aerowalk +set g_cheats 1 +give all +god"
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>

--- a/src/client/renderer/r_material.c
+++ b/src/client/renderer/r_material.c
@@ -706,9 +706,7 @@ static _Bool R_ConvertMaterial(cm_material_t *cm, r_material_t **mat) {
 		Com_Error(ERROR_DROP, "NULL diffuse name\n");
 	}
 
-	Cm_MaterialName(cm->base, key, sizeof(key));
-	g_strlcat(key, "_mat", sizeof(key));
-
+	g_snprintf(key, sizeof(key), "%s_mat", cm->base);
 	r_material_t *material = (r_material_t *) R_FindMedia(key);
 
 	if (material == NULL) {
@@ -764,13 +762,13 @@ r_material_t *R_LoadMaterial(const char *name) {
 	char key[MAX_QPATH];
 
 	StripExtension(name, key);
-	Cm_MaterialName(key, key, sizeof(key));
+	Cm_NormalizeMaterialName(key, key, sizeof(key));
 
 	g_strlcat(key, "_mat", sizeof(key));
 	r_material_t *mat = (r_material_t *) R_FindMedia(key);
 
 	if (mat == NULL) {
-		R_ConvertMaterial(Cm_LoadMaterial(name), &mat);
+		R_ConvertMaterial(Cm_AllocMaterial(name), &mat);
 	}
 
 	return mat;

--- a/src/collision/cm_material.h
+++ b/src/collision/cm_material.h
@@ -121,6 +121,7 @@ typedef enum {
 #define DEFAULT_PARALLAX 1.0
 #define DEFAULT_HARDNESS 1.0
 #define DEFAULT_SPECULAR 1.0
+#define DEFAULT_LIGHT 300.0
 
 typedef struct cm_material_s {
 	/**
@@ -159,14 +160,14 @@ typedef struct cm_material_s {
 	uint32_t surface;
 
 	/**
+	 * @brief Light emission applied to surfaces referencing this material.
+	 */
+	vec_t light;
+
+	/**
 	 * @brief The bump factor to use for the normal map.
 	 */
 	vec_t bump;
-
-	/**
-	 * @brief The parallel factor to use for the normal map.
-	 */
-	vec_t parallax;
 
 	/**
 	 * @brief The hardness factor to use for the normal map.
@@ -177,6 +178,11 @@ typedef struct cm_material_s {
 	 * @brief The specular factor to use for the specular map.
 	 */
 	vec_t specular;
+
+	/**
+	 * @brief The parallel factor to use for the normal map.
+	 */
+	vec_t parallax;
 
 	/**
 	 * @brief The name for the footstep sounds to query on this surface
@@ -200,14 +206,14 @@ typedef struct cm_material_s {
 	uint16_t num_stages;
 } cm_material_t;
 
-cm_material_t *Cm_LoadMaterial(const char *diffuse);
+cm_material_t *Cm_AllocMaterial(const char *diffuse);
 void Cm_FreeMaterial(cm_material_t *material);
 void Cm_FreeMaterialList(cm_material_t **materials);
 
 cm_material_t **Cm_LoadMaterials(const char *path, size_t *count);
 void Cm_WriteMaterials(const char *filename, const cm_material_t **materials, const size_t num_materials);
 
-void Cm_MaterialName(const char *in, char *out, size_t len);
+void Cm_NormalizeMaterialName(const char *in, char *out, size_t len);
 
 #ifdef __CM_LOCAL_H__
 #endif /* __CM_LOCAL_H__ */

--- a/src/collision/cm_model.c
+++ b/src/collision/cm_model.c
@@ -86,7 +86,7 @@ static void Cm_LoadBspSurfaces(void) {
 
 		char material_name[MAX_QPATH];
 		g_snprintf(material_name, sizeof(material_name), "textures/%s", out->name);
-		Cm_MaterialName(material_name, material_name, sizeof(material_name));
+		Cm_NormalizeMaterialName(material_name, material_name, sizeof(material_name));
 
 		for (size_t i = 0; i < cm_bsp.num_materials; i++) {
 			cm_material_t *material = cm_bsp.materials[i];

--- a/src/tools/quemap/Makefile.am
+++ b/src/tools/quemap/Makefile.am
@@ -3,6 +3,7 @@ bin_PROGRAMS = \
 
 noinst_HEADERS = \
 	bspfile.h \
+	materials.h \
 	monitor.h \
 	polylib.h \
 	quemap.h \
@@ -22,6 +23,7 @@ quemap_SOURCES = \
 	lightmap.c \
 	main.c \
 	map.c \
+	materials.c \
 	monitor.c \
 	patches.c \
 	polylib.c \

--- a/src/tools/quemap/bspfile.c
+++ b/src/tools/quemap/bspfile.c
@@ -200,7 +200,7 @@ void UnparseEntities(void) {
 	for (i = 0; i < num_entities; i++) {
 		ep = entities[i].epairs;
 		if (!ep) {
-			continue;    // ent got removed
+			continue; // ent got removed
 		}
 
 		strcat(end, "{\n");

--- a/src/tools/quemap/materials.c
+++ b/src/tools/quemap/materials.c
@@ -1,0 +1,82 @@
+/*
+ * Copyright(c) 1997-2001 id Software, Inc.
+ * Copyright(c) 2002 The Quakeforge Project.
+ * Copyright(c) 2006 Quetoo.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+#include "quemap.h"
+#include "materials.h"
+
+static GPtrArray *materials;
+
+/**
+ * @brief Loads all materials defined in the material file.
+ */
+void LoadMaterials(void) {
+
+	size_t count;
+	cm_material_t **mats = Cm_LoadMaterials(mat_name, &count);
+	cm_material_t **material = mats;
+
+	materials = g_ptr_array_new_with_free_func((GDestroyNotify) Cm_FreeMaterial);
+	assert(materials);
+
+	for (size_t i = 0; i < count; i++, material++) {
+		g_ptr_array_add(materials, *material);
+	}
+}
+
+/**
+ * @brief Frees all loaded materials.
+ */
+void FreeMaterials(void) {
+	g_ptr_array_free(materials, true);
+	materials = NULL;
+}
+
+/**
+ * @brief Loads the material with the specified name.
+ */
+cm_material_t *LoadMaterial(const char *name) {
+
+	const char *diffuse = va("textures/%s", name);
+
+	for (guint i = 0; i < materials->len; i++) {
+		cm_material_t *material = g_ptr_array_index(materials, i);
+		if (!g_strcmp0(material->diffuse, diffuse)) {
+			return material;
+		}
+	}
+
+	cm_material_t *material = Cm_AllocMaterial(diffuse);
+	g_ptr_array_add(materials, material);
+
+	Com_Debug(DEBUG_ALL, "Loaded material %s\n", diffuse);
+
+	return material;
+}
+
+/**
+ * @brief Writes the materials to the specified file.
+ */
+void WriteMaterialsFile(const char *filename) {
+
+	Cm_WriteMaterials(filename, (const cm_material_t **) materials->pdata, materials->len);
+
+	Com_Print("Generated %d materials\n", materials->len);
+}

--- a/src/tools/quemap/materials.h
+++ b/src/tools/quemap/materials.h
@@ -18,9 +18,13 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
  */
-
 #pragma once
 
-#include "qbsp.h"
-#include "materials.h"
-#include "scriptlib.h"
+#include "collision/cm_material.h"
+
+void LoadMaterials(void);
+void FreeMaterials(void);
+
+cm_material_t *LoadMaterial(const char *diffuse);
+
+void WriteMaterialsFile(const char *filename);

--- a/src/tools/quemap/qbsp.c
+++ b/src/tools/quemap/qbsp.c
@@ -21,6 +21,7 @@
 
 #include "quemap.h"
 #include "qbsp.h"
+#include "materials.h"
 #include "scriptlib.h"
 
 vec_t microvolume = 0.125;
@@ -325,20 +326,13 @@ static void CreateBSPFile(void) {
  * @brief
  */
 int32_t BSP_Main(void) {
-	char base[MAX_OS_PATH];
 
 	Com_Print("\n----- BSP -----\n\n");
 
 	const time_t start = time(NULL);
 
-	StripExtension(map_name, base);
-
 	// clear the whole bsp structure
 	memset(&bsp_file, 0, sizeof(bsp_file));
-
-	// delete portal and line files
-	remove(va("%s.prt", base));
-	remove(va("%s.lin", base));
 
 	// if onlyents, just grab the entities and re-save
 	if (onlyents) {
@@ -354,12 +348,23 @@ int32_t BSP_Main(void) {
 		WriteBSPFile(bsp_name, version);
 	} else {
 
+		// delete portal and line files
+		char base[MAX_OS_PATH];
+		StripExtension(map_name, base);
+
+		remove(va("%s.prt", base));
+		remove(va("%s.lin", base));
+
+		LoadMaterials();
+
 		CreateBSPFile();
-		// start from scratch
+
 		LoadMapFile(map_name);
 		SetModelNumbers();
 
 		ProcessModels();
+
+		FreeMaterials();
 	}
 
 	UnloadScriptFiles();


### PR DESCRIPTION
This adds full material awareness to Quemap.

 * Materials are loaded from the map source, rather than the bsp result. This enables materials to influence the BSP compilation phase, and allows mappers to generate materials files without first compiling the map.

 * `quemap -mat` now authors a complete, correct materials file, preserving any previously defined materials and stages as well. Mappers don't have to worry about losing their materials by re-running the `-mat` phase. This will come in very handy for the in-game materials editor.

 * Materials can inform the BSP compilation phase with contents, surface and light parameters. As an example:

```
    {
      material tokays/water
      contents water
      surface "blend_33 light warp"
      light 400
    }
    {
      material torn/floor_fx
      contents mist
      surface material
      {
        texture torn/floorfx_fx
        blend GL_SRC_ALPHA GL_ONE
        stretch 0.5 1.0
        pulse 1.0
        color 0.3 0.3 0.3
      }
    }
```

