### PR TITLE
Add rim lighting

### DIFF
--- a/src/cgame/default/cg_client.c
+++ b/src/cgame/default/cg_client.c
@@ -226,10 +226,14 @@ void Cg_LoadClient(cl_client_info_t *ci, const char *s) {
 
 			// load the models
 			if (!Cg_LoadClientModel(ci, info[1], v + 1)) {
+				cgi.Warn("Failed to load client skin %s/%s\n",
+					info[1], v + 1);
 				if (!Cg_LoadClientModel(ci, info[1], DEFAULT_CLIENT_SKIN)) {
+					cgi.Warn("Failed to load client model %s/%s\n",
+						info[1], DEFAULT_CLIENT_SKIN);
 					if (!Cg_LoadClientModel(ci, DEFAULT_CLIENT_MODEL, DEFAULT_CLIENT_SKIN)) {
-						cgi.Error("Failed to load default client model " \
-							DEFAULT_CLIENT_MODEL "/" DEFAULT_CLIENT_SKIN "\n");
+						cgi.Error("Failed to load default client skin %s/%s\n",
+							DEFAULT_CLIENT_MODEL, DEFAULT_CLIENT_SKIN);
 					}
 				}
 			}

--- a/src/cgame/default/cg_client.c
+++ b/src/cgame/default/cg_client.c
@@ -137,7 +137,7 @@ static _Bool Cg_ValidateSkin(cl_client_info_t *ci) {
  * has "default" specified.
  */
 color_t Cg_ClientEffectColor(const cl_client_info_t *cl, const color_t default_color) {
-	
+
 	if (cl->color.a) {
 		return cl->color;
 	}
@@ -226,8 +226,11 @@ void Cg_LoadClient(cl_client_info_t *ci, const char *s) {
 
 			// load the models
 			if (!Cg_LoadClientModel(ci, info[1], v + 1)) {
-				if (!Cg_LoadClientModel(ci, DEFAULT_CLIENT_MODEL, DEFAULT_CLIENT_SKIN)) {
-					cgi.Error("Failed to load default client model\n");
+				if (!Cg_LoadClientModel(ci, info[1], DEFAULT_CLIENT_SKIN)) {
+					if (!Cg_LoadClientModel(ci, DEFAULT_CLIENT_MODEL, DEFAULT_CLIENT_SKIN)) {
+						cgi.Error("Failed to load default client model " \
+							DEFAULT_CLIENT_MODEL "/" DEFAULT_CLIENT_SKIN "\n");
+					}
 				}
 			}
 		}
@@ -245,7 +248,7 @@ void Cg_LoadClient(cl_client_info_t *ci, const char *s) {
 		// load shirt/pant colors
 		color_t shirt, pants;
 		ci->shirt_color[3] = ci->pants_color[3] = 0.0;
-		
+
 		if (g_strcmp0(info[3], "default") && ColorParseHex(info[3], &shirt)) {
 			ColorToVec4(shirt, ci->shirt_color);
 			ci->shirt_color[3] = 1.0;
@@ -255,10 +258,10 @@ void Cg_LoadClient(cl_client_info_t *ci, const char *s) {
 			ColorToVec4(pants, ci->pants_color);
 			ci->pants_color[3] = 1.0;
 		}
-		
+
 		// ensure we were able to load everything
 		if (!Cg_ValidateSkin(ci)) {
-			
+
 			if (!g_strcmp0(s, DEFAULT_CLIENT_INFO)) {
 				cgi.Error("Failed to load default client info\n");
 			}

--- a/src/cgame/default/cg_entity_effect.c
+++ b/src/cgame/default/cg_entity_effect.c
@@ -79,9 +79,14 @@ void Cg_EntityEffects(cl_entity_t *ent, r_entity_t *e) {
 	if (e->effects & EF_PULSE) {
 		const vec_t pulse = (cos(cgi.client->unclamped_time * 0.0033 + ent->current.number) + 1.0);
 		const vec_t c = 1.0 - (cg_entity_pulse->value * 0.5 * pulse);
+
 		VectorSet(e->color, c, c, c);
 	} else {
 		VectorSet(e->color, 1.0, 1.0, 1.0);
+	}
+
+	if (e->effects & EF_RIM) {
+		Vector4Copy(ent->current.rim_color, e->rim_color);
 	}
 
 	if (e->effects & EF_INACTIVE) {

--- a/src/cgame/default/cg_main.c
+++ b/src/cgame/default/cg_main.c
@@ -342,7 +342,7 @@ static void Cg_ResolveTeamInfo(const char *s) {
 	cg_team_info_t *team = cg_team_info;
 
 	for (size_t i = 0; i < info_count; i += 2, team++) {
-		
+
 		g_strlcpy(team->team_name, info[i], sizeof(team->team_name));
 		team->hue = (int16_t) atoi(info[i + 1]);
 		team->color = ColorFromHSV((const vec3_t) {

--- a/src/client/renderer/r_array.c
+++ b/src/client/renderer/r_array.c
@@ -704,6 +704,8 @@ static void R_PrepareProgram() {
 	R_UseFog();
 
 	R_UseCaustic();
+
+	R_UseRim();
 }
 
 /**

--- a/src/client/renderer/r_bsp.c
+++ b/src/client/renderer/r_bsp.c
@@ -168,6 +168,8 @@ static void R_DrawBspInlineModel_(const r_entity_t *e) {
 
 	const r_sorted_bsp_surfaces_t *surfs = r_model_state.world->bsp->sorted_surfaces;
 
+	R_EnableRim(false, color_rgba_zero);
+
 	R_DrawOpaqueBspSurfaces(&surfs->opaque);
 
 	R_DrawOpaqueWarpBspSurfaces(&surfs->opaque_warp);

--- a/src/client/renderer/r_main.c
+++ b/src/client/renderer/r_main.c
@@ -69,6 +69,7 @@ cvar_t *r_monochrome;
 cvar_t *r_multisample;
 cvar_t *r_parallax;
 cvar_t *r_render_plugin;
+cvar_t *r_rim;
 cvar_t *r_saturation;
 cvar_t *r_screenshot_format;
 cvar_t *r_shadows;
@@ -511,6 +512,7 @@ static void R_InitLocal(void) {
 	                         "Controls multisampling (anti-aliasing)");
 	r_parallax = Cvar_Add("r_parallax", "1.0", CVAR_ARCHIVE,
 	                      "Controls the intensity of parallax mapping effects");
+	r_rim = Cvar_Add("r_rim", "1.0", CVAR_ARCHIVE | CVAR_R_MEDIA, "Controls rim lighting effects");
 	r_render_plugin = Cvar_Add("r_render_plugin", "default", CVAR_ARCHIVE,
 	                           "Specifies the active renderer plugin (default or pro)");
 	r_saturation = Cvar_Add("r_saturation", "1.0", CVAR_ARCHIVE | CVAR_R_MEDIA,

--- a/src/client/renderer/r_main.h
+++ b/src/client/renderer/r_main.h
@@ -48,6 +48,7 @@ extern cvar_t *r_monochrome;
 extern cvar_t *r_multisample;
 extern cvar_t *r_parallax;
 extern cvar_t *r_render_plugin;
+extern cvar_t *r_rim;
 extern cvar_t *r_saturation;
 extern cvar_t *r_screenshot_format;
 extern cvar_t *r_shadows;

--- a/src/client/renderer/r_material.c
+++ b/src/client/renderer/r_material.c
@@ -719,7 +719,7 @@ static _Bool R_ConvertMaterial(cm_material_t *cm, r_material_t **mat) {
 
 	if (material == NULL) {
 		material = (r_material_t *) R_AllocMedia(key, sizeof(r_material_t), MEDIA_MATERIAL);
-		
+
 		*mat = material;
 		material->cm = cm;
 
@@ -741,7 +741,7 @@ static _Bool R_ConvertMaterial(cm_material_t *cm, r_material_t **mat) {
 		R_RegisterMedia((r_media_t *) material);
 		return true;
 	}
-	
+
 	*mat = material;
 	Cm_FreeMaterial(cm);
 	return false;
@@ -909,7 +909,7 @@ void R_LoadMaterials(r_model_t *mod) {
 
 	for (size_t i = 0; i < num_materials; i++) {
 		r_material_t *r_mat;
-		
+
 		if (!R_ConvertMaterial(materials[i], &r_mat)) {
 			Com_Debug(DEBUG_RENDERER, "Retained material %s with %d stages\n", r_mat->diffuse->media.name, r_mat->cm->num_stages);
 			continue;
@@ -982,7 +982,7 @@ void R_LoadMaterials(r_model_t *mod) {
 					continue;
 				}
 			}
-			
+
 			// attach stage
 			R_AttachStage(r_mat, r_stage);
 

--- a/src/client/renderer/r_mesh.c
+++ b/src/client/renderer/r_mesh.c
@@ -197,6 +197,7 @@ static void R_ApplyMeshModelLighting_default(const r_entity_t *e) {
 /**
  * @brief Sets renderer state for the specified entity.
  */
+
 static void R_SetMeshState_default(const r_entity_t *e) {
 
 	// setup VBO states
@@ -224,6 +225,11 @@ static void R_SetMeshState_default(const r_entity_t *e) {
 
 			R_ApplyMeshModelLighting_default(e);
 		}
+
+		// rim effects
+		if (e->effects & EF_RIM) {
+			R_EnableRim(true, e->rim_color);
+		}
 	} else {
 		R_Color(NULL);
 
@@ -244,6 +250,10 @@ static void R_SetMeshState_default(const r_entity_t *e) {
 	// update tints
 	if (r_mesh_state.material->tintmap) {
 		R_UseTints();
+	}
+
+	if (!(e->effects & EF_RIM)) {
+		R_EnableRim(false, color_rgba_zero);
 	}
 }
 
@@ -270,6 +280,8 @@ static void R_ResetMeshState_default(const r_entity_t *e) {
 	R_ResetArrayState();
 
 	R_UseInterpolation(0.0);
+
+	R_EnableRim(false, color_rgba_zero);
 }
 
 /**
@@ -302,7 +314,7 @@ static void R_DrawMeshParts_default(const r_entity_t *e, const r_md3_t *md3) {
 			offset += mesh->num_elements;
 			continue;
 		}
-		
+
 		R_DrawArrays(GL_TRIANGLES, offset, mesh->num_elements);
 
 		offset += mesh->num_elements;

--- a/src/client/renderer/r_program.c
+++ b/src/client/renderer/r_program.c
@@ -151,7 +151,7 @@ void R_ProgramParameter3fv(r_uniform3fv_t *variable, const GLfloat *value) {
 void R_ProgramParameter4fv(r_uniform4fv_t *variable, const GLfloat *value) {
 
 	assert(variable && variable->location != -1);
-	
+
 	if (Vector4Compare(variable->value.vec4, value)) {
 		return;
 	}
@@ -710,6 +710,7 @@ void R_InitPrograms(void) {
 		program_default->UseFog = R_UseFog_default;
 		program_default->UseLight = R_UseLight_default;
 		program_default->UseCaustic = R_UseCaustic_default;
+		program_default->UseRim = R_UseRim_default;
 		program_default->MatricesChanged = R_MatricesChanged_default;
 		program_default->UseAlphaTest = R_UseAlphaTest_default;
 		program_default->UseInterpolation = R_UseInterpolation_default;

--- a/src/client/renderer/r_program.h
+++ b/src/client/renderer/r_program.h
@@ -92,7 +92,18 @@ typedef struct {
 	r_variable_t color;
 } r_uniform_caustic_t;
 
-#define MAX_PROGRAM_VARIABLES 32
+// rim lighting info
+typedef struct {
+	_Bool enable;
+	vec4_t color;
+} r_rim_parameters_t;
+
+typedef struct {
+	r_variable_t enable;
+	r_variable_t color;
+} r_uniform_rim_t;
+
+#define MAX_PROGRAM_VARIABLES 64
 
 // and glsl programs
 typedef struct {
@@ -115,6 +126,7 @@ typedef struct {
 	void (*UseFog)(const r_fog_parameters_t *fog);
 	void (*UseLight)(const uint16_t light_index, const r_light_t *light);
 	void (*UseCaustic)(const r_caustic_parameters_t *caustic);
+	void (*UseRim)(const r_rim_parameters_t *pulse);
 	void (*MatricesChanged)();
 	void (*UseAlphaTest)(const vec_t threshold);
 	void (*UseCurrentColor)(const vec4_t color);

--- a/src/client/renderer/r_program_default.c
+++ b/src/client/renderer/r_program_default.c
@@ -54,6 +54,8 @@ typedef struct {
 
 	r_uniform_caustic_t caustic;
 
+	r_uniform_rim_t rim;
+
 	r_uniform_matrix4fv_t normal_mat;
 
 	r_uniform1f_t alpha_threshold;
@@ -143,6 +145,9 @@ void R_InitProgram_default(r_program_t *program) {
 	R_ProgramVariable(&p->caustic.enable, R_UNIFORM_INT, "CAUSTIC.ENABLE", true);
 	R_ProgramVariable(&p->caustic.color, R_UNIFORM_VEC3, "CAUSTIC.COLOR", true);
 
+	R_ProgramVariable(&p->rim.enable, R_UNIFORM_INT, "RIM.ENABLE", true);
+	R_ProgramVariable(&p->rim.color, R_UNIFORM_VEC4, "RIM.COLOR", true);
+
 	R_ProgramVariable(&p->normal_mat, R_UNIFORM_MAT4, "NORMAL_MAT", true);
 
 	R_ProgramVariable(&p->alpha_threshold, R_UNIFORM_FLOAT, "ALPHA_THRESHOLD", true);
@@ -174,6 +179,8 @@ void R_InitProgram_default(r_program_t *program) {
 
 	R_ProgramParameter1i(&p->caustic.enable, 0);
 
+	R_ProgramParameter1i(&p->rim.enable, 0);
+
 	R_ProgramParameter1f(&p->time_fraction, 0.0f);
 	R_ProgramParameter1f(&p->time, 0.0f);
 }
@@ -199,6 +206,8 @@ void R_UseProgram_default(void) {
 	R_ProgramParameter1i(&p->diffuse, texunit_diffuse->enabled);
 	R_ProgramParameter1i(&p->deluxemap, texunit_deluxemap->enabled);
 	R_ProgramParameter1i(&p->lightmap, texunit_lightmap->enabled);
+
+	R_ProgramParameter1f(&p->time, r_view.ticks / 1000.0);
 }
 
 /**
@@ -230,7 +239,7 @@ void R_UseMaterial_default(const r_material_t *material) {
 		R_ProgramParameter1f(&p->hardness, material->cm->hardness * r_hardness->value);
 		R_ProgramParameter1f(&p->specular, material->cm->specular * r_specular->value);
 	}
-	
+
 	if (material && material->tintmap) {
 		R_BindTintTexture(material->tintmap->texnum);
 		R_ProgramParameter1i(&p->tintmap, 1);
@@ -284,10 +293,23 @@ void R_UseCaustic_default(const r_caustic_parameters_t *caustic) {
 		R_ProgramParameter1i(&p->caustic.enable, caustic->enable);
 
 		R_ProgramParameter3fv(&p->caustic.color, caustic->color);
-
-		R_ProgramParameter1f(&p->time, r_view.ticks / 1000.0);
 	} else {
 		R_ProgramParameter1i(&p->caustic.enable, 0);
+	}
+}
+
+/**
+ * @brief
+ */
+void R_UseRim_default(const r_rim_parameters_t *rim) {
+	r_default_program_t *p = &r_default_program;
+
+	if (rim && rim->enable) {
+		R_ProgramParameter1i(&p->rim.enable, rim->enable);
+
+		R_ProgramParameter4fv(&p->rim.color, rim->color);
+	} else {
+		R_ProgramParameter1i(&p->rim.enable, 0);
 	}
 }
 

--- a/src/client/renderer/r_program_default.h
+++ b/src/client/renderer/r_program_default.h
@@ -32,6 +32,7 @@ void R_UseMaterial_default(const r_material_t *material);
 void R_UseFog_default(const r_fog_parameters_t *value);
 void R_UseLight_default(const uint16_t light_index, const r_light_t *lights);
 void R_UseCaustic_default(const r_caustic_parameters_t *value);
+void R_UseRim_default(const r_rim_parameters_t *rim);
 void R_MatricesChanged_default(void);
 void R_UseAlphaTest_default(const vec_t threshold);
 void R_UseInterpolation_default(const vec_t time_fraction);

--- a/src/client/renderer/r_state.h
+++ b/src/client/renderer/r_state.h
@@ -92,7 +92,7 @@ typedef struct r_state_s {
 	GLenum blend_src, blend_dest; // blend function
 	_Bool blend_enabled;
 
-	float alpha_threshold;
+	vec_t alpha_threshold;
 	vec4_t current_color;
 
 	r_texunit_t texunits[R_TEXUNIT_TOTAL];
@@ -112,6 +112,9 @@ typedef struct r_state_s {
 
 	// caustic state
 	r_caustic_parameters_t active_caustic_parameters;
+
+	// rim state
+	r_rim_parameters_t active_rim_parameters;
 
 	// stencil state
 	GLenum stencil_op_pass;
@@ -205,6 +208,7 @@ void R_EnableWarp(const r_program_t *program, _Bool enable);
 void R_EnableShell(const r_program_t *program, _Bool enable);
 void R_EnableFog(_Bool enable);
 void R_EnableCaustic(_Bool enable);
+void R_EnableRim(_Bool enable, const vec4_t color);
 void R_UseMaterial(const r_material_t *material);
 void R_UseMatrices(void);
 void R_UseInterpolation(const vec_t lerp);
@@ -212,6 +216,7 @@ void R_UseAlphaTest(void);
 void R_UseCurrentColor(void);
 void R_UseFog(void);
 void R_UseCaustic(void);
+void R_UseRim(void);
 void R_UseTints(void);
 void R_InitState(void);
 void R_ShutdownState(void);

--- a/src/client/renderer/r_types.h
+++ b/src/client/renderer/r_types.h
@@ -76,7 +76,7 @@ typedef enum {
  * @brief Don't return the null white picture if we can't find the image, return
  * null instead.
  */
-#define IT_MASK_FAIL	512 
+#define IT_MASK_FAIL	512
 
 #define IT_MASK_TYPE	0x7F
 #define IT_MASK_FLAGS	(-1 & ~IT_MASK_TYPE)
@@ -916,6 +916,7 @@ typedef struct r_entity_s {
 	uint32_t effects; // e.g. EF_NO_DRAW, EF_WEAPON, ..
 
 	vec4_t color; // shaded color, e.g. EF_PULSE
+	vec4_t rim_color; // rim lighting color; an example is team color for players
 
 	vec3_t shell; // shell color
 

--- a/src/client/renderer/shaders/default_fs.glsl
+++ b/src/client/renderer/shaders/default_fs.glsl
@@ -185,7 +185,7 @@ void RimFragment(void) {
 	if (RIM.ENABLE) {
 		float rim = 1.0 - dot(normal, -normalize(point));
 
-		fragColor.rgb = mix(fragColor.rgb, RIM.COLOR.rgb, (rim * rim) * RIM.COLOR.a);
+		fragColor.rgb = mix(fragColor.rgb, RIM.COLOR.rgb, (rim * rim * rim) * RIM.COLOR.a);
 	}
 }
 

--- a/src/client/renderer/shaders/default_fs.glsl
+++ b/src/client/renderer/shaders/default_fs.glsl
@@ -36,6 +36,7 @@ uniform LightParameters LIGHTS;
 // RGB layer tints
 uniform vec4 TINTS[3];
 
+// what color caustics are
 struct CausticParameters
 {
 	bool ENABLE;
@@ -44,6 +45,16 @@ struct CausticParameters
 
 uniform CausticParameters CAUSTIC;
 
+// what rim lighting effects look like
+struct RimParameters
+{
+	bool ENABLE;
+	vec4 COLOR;
+};
+
+uniform RimParameters RIM;
+
+// light/color toggles
 uniform bool DIFFUSE;
 uniform bool LIGHTMAP;
 uniform bool DELUXEMAP;
@@ -51,6 +62,7 @@ uniform bool NORMALMAP;
 uniform bool GLOSSMAP;
 uniform bool TINTMAP;
 
+// surface properties
 uniform float BUMP;
 uniform float PARALLAX;
 uniform float HARDNESS;
@@ -65,7 +77,10 @@ uniform sampler2D SAMPLER6;
 
 uniform float ALPHA_THRESHOLD;
 
+// time from 0 to 1 each second
 uniform float TIME_FRACTION;
+
+// elapsed time since program start, in seconds
 uniform float TIME;
 
 in vec3 modelpoint;
@@ -164,6 +179,17 @@ void CausticFragment(in vec3 lightmap) {
 }
 
 /**
+ * @brief Render "glowing" rim lighting effects
+ */
+void RimFragment(void) {
+	if (RIM.ENABLE) {
+		float rim = 1.0 - dot(normal, -normalize(point));
+
+		fragColor.rgb = mix(fragColor.rgb, RIM.COLOR.rgb, (rim * rim) * RIM.COLOR.a);
+	}
+}
+
+/**
  * @brief Apply fog to the fragment if enabled.
  */
 void FogFragment(void) {
@@ -247,8 +273,12 @@ void main(void) {
 	// add any dynamic lighting to yield the final fragment color
 	LightFragment(diffuse, lightmap, normalmap.xyz);
 
-    // underliquid caustics
+	// underliquid caustics
 	CausticFragment(lightmap);
 
-	FogFragment(); // and lastly add fog
+	// add pulse effects
+	RimFragment();
+
+	// and lastly add fog
+	FogFragment();
 }

--- a/src/game/default/g_client.c
+++ b/src/game/default/g_client.c
@@ -97,7 +97,7 @@ static void G_ClientObituary(g_entity_t *self, g_entity_t *attacker, uint32_t mo
 				msg = "%s had their intestines shredded by %s's grappling hook";
 				break;
 		}
-		
+
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wformat-nonliteral"
 		g_snprintf(buffer, sizeof(buffer), msg, self->client->locals.persistent.net_name,
@@ -164,7 +164,7 @@ static void G_ClientObituary(g_entity_t *self, g_entity_t *attacker, uint32_t mo
 					break;
 			}
 		}
-		
+
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wformat-nonliteral"
 		g_snprintf(buffer, sizeof(buffer), msg, self->client->locals.persistent.net_name);
@@ -307,7 +307,7 @@ static void G_ClientCorpse_Die(g_entity_t *self, g_entity_t *attacker,
 
 	for (i = 0; i < count; i++) {
 		int32_t gib_index;
-		
+
 		if (i == 0) { // 0 is always chest
 			gib_index = (NUM_GIB_MODELS - 1);
 		} else if (i == 1 && !self->client) { // if we're not client, drop a head
@@ -792,7 +792,7 @@ static g_entity_t *G_SelectDeathmatchSpawnPoint(g_entity_t *ent) {
 	if (g_spawn_farthest->value) {
 		return G_SelectFarthestSpawnPoint(ent, &g_level.spawn_points);
 	}
-	
+
 	return G_SelectRandomSpawnPoint(&g_level.spawn_points);
 }
 
@@ -898,6 +898,10 @@ static void G_ClientRespawn_(g_entity_t *ent) {
 		ent->client->locals.persistent.ready = false;
 	} else { // spawn an active client
 		ent->class_name = "client";
+
+// testing rim lighting; i'll keep this for future reference
+//		ent->s.effects = EF_RIM;
+//		Vector4Set(ent->s.rim_color, 1.0, 0.0, 0.0, 1.0);
 
 		ent->solid = SOLID_BOX;
 		ent->sv_flags = 0;
@@ -1183,7 +1187,7 @@ void G_ClientUserInfoChanged(g_entity_t *ent, const char *user_info) {
 	} else {
 		g_strlcpy(cl->locals.persistent.shirt_color, "default", sizeof(cl->locals.persistent.shirt_color));
 		g_strlcpy(cl->locals.persistent.pants_color, "default", sizeof(cl->locals.persistent.pants_color));
-		
+
 		s = GetUserInfo(user_info, "shirt");
 
 		if (strlen(s) && strcmp(s, "default")) { // not default

--- a/src/game/default/g_item.c
+++ b/src/game/default/g_item.c
@@ -547,7 +547,7 @@ static _Bool G_PickupFlag(g_entity_t *ent, g_entity_t *other) {
 
 				return false;
 			}
-		}	
+		}
 
 		// touching our own flag for no particular reason
 		return false;
@@ -937,7 +937,7 @@ static _Bool G_PickupTech(g_entity_t *ent, g_entity_t *other) {
  * @brief
  */
 const g_item_t *G_CarryingTech(const g_entity_t *ent) {
-	
+
 	for (g_tech_t i = TECH_HASTE; i < TECH_TOTAL; i++) {
 
 		if (G_HasTech(ent, i)) {
@@ -1037,7 +1037,7 @@ static void G_ItemDropToFloor(g_entity_t *ent) {
 		// try thinner box
 		gi.Debug("%s in too small of a spot for large box, correcting..\n", etos(ent));
 		ent->maxs[2] /= 2.0;
-		
+
 		tr = gi.Trace(ent->s.origin, dest, ent->mins, ent->maxs, ent, MASK_SOLID);
 		if (tr.start_solid) {
 
@@ -1053,7 +1053,7 @@ static void G_ItemDropToFloor(g_entity_t *ent) {
 			if (tr.start_solid) {
 
 				gi.Debug("%s trying higher, last attempt..\n", etos(ent));
-				
+
 				ent->s.origin[2] += 8.0;
 
 				// make an effort to come up out of the floor (broken maps)
@@ -1097,7 +1097,7 @@ void G_PrecacheItem(const g_item_t *it) {
 	// parse everything for its ammo
 	if (it->ammo) {
 		const g_item_t *ammo = it->ammo_item;
-		
+
 		if (ammo != it) {
 			G_PrecacheItem(ammo);
 		}
@@ -1164,6 +1164,10 @@ void G_SpawnItem(g_entity_t *ent, const g_item_t *item) {
 	}
 
 	ent->s.effects = item->effects;
+
+	// rim lighting
+	ent->s.effects |= EF_RIM;
+	Vector4Set(ent->s.rim_color, 1.0, 1.0, 1.0, 0.5);
 
 	// weapons override the health field to store their ammo count
 	if (ent->locals.item->type == ITEM_WEAPON) {
@@ -2405,7 +2409,7 @@ static void G_InitWeapons(void) {
 		}
 
 		const g_item_t *weapon = g_media.items.weapons[t];
-		
+
 		strcat(weapon_info, va("%i\\%i", weapon->icon_index, weapon->index));
 	}
 
@@ -2448,7 +2452,7 @@ void G_InitItems(void) {
 
 		// set up media pointers
 		const g_item_t **array = NULL;
-		
+
 		switch (item->type) {
 		default:
 			gi.Error("Item %s has an invalid type\n", item->name);
@@ -2474,7 +2478,7 @@ void G_InitItems(void) {
 			array = g_media.items.techs;
 			break;
 		}
-		
+
 		if (array[item->tag]) {
 			gi.Error("Item %s has the same tag as %s\n", item->name, array[item->tag]->name);
 		}

--- a/src/game/default/g_types.h
+++ b/src/game/default/g_types.h
@@ -27,7 +27,7 @@
  * @brief Game protocol version (protocol minor version). To be incremented
  * whenever the game protocol changes.
  */
-#define PROTOCOL_MINOR 1017
+#define PROTOCOL_MINOR 1018
 
 /**
  * @brief Game-specific server protocol commands. These are parsed directly by
@@ -1147,8 +1147,11 @@ typedef struct {
 
 	uint32_t touch_time;
 	uint32_t push_time;
+
 	uint32_t ripple_time;
 	vec_t ripple_size;
+
+	vec4_t rim_color;
 
 	int16_t health;
 	int16_t max_health;

--- a/src/net/net_message.c
+++ b/src/net/net_message.c
@@ -128,6 +128,16 @@ void Net_WriteAngles(mem_buf_t *msg, const vec3_t angles) {
 /**
  * @brief
  */
+void Net_WriteColor(mem_buf_t *msg, const vec4_t color) {
+	Net_WriteAngle(msg, color[0]);
+	Net_WriteAngle(msg, color[1]);
+	Net_WriteAngle(msg, color[2]);
+	Net_WriteAngle(msg, color[3]);
+}
+
+/**
+ * @brief
+ */
 void Net_WriteDir(mem_buf_t *msg, const vec3_t dir) {
 	int32_t i, best = 0;
 	vec_t best_d = 0.0;
@@ -352,6 +362,10 @@ void Net_WriteDeltaEntity(mem_buf_t *msg, const entity_state_t *from, const enti
 		bits |= U_ANGLES;
 	}
 
+	if (!Vector4Compare(to->rim_color, from->rim_color)) {
+		bits |= U_RIM_COLOR;
+	}
+
 	if (to->animation1 != from->animation1 || to->animation2 != from->animation2) {
 		bits |= U_ANIMATIONS;
 	}
@@ -408,6 +422,10 @@ void Net_WriteDeltaEntity(mem_buf_t *msg, const entity_state_t *from, const enti
 
 	if (bits & U_ANGLES) {
 		Net_WriteAngles(msg, to->angles);
+	}
+
+	if (bits & U_RIM_COLOR) {
+		Net_WriteColor(msg, to->rim_color);
 	}
 
 	if (bits & U_ANIMATIONS) {
@@ -617,6 +635,16 @@ void Net_ReadAngles(mem_buf_t *msg, vec3_t angles) {
 /**
  * @brief
  */
+void Net_ReadColor(mem_buf_t *msg, vec4_t color) {
+	color[0] = Net_ReadAngle(msg);
+	color[1] = Net_ReadAngle(msg);
+	color[2] = Net_ReadAngle(msg);
+	color[3] = Net_ReadAngle(msg);
+}
+
+/**
+ * @brief
+ */
 void Net_ReadDir(mem_buf_t *msg, vec3_t dir) {
 
 	const int32_t b = Net_ReadByte(msg);
@@ -752,6 +780,10 @@ void Net_ReadDeltaEntity(mem_buf_t *msg, const entity_state_t *from, entity_stat
 
 	if (bits & U_ANGLES) {
 		Net_ReadAngles(msg, to->angles);
+	}
+
+	if (bits & U_RIM_COLOR) {
+		Net_ReadColor(msg, to->rim_color);
 	}
 
 	if (bits & U_ANIMATIONS) {

--- a/src/net/net_message.h
+++ b/src/net/net_message.h
@@ -54,18 +54,19 @@
  * written or read for delta compression from one snapshot to the next.
  */
 #define U_ORIGIN				(1 << 0) // origin
-#define U_TERMINATION			(1 << 1) // beams
+#define U_TERMINATION                           (1 << 1) // beams
 #define U_ANGLES				(1 << 2) // angles
-#define U_ANIMATIONS			(1 << 3) // animation frames
-#define U_EVENT					(1 << 4) // single-frame events
-#define U_EFFECTS				(1 << 5) // bit masked effects
-#define U_TRAIL					(1 << 6) // enumerated trails
-#define U_MODELS				(1 << 7) // models (primary and linked)
-#define U_CLIENT				(1 << 8) // offset into client skins array
-#define U_SOUND					(1 << 9) // looped sounds
-#define U_SOLID					(1 << 10) // solid type
-#define U_BOUNDS				(1 << 11) // encoded bounding box
-#define U_REMOVE				(1 << 12) // remove this entity, don't add it
+#define U_RIM_COLOR				(1 << 3) // rim color
+#define U_ANIMATIONS                            (1 << 4) // animation frames
+#define U_EVENT					(1 << 5) // single-frame events
+#define U_EFFECTS				(1 << 6) // bit masked effects
+#define U_TRAIL					(1 << 7) // enumerated trails
+#define U_MODELS				(1 << 8) // models (primary and linked)
+#define U_CLIENT				(1 << 9) // offset into client skins array
+#define U_SOUND					(1 << 10) // looped sounds
+#define U_SOLID					(1 << 11) // solid type
+#define U_BOUNDS				(1 << 12) // encoded bounding box
+#define U_REMOVE				(1 << 13) // remove this entity, don't add it
 
 /**
  * @brief These flags indicate which fields a given sound packet will contain.
@@ -87,6 +88,7 @@ void Net_WriteVector(mem_buf_t *msg, const vec_t f);
 void Net_WritePosition(mem_buf_t *msg, const vec3_t pos);
 void Net_WriteAngle(mem_buf_t *msg, const vec_t f);
 void Net_WriteAngles(mem_buf_t *msg, const vec3_t angles);
+void Net_WriteColor(mem_buf_t *msg, const vec4_t color);
 void Net_WriteDir(mem_buf_t *msg, const vec3_t dir);
 void Net_WriteDeltaMoveCmd(mem_buf_t *msg, const pm_cmd_t *from, const pm_cmd_t *to);
 void Net_WriteDeltaPlayerState(mem_buf_t *msg, const player_state_t *from, const player_state_t *to);
@@ -104,6 +106,7 @@ vec_t Net_ReadVector(mem_buf_t *msg);
 void Net_ReadPosition(mem_buf_t *msg, vec3_t pos);
 vec_t Net_ReadAngle(mem_buf_t *msg);
 void Net_ReadAngles(mem_buf_t *msg, vec3_t angles);
+void Net_ReadColor(mem_buf_t *msg, vec4_t color);
 void Net_ReadDir(mem_buf_t *msg, vec3_t vector);
 void Net_ReadDeltaMoveCmd(mem_buf_t *msg, const pm_cmd_t *from, pm_cmd_t *to);
 void Net_ReadDeltaPlayerState(mem_buf_t *msg, const player_state_t *from, player_state_t *to);

--- a/src/quetoo.h
+++ b/src/quetoo.h
@@ -530,12 +530,12 @@ typedef enum {
 	ANIM_LEGS_IDLECR,
 
 	ANIM_LEGS_TURN,
-	
+
 	/**
 	 * @brief Masks out the bits and only keeps the animation value
 	 */
 	ANIM_MASK_VALUE = (1 << 6) - 1,
-	
+
 	/**
 	 * @brief Play the animation backwards.
 	 */
@@ -573,8 +573,9 @@ typedef enum {
 #define EF_ROTATE			(1 << 0) // rotate on z
 #define EF_BOB				(1 << 1) // bob on z
 #define EF_PULSE			(1 << 2) // pulsing light effect
-#define EF_INACTIVE			(1 << 3) // inactive icon for when input is not going to game
-#define EF_GAME				(1 << 4) // the game may extend from here
+#define EF_RIM				(1 << 3) // rim lighting effect
+#define EF_INACTIVE			(1 << 4) // inactive icon for when input is not going to game
+#define EF_GAME				(1 << 5) // the game may extend from here
 
 /**
  * @brief The 16 high bits of the effects mask are not transmitted by the
@@ -584,10 +585,10 @@ typedef enum {
 #define EF_CLIENT			(1 << 24) // player model
 #define EF_WEAPON			(1 << 25) // view weapon
 #define EF_SHELL			(1 << 26) // environment map shell
-#define EF_ALPHATEST		(1 << 27) // alpha test
+#define EF_ALPHATEST			(1 << 27) // alpha test
 #define EF_BLEND			(1 << 28) // alpha blend
-#define EF_NO_LIGHTING		(1 << 29) // no lighting (full bright)
-#define EF_NO_SHADOW		(1 << 30) // no shadow
+#define EF_NO_LIGHTING			(1 << 29) // no lighting (full bright)
+#define EF_NO_SHADOW			(1 << 30) // no shadow
 #define EF_NO_DRAW			(1u << 31) // no draw (but perhaps shadow)
 
 /**
@@ -632,6 +633,8 @@ typedef struct {
 	uint8_t model1, model2, model3, model4; // primary model, linked models
 	uint8_t client; // client info index
 	uint8_t sound; // looped sounds
+
+	vec4_t rim_color; //  color of rim lighting for EF_RIM
 
 	/**
 	 * @brief The solid type. All solid types are sent to the client, but the

--- a/src/shared.c
+++ b/src/shared.c
@@ -23,6 +23,8 @@
 
 #include "shared.h"
 
+// vector constants
+
 const vec3_t vec3_origin = { 0.0, 0.0, 0.0 };
 
 const vec3_t vec3_up = { 0.0, 0.0, 1.0 };
@@ -30,6 +32,16 @@ const vec3_t vec3_up = { 0.0, 0.0, 1.0 };
 const vec3_t vec3_down = { 0.0, 0.0, -1.0 };
 
 const vec3_t vec3_forward = { 0.0, 1.0, 0.0 };
+
+// color constants
+
+const vec3_t color_rgb_one = { 1.0, 1.0, 1.0 };
+
+const vec3_t color_rgb_zero = { 0.0, 0.0, 0.0 };
+
+const vec4_t color_rgba_one = { 1.0, 1.0, 1.0, 1.0 };
+
+const vec4_t color_rgba_zero = { 0.0, 0.0, 0.0, 0.0 };
 
 /**
  * @brief Returns a pseudo-random positive integer.
@@ -1161,7 +1173,7 @@ static _Bool ParseHexString(const char *input, color_t *output, const uint8_t nu
 			if (!((l >= 'a' && l <= 'f') || (l >= '0' && l <= '9'))) {
 				return false;
 			}
-			
+
 			const uint8_t dec = HEX_TO_DEC(l);
 
 			if (d == 0) {
@@ -1181,7 +1193,7 @@ static _Bool ParseHexString(const char *input, color_t *output, const uint8_t nu
 _Bool ColorParseHex(const char *s, color_t *color) {
 	const size_t s_len = strlen(s);
 	static color_t temp;
-	
+
 	if (!color) {
 		color = &temp;
 	}
@@ -1238,7 +1250,7 @@ _Bool ColorParseHex(const char *s, color_t *color) {
  * @brief Attempt to convert a color to a hexadecimal string representation.
  */
 _Bool ColorToHex(const color_t color, char *s, const size_t s_len) {
-	
+
 	_Bool is_short_form = COLOR_BYTES_ARE_SAME(color.r) &&
 						  COLOR_BYTES_ARE_SAME(color.g) &&
 						  COLOR_BYTES_ARE_SAME(color.b);
@@ -1246,7 +1258,7 @@ _Bool ColorToHex(const color_t color, char *s, const size_t s_len) {
 
 	if (is_32_bit) {
 		is_short_form = is_short_form && COLOR_BYTES_ARE_SAME(color.a);
-	
+
 		if (is_short_form) {
 			if (g_strlcat(s, va("%1x%1x%1x%1x", color.r & 15, color.g & 15, color.b & 15, color.a & 15), s_len) >= s_len) {
 				return false;

--- a/src/shared.h
+++ b/src/shared.h
@@ -44,6 +44,26 @@ extern const vec3_t vec3_down;
 extern const vec3_t vec3_forward;
 
 /**
+ * @brief RGB full one color (1, 1, 1).
+ */
+extern const vec3_t color_rgb_one;
+
+/**
+ * @brief RGB full zero color (0, 0, 0).
+ */
+extern const vec3_t color_rgb_zero;
+
+/**
+ * @brief RGBA full one color (1, 1, 1).
+ */
+extern const vec4_t color_rgba_one;
+
+/**
+ * @brief RGBA full zero color (0, 0, 0, 0).
+ */
+extern const vec4_t color_rgba_zero;
+
+/**
  * @brief Math library.
  */
 /**


### PR DESCRIPTION
Adds rim lighting as an effect (`g_entity_t->s.effects & EF_RIM` and `g_entity_t->s.rim_color[vec4]`), can be configured in game or cgame fairly easily, this is also a shader effect meaning it can be tuned very easily.
The CVar `r_rim` toggles this effect.