### PR TITLE
The better version of my terrible commit.

### DIFF
--- a/src/cgame/default/cg_hud.c
+++ b/src/cgame/default/cg_hud.c
@@ -1218,8 +1218,8 @@ void Cg_LoadHudMedia(void) {
  * @brief
  */
 void Cg_InitHud(void) {
-	cgi.Cmd("cg_weapon_next", Cg_Weapon_Next_f, CMD_CGAME, NULL);
-	cgi.Cmd("cg_weapon_previous", Cg_Weapon_Prev_f, CMD_CGAME, NULL);
+	cgi.Cmd("cg_weapon_next", Cg_Weapon_Next_f, CMD_CGAME, "Open the weapon bar to the next weapon. In chasecam, switches to next target.");
+	cgi.Cmd("cg_weapon_previous", Cg_Weapon_Prev_f, CMD_CGAME, "Open the weapon bar to the previous weapon. In chasecam, switches to previous target.");
 	
 	cg_weaponbar_choose_time = cgi.Cvar("cg_weaponbar_choose_time", "250", CVAR_ARCHIVE, "The amount of time, in milliseconds, to wait between changing weapons in the scroll view. Clicking will override this value and switch immediately.");
 	cg_weaponbar_wait_time = cgi.Cvar("cg_weaponbar_wait_time", "750", CVAR_ARCHIVE, "The amount of time, in milliseconds, to show the weapon bar after changing weapons.");

--- a/src/client/cl_keys.c
+++ b/src/client/cl_keys.c
@@ -439,14 +439,10 @@ static void Cl_Bind_Autocomplete_f(const uint32_t argi, GList **matches) {
 
 	for (SDL_Scancode k = SDL_SCANCODE_UNKNOWN; k < SDL_NUM_SCANCODES; k++) {
 		if (cl_key_names[k]) {
-
 			const char *keyName = cl_key_names[k];
 
-			//Com_Print("dbg: %s vs %s: %s\n", keyName, pattern, GlobMatch(pattern, keyName) ? "yes" : "no");
-
 			if (GlobMatch(pattern, keyName, GLOB_CASE_INSENSITIVE)) {
-				*matches = g_list_prepend(*matches, Mem_TagCopyString(keyName, MEM_TAG_CLIENT));
-				Com_Print("%s\n", keyName);
+				*matches = g_list_insert_sorted(*matches, Com_AllocMatch(keyName, NULL), Com_MatchCompare);
 			}
 		}
 	}

--- a/src/common.c
+++ b/src/common.c
@@ -473,3 +473,30 @@ void Com_PrintInfo(const char *s) {
 		Com_Print("%s\n", value);
 	}
 }
+
+/**
+ * @brief Allocate a match for autocomplete "matches" list.
+ */
+com_autocomplete_match_t *Com_AllocMatch(const char *name, const char *description) {
+	com_autocomplete_match_t *match = Mem_Malloc(sizeof(com_autocomplete_match_t));
+
+	match->name = Mem_CopyString(name);
+	Mem_Link(match, match->name);
+	
+	if (description) {
+		match->description = Mem_CopyString(description);
+		Mem_Link(match, match->description);
+	}
+	
+	return match;
+}
+
+/**
+ * @brief Autocomplete match compare function
+ */
+int32_t Com_MatchCompare(const void *a, const void *b) {
+	const com_autocomplete_match_t *ma = (const com_autocomplete_match_t *) a;
+	const com_autocomplete_match_t *mb = (const com_autocomplete_match_t *) b;
+
+	return g_strcmp0(ma->description ?: ma->name, mb->description ?: mb->name);
+}

--- a/src/common.h
+++ b/src/common.h
@@ -163,6 +163,24 @@ void Com_Warnv_(const char *func, const char *fmt, va_list args) __attribute__((
 #define Com_Warn(...) Com_Warn_(__func__, __VA_ARGS__)
 #define Com_Warnv(fmt, args) Com_Warnv_(__func__, fmt, args)
 
+/**
+ * @brief The structure used for autocomplete values.
+ */
+typedef struct {
+	/**
+	 * @brief The match itself
+	 */
+	char *name;
+
+	/**
+	 * @brief The value printed to the screen. If null, name isused.
+	 */
+	char *description;
+} com_autocomplete_match_t;
+
+com_autocomplete_match_t *Com_AllocMatch(const char *name, const char *description);
+int32_t Com_MatchCompare(const void *a, const void *b);
+
 void Com_Init(int32_t argc, char *argv[]);
 void Com_Shutdown(const char *fmt, ...) __attribute__((noreturn, format(printf, 1, 2)));
 

--- a/src/console.h
+++ b/src/console.h
@@ -191,7 +191,6 @@ typedef struct {
 	 * @brief An optional print callback.
 	 */
 	void (*Append)(const console_string_t *str);
-
 } console_t;
 
 void Con_Append(int32_t level, const char *string);

--- a/src/filesystem.c
+++ b/src/filesystem.c
@@ -22,6 +22,7 @@
 #include <physfs.h>
 
 #include "filesystem.h"
+#include "console.h"
 
 #define FS_FILE_BUFFER (1024 * 1024 * 2)
 
@@ -384,6 +385,20 @@ void Fs_Enumerate(const char *pattern, Fs_EnumerateFunc func, void *data) {
 }
 
 /**
+ * @brief OS compare, wee.
+ */
+static int32_t Fs_CompleteFile_compare(const void *a, const void *b) {
+	const com_autocomplete_match_t *ma = (const com_autocomplete_match_t *) a;
+	const com_autocomplete_match_t *mb = (const com_autocomplete_match_t *) b;
+
+#if defined(WIN32)
+	return stricmp(ma->name, mb->name);
+#else
+	return g_strcmp0(ma->name, mb->name);
+#endif
+}
+
+/**
  * @brief GHFunc for Fs_CompleteFile.
  */
 static void Fs_CompleteFile_enumerate(const char *path, void *data) {
@@ -391,10 +406,13 @@ static void Fs_CompleteFile_enumerate(const char *path, void *data) {
 	char match[MAX_OS_PATH];
 
 	StripExtension(Basename(path), match);
+	com_autocomplete_match_t temp_match = {
+		.name = match,
+		.description = NULL
+	};
 
-	if (!g_list_find_custom(*matches, match, (GCompareFunc) strcmp)) {
-		*matches = g_list_insert_sorted(*matches, Mem_CopyString(match),
-		                                (GCompareFunc) g_ascii_strcasecmp);
+	if (!g_list_find_custom(*matches, &temp_match, Fs_CompleteFile_compare)) {
+		*matches = g_list_insert_sorted(*matches, Com_AllocMatch(match, NULL), Fs_CompleteFile_compare);
 	}
 }
 
@@ -404,12 +422,6 @@ static void Fs_CompleteFile_enumerate(const char *path, void *data) {
 void Fs_CompleteFile(const char *pattern, GList **matches) {
 
 	Fs_Enumerate(pattern, Fs_CompleteFile_enumerate, (void *) matches);
-
-	GList *m = *matches;
-	while (m) {
-		Com_Print("%s\n", (char *) m->data);
-		m = m->next;
-	}
 }
 
 static void Fs_AddToSearchPath_enumerate(const char *path, void *data);

--- a/src/filesystem.c
+++ b/src/filesystem.c
@@ -22,7 +22,6 @@
 #include <physfs.h>
 
 #include "filesystem.h"
-#include "console.h"
 
 #define FS_FILE_BUFFER (1024 * 1024 * 2)
 

--- a/src/shared.c
+++ b/src/shared.c
@@ -631,36 +631,6 @@ void ColorDecompose3(const vec3_t in, u8vec3_t out) {
 }
 
 /**
- * @brief Returns the longest common prefix the specified words share.
- */
-char *CommonPrefix(GList *words) {
-	static char common_prefix[MAX_TOKEN_CHARS];
-
-	memset(common_prefix, 0, sizeof(common_prefix));
-
-	if (!words) {
-		return common_prefix;
-	}
-
-	for (size_t i = 0; i < sizeof(common_prefix) - 1; i++) {
-		GList *e = words;
-		const char c = ((char *) e->data)[i];
-		while (e) {
-			const char *w = (char *) e->data;
-
-			if (!c || tolower(w[i]) != tolower(c)) { // prefix no longer common
-				return common_prefix;
-			}
-
-			e = e->next;
-		}
-		common_prefix[i] = c;
-	}
-
-	return common_prefix;
-}
-
-/**
  * @brief Handles wildcard suffixes for GlobMatch.
  */
 static _Bool GlobMatchStar(const char *pattern, const char *text, const glob_flags_t flags) {

--- a/src/shared.h
+++ b/src/shared.h
@@ -177,7 +177,6 @@ typedef enum {
 } glob_flags_t;
 
 _Bool GlobMatch(const char *pattern, const char *text, const glob_flags_t flags);
-char *CommonPrefix(GList *words);
 const char *Basename(const char *path);
 void Dirname(const char *in, char *out);
 void StripExtension(const char *in, char *out);


### PR DESCRIPTION
- Autocompletes now have two components: "name" and "description". "name" is the keyname of the object to complete, and "description" is what can be printed to the console in the case where there is enough room for a lot of info to be displayed.
- A few helper functions to help write autocomplete functions (Com_MatchCompare and Com_AllocMatch).
- All autocomplete matches are sorted alphabetically now.
- Autocompletes now only print in the console function, instead of Com_Printing from cvar/cmd/etc. This allows autocomplete to columnize if possible. Columns only appear if there's more than 1 row (and there are no descriptions available) and more than 1 match.
- File system autocomplete compare uses stricmp on Windows and strcmp on Unix. This fixes issue of differently-cased files appearing on Windows even though Windows doesn't care.
- CommonPrefix moved to console since it was the only implementor and to use new match struct