### PR TITLE
#428 material resolution

### DIFF
--- a/Quetoo.xcodeproj/project.pbxproj
+++ b/Quetoo.xcodeproj/project.pbxproj
@@ -1398,6 +1398,7 @@
 		CE68F9A41E5E8E8400AC9AAE /* r_program_stain.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = r_program_stain.h; sourceTree = "<group>"; };
 		CE6C2D0F1E24902900F55B0A /* cm_bsp.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = cm_bsp.c; sourceTree = "<group>"; };
 		CE6C2D101E24902900F55B0A /* cm_bsp.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = cm_bsp.h; sourceTree = "<group>"; };
+		CE6FF29C1E9E6FBA00F3C160 /* qzip.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = qzip.h; sourceTree = "<group>"; };
 		CE72D8A91D404ACA002129FC /* libObjectivelyMVC.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libObjectivelyMVC.dylib; path = ../ObjectivelyMVC/build/Debug/libObjectivelyMVC.dylib; sourceTree = "<group>"; };
 		CE8000051C5E4F0500A21A51 /* libxml2.2.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libxml2.2.dylib; path = /opt/local/lib/libxml2.2.dylib; sourceTree = "<absolute>"; };
 		CE8000071C5E52A200A21A51 /* libz.1.2.8.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libz.1.2.8.dylib; path = /opt/local/lib/libz.1.2.8.dylib; sourceTree = "<absolute>"; };
@@ -2612,6 +2613,7 @@
 				CE12D7001C5C58C300CD0B13 /* qvis.c */,
 				CE12D7011C5C58C300CD0B13 /* qvis.h */,
 				CE12D7021C5C58C300CD0B13 /* qzip.c */,
+				CE6FF29C1E9E6FBA00F3C160 /* qzip.h */,
 				CE12D7031C5C58C300CD0B13 /* scriptlib.c */,
 				CE12D7041C5C58C300CD0B13 /* scriptlib.h */,
 				CE12D7051C5C58C300CD0B13 /* textures.c */,

--- a/Quetoo.xcodeproj/xcshareddata/xcschemes/quetoo.xcscheme
+++ b/Quetoo.xcodeproj/xcshareddata/xcschemes/quetoo.xcscheme
@@ -71,7 +71,7 @@
             isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
-            argument = "+map torn"
+            argument = "+map fragpipe"
             isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument

--- a/Quetoo.xcodeproj/xcshareddata/xcschemes/quetoo.xcscheme
+++ b/Quetoo.xcodeproj/xcshareddata/xcschemes/quetoo.xcscheme
@@ -67,6 +67,10 @@
             isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
+            argument = "+debug collision"
+            isEnabled = "YES">
+         </CommandLineArgument>
+         <CommandLineArgument
             argument = "+map torn"
             isEnabled = "YES">
          </CommandLineArgument>
@@ -76,10 +80,6 @@
          </CommandLineArgument>
          <CommandLineArgument
             argument = "+set net_loop_latency 300 +set net_loop_jitter 150"
-            isEnabled = "NO">
-         </CommandLineArgument>
-         <CommandLineArgument
-            argument = "+debug cgame"
             isEnabled = "NO">
          </CommandLineArgument>
       </CommandLineArguments>

--- a/Quetoo.xcodeproj/xcshareddata/xcschemes/quetoo.xcscheme
+++ b/Quetoo.xcodeproj/xcshareddata/xcschemes/quetoo.xcscheme
@@ -67,7 +67,7 @@
             isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
-            argument = "+map edge"
+            argument = "+map torn"
             isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument

--- a/Quetoo.xcodeproj/xcshareddata/xcschemes/quetoo.xcscheme
+++ b/Quetoo.xcodeproj/xcshareddata/xcschemes/quetoo.xcscheme
@@ -68,7 +68,7 @@
          </CommandLineArgument>
          <CommandLineArgument
             argument = "+debug collision"
-            isEnabled = "YES">
+            isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
             argument = "+map torn"

--- a/src/cgame/cgame.h
+++ b/src/cgame/cgame.h
@@ -576,6 +576,15 @@ typedef struct cg_import_s {
 	r_material_t *(*LoadMaterial)(const char *name, cm_asset_context_t context);
 
 	/**
+	 * @brief Loads all materials defined in the given file.
+	 * @param path The materials file path, e.g. `"materials/torn.mat"`.
+	 * @param context The asset context, e.g. `ASSET_CONTEXT_TEXTURES`.
+	 * @param materials The list of materials to prepend.
+	 * @return The number of materials loaded.
+	 */
+	ssize_t (*LoadMaterials)(const char *path, cm_asset_context_t context, GList **materials);
+
+	/**
 	 * @brief Loads the model with the given name.
 	 * @param name The model name (e.g. `"models/objects/rocket/tris"`).
 	 * @return The model.

--- a/src/cgame/cgame.h
+++ b/src/cgame/cgame.h
@@ -412,11 +412,6 @@ typedef struct cg_import_s {
 	const char *(*EntityString)(void);
 
 	/**
-	 * @return The materials for the currently loaded level.
-	 */
-	const cm_material_t **(*MapMaterials)(size_t *num_materials);
-
-	/**
 	 * @defgroup collision Collision model
 	 * @{
 	 */

--- a/src/cgame/cgame.h
+++ b/src/cgame/cgame.h
@@ -573,11 +573,12 @@ typedef struct cg_import_s {
 	void (*CompileAtlas)(r_atlas_t *atlas);
 
 	/**
-	 * @brief Loads the material with the given diffuse texture name.
-	 * @param name The diffuse texture name, e.g. `"models/objects/rocket/skin"`.
+	 * @brief Loads the material with the given name.
+	 * @param name The material name, e.g. `"objects/rocket/skin"`.
+	 * @param context The asset context, e.g. `ASSET_CONTEXT_PLAYERS`.
 	 * @return The material.
 	 */
-	r_material_t *(*LoadMaterial)(const char *diffuse);
+	r_material_t *(*LoadMaterial)(const char *name, cm_asset_context_t context);
 
 	/**
 	 * @brief Loads the model with the given name.

--- a/src/cgame/default/cg_client.c
+++ b/src/cgame/default/cg_client.c
@@ -53,7 +53,7 @@ static void Cg_LoadClientSkin(r_material_t **skins, const r_md3_t *md3, char *li
 	for (i = 0; i < md3->num_meshes; i++, mesh++) {
 
 		if (!g_ascii_strcasecmp(mesh_name, mesh->name)) {
-			skins[i] = cgi.LoadMaterial(skin_name);
+			skins[i] = cgi.LoadMaterial(skin_name, ASSET_CONTEXT_PLAYERS);
 			break;
 		}
 	}
@@ -92,7 +92,7 @@ static _Bool Cg_LoadClientSkins(const r_model_t *mod, r_material_t **skins, cons
 
 		if (c == '\n' || c == '\r' || i == len) {
 
-			Cg_LoadClientSkin(skins, md3, line);
+			Cg_LoadClientSkin(skins, md3, g_strstrip(line));
 
 			j = 0;
 			memset(line, 0, sizeof(line));

--- a/src/cgame/default/cg_media.c
+++ b/src/cgame/default/cg_media.c
@@ -154,9 +154,9 @@ static void Cg_InitFootsteps(void) {
 
 	default_samples = g_array_append_vals(default_samples, (const s_sample_t *[]) {
 		cgi.LoadSample("#players/common/step_1"),
-		               cgi.LoadSample("#players/common/step_2"),
-		               cgi.LoadSample("#players/common/step_3"),
-		               cgi.LoadSample("#players/common/step_4")
+		cgi.LoadSample("#players/common/step_2"),
+		cgi.LoadSample("#players/common/step_3"),
+		cgi.LoadSample("#players/common/step_4")
 	}, 4);
 
 	g_hash_table_insert(cg_footstep_table, "default", default_samples);

--- a/src/cgame/default/cg_media.c
+++ b/src/cgame/default/cg_media.c
@@ -160,17 +160,12 @@ static void Cg_InitFootsteps(void) {
 	}, 4);
 
 	g_hash_table_insert(cg_footstep_table, "default", default_samples);
-	
-	size_t num_materials = 0;
-	const cm_material_t **materials = cgi.MapMaterials(&num_materials);
 
-	if (num_materials) {
-		for (size_t i = 0; i < num_materials; i++) {
-			const cm_material_t *material = materials[i];
+	r_material_t **material = cgi.WorldModel()->materials;
+	for (size_t i = 0; i < cgi.WorldModel()->num_materials; i++, material++) {
 
-			if (*material->footsteps) {
-				Cg_FootstepsTable_Load(material->footsteps);
-			}
+		if (strlen((*material)->cm->footsteps)) {
+			Cg_FootstepsTable_Load((*material)->cm->footsteps);
 		}
 	}
 }

--- a/src/cgame/default/cg_particle.c
+++ b/src/cgame/default/cg_particle.c
@@ -197,7 +197,7 @@ static _Bool Cg_UpdateParticle_Weather(cg_particle_t *p, const vec_t delta, cons
 				p->part.org[0],
 				p->part.org[1],
 				p->weather.end_z + 1.0
-			}, 2.0, 2.5);
+			}, 2.0, 2);
 		}
 
 		return true;

--- a/src/client/cl_cgame.c
+++ b/src/client/cl_cgame.c
@@ -247,6 +247,7 @@ void Cl_InitCgame(void) {
 	import.GetAtlasImageFromAtlas = R_GetAtlasImageFromAtlas;
 	import.CompileAtlas = R_CompileAtlas;
 	import.LoadMaterial = R_LoadMaterial;
+	import.LoadMaterials = R_LoadMaterials;
 	import.LoadModel = R_LoadModel;
 	import.WorldModel = R_WorldModel;
 

--- a/src/client/cl_cgame.c
+++ b/src/client/cl_cgame.c
@@ -218,7 +218,6 @@ void Cl_InitCgame(void) {
 	import.ReadAngles = Cl_ReadAngles;
 
 	import.EntityString = Cm_EntityString;
-	import.MapMaterials = Cm_MapMaterials;
 
 	import.PointContents = Cl_PointContents;
 	import.Trace = Cl_Trace;

--- a/src/client/renderer/r_bsp_model.c
+++ b/src/client/renderer/r_bsp_model.c
@@ -127,7 +127,7 @@ static void R_LoadBspTexinfo(r_bsp_model_t *bsp) {
 		out->flags = in->flags;
 		out->value = in->value;
 
-		out->material = R_LoadMaterial(va("textures/%s", out->name));
+		out->material = R_LoadMaterial(out->name, ASSET_CONTEXT_TEXTURES);
 
 		// hack to down-scale high-res textures for legacy levels
 		if (bsp->version == BSP_VERSION) {
@@ -156,8 +156,8 @@ static void R_LoadBspTexinfo(r_bsp_model_t *bsp) {
  * @brief Convenience for resolving r_bsp_vertex_t from surface edges.
  */
 #define R_BSP_VERTEX(b, e) ((e) >= 0 ? \
-                            (&r_unique_vertices.vertexes[b->file->edges[(e)].v[0]]) : (&r_unique_vertices.vertexes[b->file->edges[-(e)].v[1]]) \
-                           )
+	(&r_unique_vertices.vertexes[b->file->edges[(e)].v[0]]) : (&r_unique_vertices.vertexes[b->file->edges[-(e)].v[1]]) \
+)
 
 /**
  * @brief Unwinds the surface, iterating all non-collinear vertices.

--- a/src/client/renderer/r_bsp_model.c
+++ b/src/client/renderer/r_bsp_model.c
@@ -20,10 +20,10 @@
  */
 
 #include "r_local.h"
-#include "client.h" // load in a few Cl_ functions
+#include "client.h"
 
-/*
- * Structures used for intermediate representation of data
+/**
+ * @brief Structures used for intermediate representation of data
  * to compile unique vertex list and element array
  */
 typedef struct {
@@ -994,6 +994,9 @@ void R_LoadBspModel(r_model_t *mod, void *buffer) {
 	}
 
 	mod->bsp->version = version;
+
+	Cl_LoadingProgress(2, "materials");
+	R_LoadModelMaterials(mod);
 
 	Cl_LoadingProgress(4, "vertices");
 	R_LoadBspVertexes(mod->bsp);

--- a/src/client/renderer/r_bsp_model.c
+++ b/src/client/renderer/r_bsp_model.c
@@ -888,11 +888,11 @@ static void R_LoadBspSurfacesArrays(r_model_t *mod) {
 			}
 		}
 
-		if (surf->texinfo->material->flags & STAGE_DIFFUSE) {
+		if (surf->texinfo->material->cm->flags & STAGE_DIFFUSE) {
 			sorted->material.count++;
 		}
 
-		if (surf->texinfo->material->flags & STAGE_FLARE) {
+		if (surf->texinfo->material->cm->flags & STAGE_FLARE) {
 			sorted->flare.count++;
 		}
 
@@ -938,11 +938,11 @@ static void R_LoadBspSurfacesArrays(r_model_t *mod) {
 			}
 		}
 
-		if (surf->texinfo->material->flags & STAGE_DIFFUSE) {
+		if (surf->texinfo->material->cm->flags & STAGE_DIFFUSE) {
 			R_SURFACE_TO_SURFACES(&sorted->material, surf);
 		}
 
-		if (surf->texinfo->material->flags & STAGE_FLARE) {
+		if (surf->texinfo->material->cm->flags & STAGE_FLARE) {
 			R_SURFACE_TO_SURFACES(&sorted->flare, surf);
 		}
 

--- a/src/client/renderer/r_flare.c
+++ b/src/client/renderer/r_flare.c
@@ -32,7 +32,7 @@ void R_CreateBspSurfaceFlare(r_bsp_model_t *bsp, r_bsp_surface_t *surf) {
 
 	const r_material_t *m = surf->texinfo->material;
 
-	if (!(m->flags & STAGE_FLARE)) { // surface is not flared
+	if (!(m->cm->flags & STAGE_FLARE)) { // surface is not flared
 		return;
 	}
 

--- a/src/client/renderer/r_image.c
+++ b/src/client/renderer/r_image.c
@@ -294,6 +294,11 @@ static void R_LoadHeightmap(const char *name, const SDL_Surface *surf) {
 		*c = '\0';
 	}
 
+	// FIXME:
+	// This should use the material's heightmap asset, which might be resolved
+	// from multiple potential suffixes. This is a total hack and is incorrect.
+	// Solving this without completely refactoring R_LoadImage is hard.
+
 	SDL_Surface *hsurf;
 	if (Img_LoadImage(va("%s_h", heightmap), &hsurf)) {
 

--- a/src/client/renderer/r_material.c
+++ b/src/client/renderer/r_material.c
@@ -647,8 +647,7 @@ static void R_RegisterMaterial(r_media_t *self) {
 	while (s) {
 		R_RegisterDependency(self, (r_media_t *) s->image);
 
-		uint16_t i;
-		for (i = 0; i < s->cm->anim.num_frames; i++) {
+		for (uint16_t i = 0; i < s->cm->anim.num_frames; i++) {
 			R_RegisterDependency(self, (r_media_t *) s->anim.frames[i]);
 		}
 
@@ -667,259 +666,165 @@ static void R_FreeMaterial(r_media_t *self) {
 }
 
 /**
- * @brief
+ * @return The number of frames resolved, or -1 on error.
  */
-static void R_LoadNormalmap(r_material_t *mat) {
+static int32_t R_ResolveStageAnimation(r_stage_t *stage, cm_asset_context_t context) {
 
-	if (strlen(mat->cm->normalmap)) {
-		mat->normalmap = R_LoadImage(mat->cm->normalmap, IT_NORMALMAP);
-	} else {
-		const char *suffix[] = { "_nm", "_norm", "_local", "_bump" };
+	const size_t size = sizeof(r_image_t *) * stage->cm->anim.num_frames;
+	stage->anim.frames = Mem_LinkMalloc(size, stage);
 
-		for (size_t i = 0; i < lengthof(suffix); i++) {
-			mat->normalmap = R_LoadImage(va("%s%s", mat->cm->base, suffix[i]), IT_NORMALMAP);
-			if (mat->normalmap->type == IT_NORMALMAP) {
+	uint16_t i;
+	for (i = 0; i < stage->cm->anim.num_frames; i++) {
+
+		cm_asset_t *frame = &stage->cm->anim.frames[i];
+		if (*frame->path) {
+			stage->anim.frames[i] = R_LoadImage(frame->path, IT_DIFFUSE);
+			if (stage->anim.frames[i]->type == IT_NULL) {
 				break;
 			}
+		} else {
+			break;
 		}
 	}
 
-	if (mat->normalmap->type == IT_NULL) {
-		mat->normalmap = NULL;
+	if (i < stage->cm->anim.num_frames) {
+		Com_Warn("Failed to resolve frame: %d: %s\n", i, stage->cm->asset.name);
+		return -1;
 	}
+
+	return i;
 }
 
 /**
- * @brief
+ * @brief Resolves assets for the specified stage, within the given context.
  */
-static void R_LoadSpecularmap(r_material_t *mat) {
+static int32_t R_ResolveStage(r_stage_t *stage, cm_asset_context_t context) {
 
-	if (strlen(mat->cm->specularmap)) {
-		mat->specularmap = R_LoadImage(mat->cm->specularmap, IT_SPECULARMAP);
-	} else {
-		const char *suffix[] = { "_s", "_gloss", "_spec" };
+	if (*stage->cm->asset.path) {
 
-		for (size_t i = 0; i < lengthof(suffix); i++) {
-			mat->specularmap = R_LoadImage(va("%s%s", mat->cm->base, suffix[i]), IT_SPECULARMAP);
-			if (mat->specularmap->type == IT_SPECULARMAP) {
-				break;
-			}
-		}
-	}
-
-	if (mat->specularmap->type == IT_NULL) {
-		mat->specularmap = NULL;
-	}
-}
-
-/**
- * @brief
- */
-static void R_LoadTintmap(r_material_t *mat) {
-
-	if (strlen(mat->cm->tintmap)) {
-		mat->tintmap = R_LoadImage(mat->cm->tintmap, IT_TINTMAP);
-	} else {
-		const char *suffix[] = { "_tint" };
-
-		for (size_t i = 0; i < lengthof(suffix); i++) {
-			mat->tintmap = R_LoadImage(va("%s%s", mat->cm->base, suffix[i]), IT_TINTMAP);
-			if (mat->tintmap->type == IT_TINTMAP) {
-				break;
-			}
-		}
-	}
-
-	if (mat->tintmap->type == IT_NULL) {
-		mat->tintmap = NULL;
-	}
-}
-
-/**
- * @brief Loads the r_material_t from the specified cm_material_t. If the material is
- * already loaded, the cm_material_t will be freed, so don't use it after this function!
- * Use the "cm" member of the renderer material.
- * @returns False if the material is already loaded and shouldn't be re-parsed.
- */
-static _Bool R_ConvertMaterial(cm_material_t *cm, r_material_t **mat) {
-	char key[MAX_QPATH];
-
-	if (!cm || !cm->diffuse[0]) {
-		Com_Error(ERROR_DROP, "NULL diffuse name\n");
-	}
-
-	g_snprintf(key, sizeof(key), "%s_mat", cm->base);
-	r_material_t *material = (r_material_t *) R_FindMedia(key);
-
-	if (material == NULL) {
-		material = (r_material_t *) R_AllocMedia(key, sizeof(r_material_t), MEDIA_MATERIAL);
-		
-		*mat = material;
-		material->cm = cm;
-
-		material->media.Register = R_RegisterMaterial;
-		material->media.Free = R_FreeMaterial;
-
-		material->diffuse = R_LoadImage(cm->diffuse, IT_DIFFUSE);
-
-		if (material->diffuse->type == IT_DIFFUSE) {
-			R_LoadNormalmap(material);
-
-			if (material->normalmap) {
-				R_LoadSpecularmap(material);
-			}
-
-			if (!g_str_has_prefix(material->cm->base, "textures/")) {
-				R_LoadTintmap(material);
-			}
+		if (stage->cm->flags & STAGE_TEXTURE) {
+			stage->image = R_LoadImage(stage->cm->asset.path, IT_DIFFUSE);
+		} else if (stage->cm->flags & STAGE_ENVMAP) {
+			stage->image = R_LoadImage(stage->cm->asset.path, IT_ENVMAP);
+		} else if (stage->cm->flags & STAGE_FLARE) {
+			stage->image = R_LoadImage(stage->cm->asset.path, IT_FLARE);
 		}
 
-		R_RegisterMedia((r_media_t *) material);
-		return true;
+		if (stage->image->type == IT_NULL) {
+			Com_Warn("Failed to resolve stage: %s\n", stage->cm->asset.name);
+			return -1;
+		}
+
+		if (stage->cm->flags & STAGE_LIGHTING) {
+			stage->material = R_LoadMaterial(stage->cm->asset.name, context);
+		}
+
+		if (stage->cm->flags & STAGE_ANIM) {
+			return R_ResolveStageAnimation(stage, context);
+		}
 	}
 	
-	*mat = material;
-	Cm_FreeMaterial(cm);
-	return false;
+	return 0;
 }
 
 /**
  * @brief
  */
-static void R_AttachStage(r_material_t *m, r_stage_t *s) {
+static void R_AppendStage(r_material_t *m, r_stage_t *s) {
 
-	// append the stage to the chain
-	if (!m->stages) {
+	if (m->stages == NULL) {
 		m->stages = s;
-		return;
+	} else {
+		r_stage_t *stages = m->stages;
+		while (stages->next) {
+			stages = stages->next;
+		}
+		stages->next = s;
+	}
+}
+
+/**
+ * @brief Resolves all asset references in the specified collision material, yielding a usable
+ * renderer material.
+ */
+static r_material_t *R_ResolveMaterial(cm_material_t *cm, cm_asset_context_t context) {
+	char key[MAX_QPATH];
+
+	StripExtension(cm->name, key);
+	Cm_MaterialBasename(key, key, sizeof(key));
+
+	g_strlcat(key, "_mat", sizeof(key));
+
+	r_material_t *material = (r_material_t *) R_AllocMedia(key, sizeof(r_material_t), MEDIA_MATERIAL);
+	material->cm = cm;
+
+	material->media.Register = R_RegisterMaterial;
+	material->media.Free = R_FreeMaterial;
+
+	Cm_ResolveMaterial(cm, context);
+
+	material->diffuse = R_LoadImage(cm->diffuse.path, IT_DIFFUSE);
+
+	if (material->diffuse->type == IT_DIFFUSE) {
+
+		if (*cm->normalmap.path) {
+			material->normalmap = R_LoadImage(cm->normalmap.path, IT_NORMALMAP);
+			if (material->normalmap->type == IT_NULL) {
+				material->normalmap = NULL;
+			}
+		}
+
+		if (*cm->specularmap.path) {
+			material->specularmap = R_LoadImage(cm->specularmap.path, IT_SPECULARMAP);
+			if (material->specularmap->type == IT_NULL) {
+				material->specularmap = NULL;
+			}
+		}
+
+		if (*cm->tintmap.path) {
+			material->tintmap = R_LoadImage(cm->tintmap.path, IT_TINTMAP);
+			if (material->tintmap->type == IT_NULL) {
+				material->tintmap = NULL;
+			}
+		}
+
+		for (cm_stage_t *s = cm->stages; s; s = s->next) {
+			r_stage_t *stage = (r_stage_t *) Mem_LinkMalloc(sizeof(r_stage_t), material);
+			stage->cm = s;
+
+			if (R_ResolveStage(stage, context) == -1) {
+				Mem_Free(stage);
+			} else {
+				R_AppendStage(material, stage);
+			}
+		}
 	}
 
-	r_stage_t *ss = m->stages;
-	while (ss->next) {
-		ss = ss->next;
-	}
-	ss->next = s;
+	R_RegisterMedia((r_media_t *) material);
+
+	return material;
 }
 
 /**
  * @brief Loads the r_material_t from the specified texture.
  */
-r_material_t *R_LoadMaterial(const char *name) {
+r_material_t *R_LoadMaterial(const char *name, cm_asset_context_t context) {
 	char key[MAX_QPATH];
 
 	StripExtension(name, key);
-	Cm_NormalizeMaterialName(key, key, sizeof(key));
+	Cm_MaterialBasename(key, key, sizeof(key));
 
 	g_strlcat(key, "_mat", sizeof(key));
 	r_material_t *mat = (r_material_t *) R_FindMedia(key);
 
 	if (mat == NULL) {
-		R_ConvertMaterial(Cm_AllocMaterial(name), &mat);
+
+		cm_material_t *cm = Cm_AllocMaterial(name);
+
+		mat = R_ResolveMaterial(cm, context);
 	}
 
 	return mat;
-}
-
-/**
- * @brief
- */
-static int32_t R_LoadStageFrames(r_stage_t *s) {
-	char name[MAX_QPATH];
-	int32_t i, j;
-
-	if (!s->image) {
-		Com_Warn("Texture not defined in anim stage\n");
-		return -1;
-	}
-
-	g_strlcpy(name, s->image->media.name, sizeof(name));
-	const size_t len = strlen(name);
-
-	if ((i = (int32_t) strtol(&name[len - 1], NULL, 0)) < 0) {
-		Com_Warn("Texture name does not end in numeric: %s\n", name);
-		return -1;
-	}
-
-	// the first image was already loaded by the stage parse, so just copy
-	// the pointer into the array
-
-	s->anim.frames = Mem_LinkMalloc(s->cm->anim.num_frames * sizeof(r_image_t *), s);
-	s->anim.frames[0] = s->image;
-
-	// now load the rest
-	name[len - 1] = '\0';
-	for (j = 1, i = i + 1; j < s->cm->anim.num_frames; j++, i++) {
-		char frame[MAX_QPATH];
-
-		g_snprintf(frame, sizeof(frame), "%s%d", name, i);
-		s->anim.frames[j] = R_LoadImage(frame, IT_DIFFUSE);
-
-		if (s->anim.frames[j]->type == IT_NULL) {
-			Com_Warn("Failed to resolve frame: %d: %s\n", j, frame);
-			return -1;
-		}
-	}
-
-	return 0;
-}
-
-/**
- * @brief
- */
-static int32_t R_ParseStage(r_stage_t *s, const cm_stage_t *cm) {
-
-	s->cm = cm;
-
-	if (*cm->image) {
-
-		if (cm->flags & STAGE_TEXTURE) {
-			if (*cm->image == '#') {
-				s->image = R_LoadImage(cm->image + 1, IT_DIFFUSE);
-			} else {
-				s->image = R_LoadImage(va("textures/%s", cm->image), IT_DIFFUSE);
-			}
-
-			if (s->image->type == IT_NULL) {
-				Com_Warn("Failed to resolve texture: %s\n", cm->image);
-				return -1;
-			}
-		} else if (cm->flags & STAGE_ENVMAP) {
-			if (*cm->image == '#') {
-				s->image = R_LoadImage(cm->image + 1, IT_ENVMAP);
-			} else if (*cm->image == '0' || cm->image_index > 0) {
-				s->image = R_LoadImage(va("envmaps/envmap_%d", cm->image_index), IT_ENVMAP);
-			} else {
-				s->image = R_LoadImage(va("envmaps/%s", cm->image), IT_ENVMAP);
-			}
-
-			if (s->image->type == IT_NULL) {
-				Com_Warn("Failed to resolve envmap: %s\n", cm->image);
-				return -1;
-			}
-		} else if (cm->flags & STAGE_FLARE) {
-			s->image = R_LoadImage(cm->image, IT_FLARE);
-
-			if (*cm->image == '#') {
-				s->image = R_LoadImage(cm->image + 1, IT_FLARE);
-			} else if (*cm->image == '0' || cm->image_index > 0) {
-				s->image = R_LoadImage(va("flares/flare_%d", cm->image_index), IT_FLARE);
-			} else {
-				s->image = R_LoadImage(va("flares/%s", cm->image), IT_FLARE);
-			}
-
-			if (s->image->type == IT_NULL) {
-				Com_Warn("Failed to resolve flare: %s\n", cm->image);
-				return -1;
-			}
-		}
-	}
-
-	// load material if lighting
-	if (cm->flags & STAGE_LIGHTING) {
-		s->material = R_LoadMaterial(cm->image);
-	}
-
-	return 0;
 }
 
 /**
@@ -928,107 +833,34 @@ static int32_t R_ParseStage(r_stage_t *s, const cm_stage_t *cm) {
  * materials/${model_name}.mat for BSP models.
  */
 void R_LoadMaterials(r_model_t *mod) {
-	cm_material_t **materials;
-	size_t num_materials;
 
-	// load the materials file for parsing
+	const char *path;
+	cm_asset_context_t context;
+
 	if (mod->type == MOD_BSP) {
-		materials = Cm_LoadMaterials(va("materials/%s.mat", Basename(mod->media.name)), &num_materials);
+		path = va("materials/%s.mat", Basename(mod->media.name));
+		context = ASSET_CONTEXT_TEXTURES;
 	} else {
-		materials = Cm_LoadMaterials(va("%s.mat", mod->media.name), &num_materials);
+		path = va("%s.mat", mod->media.name);
+		context = ASSET_CONTEXT_MODELS;
 	}
 
-	if (!num_materials) {
-		return;
-	}
+	size_t num_materials;
+	cm_material_t **materials = Cm_LoadMaterials(path, &num_materials);
 
 	for (size_t i = 0; i < num_materials; i++) {
-		r_material_t *r_mat;
-		
-		if (!R_ConvertMaterial(materials[i], &r_mat)) {
-			Com_Debug(DEBUG_RENDERER, "Retained material %s with %d stages\n", r_mat->diffuse->media.name, r_mat->cm->num_stages);
+
+		r_material_t *mat = R_ResolveMaterial(materials[i], context);
+
+		if (mat->diffuse->type == IT_NULL) {
+			Com_Warn("Failed to resolve %s\n", mat->cm->name);
 			continue;
 		}
 
-		if (!r_mat) {
-			Com_Warn("Failed to convert %s\n", r_mat->cm->diffuse);
-			continue;
-		}
-
-		if (r_mat->diffuse->type == IT_NULL) {
-			Com_Warn("Failed to resolve %s\n", r_mat->cm->diffuse);
-			continue;
-		}
-
-		if (r_bumpmap->value) { // if per-pixel lighting is enabled, resolve normal and specular
-
-			if (*r_mat->cm->normalmap) {
-				if (*r_mat->cm->normalmap == '#') {
-					r_mat->normalmap = R_LoadImage(r_mat->cm->normalmap + 1, IT_NORMALMAP);
-				} else {
-					r_mat->normalmap = R_LoadImage(va("textures/%s", r_mat->cm->normalmap), IT_NORMALMAP);
-				}
-
-				if (r_mat->normalmap->type == IT_NULL) {
-					Com_Warn("Failed to resolve normalmap: %s\n", r_mat->cm->normalmap);
-					r_mat->normalmap = NULL;
-				}
-			}
-
-			if (*r_mat->cm->specularmap) {
-				if (*r_mat->cm->specularmap == '#') {
-					r_mat->specularmap = R_LoadImage(r_mat->cm->specularmap + 1, IT_SPECULARMAP);
-				} else {
-					r_mat->specularmap = R_LoadImage(va("textures/%s", r_mat->cm->specularmap), IT_SPECULARMAP);
-				}
-
-				if (r_mat->specularmap->type == IT_NULL) {
-					Com_Warn("Failed to resolve specularmap: %s\n", r_mat->cm->specularmap);
-					r_mat->specularmap = NULL;
-				}
-			}
-		}
-
-		if (*r_mat->cm->tintmap) {
-			if (*r_mat->cm->tintmap == '#') {
-				r_mat->tintmap = R_LoadImage(r_mat->cm->tintmap + 1, IT_TINTMAP);
-			} else {
-				r_mat->tintmap = R_LoadImage(va("textures/%s", r_mat->cm->tintmap), IT_TINTMAP);
-			}
-
-			if (r_mat->tintmap->type == IT_NULL) {
-				Com_Warn("Failed to resolve tintmap: %s\n", r_mat->cm->tintmap);
-				r_mat->tintmap = NULL;
-			}
-		}
-
-		for (cm_stage_t *cm_stage = r_mat->cm->stages; cm_stage; cm_stage = cm_stage->next) {
-			r_stage_t *r_stage = (r_stage_t *) Mem_LinkMalloc(sizeof(r_stage_t), r_mat);
-
-			if (R_ParseStage(r_stage, cm_stage) == -1) {
-				Mem_Free(r_stage);
-				continue;
-			}
-
-			// load animation frame images
-			if (cm_stage->flags & STAGE_ANIM) {
-				if (R_LoadStageFrames(r_stage) == -1) {
-					Mem_Free(r_stage);
-					continue;
-				}
-			}
-			
-			// attach stage
-			R_AttachStage(r_mat, r_stage);
-
-			r_mat->flags |= cm_stage->flags;
-			continue;
-		}
-
-		R_RegisterDependency((r_media_t *) mod, (r_media_t *) r_mat);
-		Com_Debug(DEBUG_RENDERER, "Parsed material %s with %d stages\n", r_mat->diffuse->media.name, r_mat->cm->num_stages);
+		R_RegisterDependency((r_media_t *) mod, (r_media_t *) mat);
+		Com_Debug(DEBUG_RENDERER, "Parsed material %s with %d stages\n", mat->cm->name, mat->cm->num_stages);
 	}
-	
+
 	Cm_FreeMaterialList(materials);
 }
 
@@ -1050,12 +882,12 @@ static void R_SaveMaterials_f(void) {
 
 	cm_material_t **c = mod->bsp->cm->materials;
 	for (size_t i = 0; i < mod->bsp->cm->num_materials; i++, c++) {
-
-		const r_material_t *mat = R_LoadMaterial((*c)->diffuse);
+		const char *name = (*c)->diffuse.name;
+		const r_material_t *mat = R_LoadMaterial(name, ASSET_CONTEXT_TEXTURES);
 		if (mat) {
 			materials[i] = mat->cm;
 		} else {
-			Com_Debug(DEBUG_RENDERER, "Failed to resolve renderer material %s\n", (*c)->diffuse);
+			Com_Debug(DEBUG_RENDERER, "Failed to resolve renderer material %s\n", name);
 		}
 	}
 

--- a/src/client/renderer/r_material.c
+++ b/src/client/renderer/r_material.c
@@ -623,7 +623,7 @@ void R_DrawMeshMaterial(r_material_t *m, const GLuint offset, const GLuint count
 		return;
 	}
 
-	if (!(m->flags & STAGE_DIFFUSE)) {
+	if (!(m->cm->flags & STAGE_DIFFUSE)) {
 		return;
 	}
 

--- a/src/client/renderer/r_material.c
+++ b/src/client/renderer/r_material.c
@@ -730,7 +730,7 @@ static int32_t R_ResolveStageAnimation(r_stage_t *stage, cm_asset_context_t cont
 		return -1;
 	}
 
-	return i;
+	return stage->cm->anim.num_frames;
 }
 
 /**

--- a/src/client/renderer/r_material.c
+++ b/src/client/renderer/r_material.c
@@ -863,7 +863,7 @@ r_material_t *R_LoadMaterial(const char *name, cm_asset_context_t context) {
 }
 
 /**
- * @brief
+ * @brief Loads all materials defined in the given file.
  */
 ssize_t R_LoadMaterials(const char *path, cm_asset_context_t context, GList **materials) {
 

--- a/src/client/renderer/r_material.h
+++ b/src/client/renderer/r_material.h
@@ -24,6 +24,7 @@
 #include "r_types.h"
 
 r_material_t *R_LoadMaterial(const char *name, cm_asset_context_t context);
+ssize_t R_LoadMaterials(const char *path, cm_asset_context_t context, GList **materials);
 
 #ifdef __R_LOCAL_H__
 #define R_OFFSET_UNITS -1.0
@@ -31,7 +32,7 @@ r_material_t *R_LoadMaterial(const char *name, cm_asset_context_t context);
 
 void R_DrawMaterialBspSurfaces(const r_bsp_surfaces_t *surfs);
 void R_DrawMeshMaterial(r_material_t *m, const GLuint offset, const GLuint count);
-void R_LoadMaterials(r_model_t *mod);
 void R_InitMaterials(void);
+void R_LoadModelMaterials(r_model_t *mod);
 void R_ShutdownMaterials(void);
 #endif /* __R_LOCAL_H__ */

--- a/src/client/renderer/r_material.h
+++ b/src/client/renderer/r_material.h
@@ -23,7 +23,7 @@
 
 #include "r_types.h"
 
-r_material_t *R_LoadMaterial(const char *name);
+r_material_t *R_LoadMaterial(const char *name, cm_asset_context_t context);
 
 #ifdef __R_LOCAL_H__
 #define R_OFFSET_UNITS -1.0

--- a/src/client/renderer/r_media.c
+++ b/src/client/renderer/r_media.c
@@ -122,7 +122,7 @@ void R_DumpImages_f(void) {
  * @brief Establishes a dependency from the specified dependent to the given
  * dependency. Dependencies in use by registered media are never freed.
  */
-void R_RegisterDependency(r_media_t *dependent, r_media_t *dependency) {
+r_media_t *R_RegisterDependency(r_media_t *dependent, r_media_t *dependency) {
 
 	if (dependent) {
 		if (dependency) {
@@ -138,6 +138,8 @@ void R_RegisterDependency(r_media_t *dependent, r_media_t *dependency) {
 	} else {
 		Com_Warn("Invalid dependent\n");
 	}
+
+	return dependency;
 }
 
 /**
@@ -153,7 +155,7 @@ static gboolean R_FreeMedia_(gpointer key, gpointer value, gpointer data);
  * @brief Inserts the specified media into the shared table, re-registering all
  * of its dependencies as well.
  */
-void R_RegisterMedia(r_media_t *media) {
+r_media_t *R_RegisterMedia(r_media_t *media) {
 
 	// check to see if we're already seeded
 	if (media->seed != r_media_state.seed) {
@@ -190,6 +192,8 @@ void R_RegisterMedia(r_media_t *media) {
 		R_RegisterMedia((r_media_t *) d->data);
 		d = d->next;
 	}
+
+	return media;
 }
 
 /**

--- a/src/client/renderer/r_media.h
+++ b/src/client/renderer/r_media.h
@@ -27,8 +27,8 @@
 
 void R_ListMedia_f(void);
 void R_DumpImages_f(void);
-void R_RegisterDependency(r_media_t *dependent, r_media_t *dependency);
-void R_RegisterMedia(r_media_t *media);
+r_media_t *R_RegisterDependency(r_media_t *dependent, r_media_t *dependency);
+r_media_t *R_RegisterMedia(r_media_t *media);
 r_media_t *R_FindMedia(const char *name);
 r_media_t *R_AllocMedia(const char *name, size_t size, r_media_type_t type);
 void R_FreeMedia(void);

--- a/src/client/renderer/r_mesh_model.c
+++ b/src/client/renderer/r_mesh_model.c
@@ -23,21 +23,6 @@
 #include "parse.h"
 
 /**
- * @brief Resolves the skin for the specified model. By default, we simply load
- * "skin.tga" in the model's directory.
- */
-static void R_LoadMeshMaterial(r_model_t *mod) {
-
-	R_LoadModelMaterials(mod);
-
-	char skin[MAX_QPATH];
-	Dirname(mod->media.name, skin);
-	g_strlcat(skin, "skin", sizeof(skin));
-
-	mod->mesh->material = R_LoadMaterial(skin, ASSET_CONTEXT_MODELS);
-}
-
-/**
  * @brief Parses animation.cfg, loading the frame specifications for the given model.
  */
 static void R_LoadMd3Animations(r_model_t *mod) {
@@ -610,12 +595,13 @@ void R_LoadMd3Model(r_model_t *mod, void *buffer) {
 		in_mesh = (d_md3_mesh_t *) ((byte *) in_mesh + in_mesh->size);
 	}
 
-	// load the skin for objects, and the animations for players
+	// load materials
 	if (!strstr(mod->media.name, "players/")) {
-		R_LoadMeshMaterial(mod);
+		R_LoadModelMaterials(mod);
 	}
 
-	else if (strstr(mod->media.name, "/upper")) {
+	// and animations for player models
+	if (strstr(mod->media.name, "/upper")) {
 		R_LoadMd3Animations(mod);
 	}
 
@@ -1083,7 +1069,7 @@ void R_LoadObjModel(r_model_t *mod, void *buffer) {
 	R_LoadObjTangents(mod, obj);
 
 	// load the material
-	R_LoadMeshMaterial(mod);
+	R_LoadModelMaterials(mod);
 
 	// and configs
 	R_LoadMeshConfigs(mod);

--- a/src/client/renderer/r_mesh_model.c
+++ b/src/client/renderer/r_mesh_model.c
@@ -27,10 +27,12 @@
  * "skin.tga" in the model's directory.
  */
 static void R_LoadMeshMaterial(r_model_t *mod) {
-	char skin[MAX_QPATH];
 
+	R_LoadModelMaterials(mod);
+
+	char skin[MAX_QPATH];
 	Dirname(mod->media.name, skin);
-	strcat(skin, "skin");
+	g_strlcat(skin, "skin", sizeof(skin));
 
 	mod->mesh->material = R_LoadMaterial(skin, ASSET_CONTEXT_MODELS);
 }

--- a/src/client/renderer/r_mesh_model.c
+++ b/src/client/renderer/r_mesh_model.c
@@ -32,7 +32,7 @@ static void R_LoadMeshMaterial(r_model_t *mod) {
 	Dirname(mod->media.name, skin);
 	strcat(skin, "skin");
 
-	mod->mesh->material = R_LoadMaterial(skin);
+	mod->mesh->material = R_LoadMaterial(skin, ASSET_CONTEXT_MODELS);
 }
 
 /**

--- a/src/client/renderer/r_model.c
+++ b/src/client/renderer/r_model.c
@@ -151,9 +151,6 @@ r_model_t *R_LoadModel(const char *name) {
 
 		mod->type = format->type;
 
-		// load the materials first, so that we can resolve surfaces lists
-		R_LoadMaterials(mod);
-
 		void *buf = NULL;
 
 		Fs_Load(file_name, &buf);

--- a/src/client/renderer/r_types.h
+++ b/src/client/renderer/r_types.h
@@ -389,7 +389,6 @@ typedef struct r_material_s {
 	r_media_t media;
 
 	struct cm_material_s *cm; // the parsed material
-	r_model_type_t mod_type;
 
 	// renderer-local stuff parsed from cm
 	r_image_t *diffuse;

--- a/src/client/renderer/r_types.h
+++ b/src/client/renderer/r_types.h
@@ -800,6 +800,9 @@ typedef struct r_model_s {
 	r_bsp_inline_model_t *bsp_inline;
 	r_mesh_model_t *mesh;
 
+	r_material_t **materials;
+	size_t num_materials;
+
 	vec3_t mins, maxs;
 	vec_t radius;
 

--- a/src/client/renderer/r_types.h
+++ b/src/client/renderer/r_types.h
@@ -397,7 +397,6 @@ typedef struct r_material_s {
 	r_image_t *tintmap;
 
 	uint32_t time;
-	uint32_t flags; // these may differ from cm->flags
 
 	r_stage_t *stages;
 } r_material_t;

--- a/src/client/ui/views/EditorView.c
+++ b/src/client/ui/views/EditorView.c
@@ -54,21 +54,26 @@ static void updateBindings(View *self) {
 
 	EditorView *this = (EditorView *) self;
 
+	free(this->materialName->defaultText);
+	free(this->diffuseTexture->defaultText);
+	free(this->normalmapTexture->defaultText);
+	free(this->specularmapTexture->defaultText);
+
+	this->material = NULL;
+
 	vec3_t end;
 	VectorMA(r_view.origin, MAX_WORLD_DIST, r_view.forward, end);
 
 	const cm_trace_t tr = Cl_Trace(r_view.origin, end, NULL, NULL, 0, MASK_SOLID);
-
 	if (tr.fraction < 1.0 && tr.surface->material) {
-		this->material = R_LoadMaterial(tr.surface->material->diffuse);
-	} else {
-		this->material = NULL;
+		this->material = R_LoadMaterial(tr.surface->name, ASSET_CONTEXT_TEXTURES);
 	}
 
 	if (this->material) {
-		this->materialName->defaultText = this->material->cm->base;
-		this->diffuseTexture->defaultText = this->material->cm->diffuse;
-		this->normalmapTexture->defaultText = this->material->cm->normalmap;
+		this->materialName->defaultText = strdup(this->material->cm->basename);
+		this->diffuseTexture->defaultText = strdup(this->material->cm->diffuse.name);
+		this->normalmapTexture->defaultText = strdup(this->material->cm->normalmap.name);
+		this->specularmapTexture->defaultText = strdup(this->material->cm->specularmap.name);
 
 		$(this->bumpSlider, setValue, (double) this->material->cm->bump);
 		$(this->hardnessSlider, setValue, (double) this->material->cm->hardness);
@@ -160,6 +165,10 @@ static EditorView *initWithFrame(EditorView *self, const SDL_Rect *frame) {
 				self->normalmapTexture = $(alloc(TextView), initWithFrame, &frame, ControlStyleDefault);
 				self->normalmapTexture->isEditable = false;
 				addInput((View *) stackView, "Normalmap texture", (Control *) self->normalmapTexture);
+
+				self->specularmapTexture = $(alloc(TextView), initWithFrame, &frame, ControlStyleDefault);
+				self->specularmapTexture->isEditable = false;
+				addInput((View *) stackView, "Specularmap texture", (Control *) self->specularmapTexture);
 
 				self->bumpSlider = $(alloc(Slider), initWithFrame, NULL, ControlStyleDefault);
 				self->bumpSlider->min = 0.0;

--- a/src/client/ui/views/EditorView.h
+++ b/src/client/ui/views/EditorView.h
@@ -72,6 +72,11 @@ struct EditorView {
 	TextView *normalmapTexture;
 
 	/**
+	 * @brief The specularmap texture.
+	 */
+	TextView *specularmapTexture;
+
+	/**
 	 * @brief The bump slider.
 	 */
 	Slider *bumpSlider;

--- a/src/collision/cm_material.c
+++ b/src/collision/cm_material.c
@@ -616,18 +616,18 @@ static int32_t Cm_ParseStage(cm_material_t *m, cm_stage_t *s, parser_t *parser, 
 			          "  texture: %s\n"
 			          "   -> material: %s\n"
 			          "  blend: %d %d\n"
-			          "  color: %3f %3f %3f\n"
-			          "  pulse: %3f\n"
-			          "  stretch: %3f %3f\n"
-			          "  rotate: %3f\n"
-			          "  scroll.s: %3f\n"
-			          "  scroll.t: %3f\n"
-			          "  scale.s: %3f\n"
-			          "  scale.t: %3f\n"
-			          "  terrain.floor: %5f\n"
-			          "  terrain.ceil: %5f\n"
+			          "  color: %.1f %.1f %.1f\n"
+			          "  pulse: %.1f\n"
+			          "  stretch: %.1f %.1f\n"
+			          "  rotate: %.1f\n"
+			          "  scroll.s: %.1f\n"
+			          "  scroll.t: %.1f\n"
+			          "  scale.s: %.1f\n"
+			          "  scale.t: %.1f\n"
+			          "  terrain.floor: %.1f\n"
+			          "  terrain.ceil: %.1f\n"
 			          "  anim.num_frames: %d\n"
-			          "  anim.fps: %3f\n", s->flags, (*s->asset.name ? s->asset.name : "NULL"),
+			          "  anim.fps: %.1f\n", s->flags, (*s->asset.name ? s->asset.name : "NULL"),
 			          ((s->flags & STAGE_LIGHTING) ? "true" : "false"), s->blend.src,
 			          s->blend.dest, s->color[0], s->color[1], s->color[2], s->pulse.hz,
 			          s->stretch.amp, s->stretch.hz, s->rotate.hz, s->scroll.s, s->scroll.t,
@@ -1049,9 +1049,9 @@ static _Bool Cm_ResolveMaterialAsset(cm_material_t *material, cm_asset_t *asset,
 	} else if (asset == &material->heightmap) {
 		suffix = (const char *[]) { "_h", "_height", NULL };
 	} else if (asset == &material->specularmap) {
-		suffix = (const char *[]) { "s", "gloss", "spec", NULL };
+		suffix = (const char *[]) { "_s", "_gloss", "_spec", NULL };
 	} else if (asset == &material->tintmap) {
-		suffix = (const char *[]) { "tint", NULL };
+		suffix = (const char *[]) { "_tint", NULL };
 	} else {
 		assert(false);
 	}
@@ -1059,11 +1059,12 @@ static _Bool Cm_ResolveMaterialAsset(cm_material_t *material, cm_asset_t *asset,
 	for (const char **s = suffix; *s; s++) {
 		g_snprintf(asset->name, sizeof(asset->name), "%s%s", material->basename, *s);
 		if (Cm_ResolveAsset(asset, context)) {
+			Com_Debug(DEBUG_COLLISION, "Resolved %s for %s\n", asset->path, material->name);
 			return true;
 		}
 	}
 
-	Com_Debug(DEBUG_COLLISION, "Failed to resolve asset for %s\n", material->name);
+	Com_Debug(DEBUG_COLLISION, "Failed to resolve asset %s for %s\n", *suffix, material->name);
 
 	*asset->name = '\0';
 	return false;

--- a/src/collision/cm_material.c
+++ b/src/collision/cm_material.c
@@ -986,16 +986,20 @@ static void Cm_ResolveStageAnimation(cm_stage_t *stage, cm_asset_context_t type)
 		stage->anim.frames = Mem_LinkMalloc(size, stage);
 
 		char base[MAX_QPATH];
-
 		g_strlcpy(base, stage->asset.name, sizeof(base));
-		if (g_str_has_suffix(base, "0")) {
-			base[strlen(base) - 1] = '\0';
+
+		char *c = base + strlen(base) - 1;
+		while (isdigit(*c)) {
+			c--;
 		}
+
+		int32_t start = (int32_t) strtol(c, NULL, 10);
+		*(c + 1) = '\0';
 
 		for (uint16_t i = 0; i < stage->anim.num_frames; i++) {
 
 			cm_asset_t *frame = &stage->anim.frames[i];
-			g_snprintf(frame->name, sizeof(frame->name), "%s%d", base, i);
+			g_snprintf(frame->name, sizeof(frame->name), "%s%d", base, start + i);
 
 			if (!Cm_ResolveAsset(frame, type)) {
 				Com_Warn("Failed to resolve frame: %d: %s\n", i, stage->asset.name);

--- a/src/collision/cm_material.c
+++ b/src/collision/cm_material.c
@@ -921,43 +921,43 @@ ssize_t Cm_LoadMaterials(const char *path, GList **materials) {
  */
 static _Bool Cm_ResolveAsset(cm_asset_t *asset, cm_asset_context_t context) {
 	const char *extensions[] = { "tga", "png", "jpg", "pcx", "wal" };
-	const char *name;
+	char name[MAX_QPATH];
 
 	if (asset->name[0] == '#') {
-		name = asset->name + 1;
+		g_strlcpy(name, asset->name + 1, sizeof(name));
 	} else {
-		name = asset->name;
+		g_strlcpy(name, asset->name, sizeof(name));
 
 		switch (context) {
 			case ASSET_CONTEXT_NONE:
 				break;
 			case ASSET_CONTEXT_TEXTURES:
 				if (!g_str_has_prefix(asset->name, "textures/")) {
-					name = va("textures/%s", asset->name);
+					g_snprintf(name, sizeof(name), "textures/%s", asset->name);
 				}
 				break;
 			case ASSET_CONTEXT_MODELS:
 				if (!g_str_has_prefix(asset->name, "models/")) {
-					name = va("models/%s", asset->name);
+					g_snprintf(name, sizeof(name), "models/%s", asset->name);
 				}
 				break;
 			case ASSET_CONTEXT_PLAYERS:
 				if (!g_str_has_prefix(asset->name, "players/")) {
-					name = va("players/%s", asset->name);
+					g_snprintf(name, sizeof(name), "players/%s", asset->name);
 				}
 				break;
 			case ASSET_CONTEXT_ENVMAPS:
 				if (asset->index > -1) {
-					name = va("envmaps/envmap_%s", asset->name);
+					g_snprintf(name, sizeof(name), "envmaps/envmap_%s", asset->name);
 				} else if (!g_str_has_prefix(asset->name, "envmaps/")) {
-					name = va("envmaps/%s", asset->name);
+					g_snprintf(name, sizeof(name), "envmaps/%s", asset->name);
 				}
 				break;
 			case ASSET_CONTEXT_FLARES:
 				if (asset->index > -1) {
-					name = va("flares/flare_%s", asset->name);
+					g_snprintf(name, sizeof(name), "flares/flare_%s", asset->name);
 				} else if (!g_str_has_prefix(asset->name, "flares/")) {
-					name = va("flares/%s", asset->name);
+					g_snprintf(name, sizeof(name), "flares/%s", asset->name);
 				}
 				break;
 		}

--- a/src/collision/cm_material.c
+++ b/src/collision/cm_material.c
@@ -993,8 +993,10 @@ static void Cm_ResolveStageAnimation(cm_stage_t *stage, cm_asset_context_t type)
 			c--;
 		}
 
+		c++;
+
 		int32_t start = (int32_t) strtol(c, NULL, 10);
-		*(c + 1) = '\0';
+		*c = '\0';
 
 		for (uint16_t i = 0; i < stage->anim.num_frames; i++) {
 

--- a/src/collision/cm_material.c
+++ b/src/collision/cm_material.c
@@ -1221,17 +1221,29 @@ static void Cm_WriteMaterial(const cm_material_t *material, file_t *file) {
 }
 
 /**
+ * @brief GCompareFunc for Cm_WriteMaterials.
+ */
+gint Cm_WriteMaterials_compare(gconstpointer a, gconstpointer b) {
+	return g_strcmp0(((const cm_material_t *) a)->name, ((const cm_material_t *) b)->name);
+}
+
+/**
  * @brief Serialize the material(s) into the specified file.
  */
-ssize_t Cm_WriteMaterials(const char *path, const GList *materials) {
+ssize_t Cm_WriteMaterials(const char *path, GList *materials) {
 
 	ssize_t count = -1;
 	file_t *file = Fs_OpenWrite(path);
 	if (file) {
 		count = 0;
-		for (const GList *list = materials; list; list = list->next, count++) {
+
+		GList *sorted = g_list_sort(g_list_copy(materials), Cm_WriteMaterials_compare);
+
+		for (const GList *list = sorted; list; list = list->next, count++) {
 			Cm_WriteMaterial((cm_material_t *) list->data, file);
 		}
+
+		g_list_free(sorted);
 
 		Fs_Close(file);
 		Com_Print("Wrote %zd materials to %s\n", count, path);

--- a/src/collision/cm_material.h
+++ b/src/collision/cm_material.h
@@ -250,13 +250,21 @@ typedef struct cm_material_s {
 	uint16_t num_stages;
 } cm_material_t;
 
+/**
+ * @brief An immutable array of material references.
+ */
+typedef struct {
+	cm_material_t **materials;
+	size_t count;
+} cm_material_list_t;
+
 cm_material_t *Cm_AllocMaterial(const char *name);
 void Cm_ResolveMaterial(cm_material_t *material, cm_asset_context_t context);
 void Cm_FreeMaterial(cm_material_t *material);
-void Cm_FreeMaterialList(cm_material_t **materials);
+void Cm_FreeMaterialList(cm_material_list_t *materials, _Bool full);
 
-cm_material_t **Cm_LoadMaterials(const char *path, size_t *count);
-void Cm_WriteMaterials(const char *path, const cm_material_t **materials, const size_t num_materials);
+size_t Cm_LoadMaterials(const char *path, cm_material_list_t *materials);
+void Cm_WriteMaterials(const char *path, const cm_material_list_t *materials);
 
 void Cm_MaterialBasename(const char *in, char *out, size_t len);
 

--- a/src/collision/cm_material.h
+++ b/src/collision/cm_material.h
@@ -255,7 +255,7 @@ void Cm_FreeMaterial(cm_material_t *material);
 void Cm_FreeMaterials(GList *materials, _Bool full);
 ssize_t Cm_LoadMaterials(const char *path, GList **materials);
 void Cm_ResolveMaterial(cm_material_t *material, cm_asset_context_t context);
-ssize_t Cm_WriteMaterials(const char *path, const GList *materials);
+ssize_t Cm_WriteMaterials(const char *path, GList *materials);
 
 void Cm_MaterialBasename(const char *in, char *out, size_t len);
 

--- a/src/collision/cm_material.h
+++ b/src/collision/cm_material.h
@@ -169,7 +169,7 @@ typedef struct cm_material_s {
 	cm_asset_t normalmap;
 
 	/**
-	 * @brief The heightmap asset (optional, merged into normalmap).
+	 * @brief The heightmap asset.
 	 */
 	cm_asset_t heightmap;
 
@@ -254,7 +254,7 @@ cm_material_t *Cm_AllocMaterial(const char *name);
 void Cm_FreeMaterial(cm_material_t *material);
 void Cm_FreeMaterials(GList *materials, _Bool full);
 ssize_t Cm_LoadMaterials(const char *path, GList **materials);
-void Cm_ResolveMaterial(cm_material_t *material, cm_asset_context_t context);
+_Bool Cm_ResolveMaterial(cm_material_t *material, cm_asset_context_t context);
 ssize_t Cm_WriteMaterials(const char *path, GList *materials);
 
 void Cm_MaterialBasename(const char *in, char *out, size_t len);

--- a/src/collision/cm_material.h
+++ b/src/collision/cm_material.h
@@ -250,21 +250,12 @@ typedef struct cm_material_s {
 	uint16_t num_stages;
 } cm_material_t;
 
-/**
- * @brief An immutable array of material references.
- */
-typedef struct {
-	cm_material_t **materials;
-	size_t count;
-} cm_material_list_t;
-
 cm_material_t *Cm_AllocMaterial(const char *name);
-void Cm_ResolveMaterial(cm_material_t *material, cm_asset_context_t context);
 void Cm_FreeMaterial(cm_material_t *material);
-void Cm_FreeMaterialList(cm_material_list_t *materials, _Bool full);
-
-size_t Cm_LoadMaterials(const char *path, cm_material_list_t *materials);
-void Cm_WriteMaterials(const char *path, const cm_material_list_t *materials);
+void Cm_FreeMaterials(GList *materials, _Bool full);
+ssize_t Cm_LoadMaterials(const char *path, GList **materials);
+void Cm_ResolveMaterial(cm_material_t *material, cm_asset_context_t context);
+ssize_t Cm_WriteMaterials(const char *path, const GList *materials);
 
 void Cm_MaterialBasename(const char *in, char *out, size_t len);
 

--- a/src/collision/cm_material.h
+++ b/src/collision/cm_material.h
@@ -23,6 +23,21 @@
 
 #include "cm_types.h"
 
+typedef enum {
+	ASSET_CONTEXT_NONE,
+	ASSET_CONTEXT_TEXTURES,
+	ASSET_CONTEXT_MODELS,
+	ASSET_CONTEXT_PLAYERS,
+	ASSET_CONTEXT_ENVMAPS,
+	ASSET_CONTEXT_FLARES,
+} cm_asset_context_t;
+
+typedef struct {
+	char name[MAX_QPATH];
+	char path[MAX_QPATH];
+	int32_t index;
+} cm_asset_t;
+
 typedef struct {
 	uint32_t src, dest;
 } cm_stage_blend_t;
@@ -60,6 +75,7 @@ typedef struct {
 // frame based material animation, lerp between consecutive images
 typedef struct {
 	uint16_t num_frames;
+	cm_asset_t *frames;
 	vec_t fps;
 } cm_stage_anim_t;
 
@@ -73,8 +89,7 @@ typedef enum {
 
 typedef struct cm_stage_s {
 	uint32_t flags;
-	char image[MAX_QPATH];
-	int32_t image_index;
+	cm_asset_t asset;
 	cm_stage_blend_t blend;
 	vec3_t color;
 
@@ -132,30 +147,41 @@ typedef enum {
 #define DEFAULT_LIGHT 300.0
 
 typedef struct cm_material_s {
-	/**
-	 * @brief The base name of this material without suffixes
-	 */
-	char base[MAX_QPATH];
 
 	/**
-	 * @brief The image to use for the diffuse map
+	 * @brief The material name, as it appears in the materials file.
 	 */
-	char diffuse[MAX_QPATH];
+	char name[MAX_QPATH];
 
 	/**
-	 * @brief The image to use for the normal map
+	 * @brief The base name of this material without any diffuse suffix.
 	 */
-	char normalmap[MAX_QPATH];
+	char basename[MAX_QPATH];
 
 	/**
-	 * @brief The image to use for the specular/shiny map
+	 * @brief The diffuse asset.
 	 */
-	char specularmap[MAX_QPATH];
+	cm_asset_t diffuse;
 
 	/**
-	 * @brief The image to use for the tint map
+	 * @brief The normalmap asset.
 	 */
-	char tintmap[MAX_QPATH];
+	cm_asset_t normalmap;
+
+	/**
+	 * @brief The heightmap asset (optional, merged into normalmap).
+	 */
+	cm_asset_t heightmap;
+
+	/**
+	 * @brief The specularmap asset.
+	 */
+	cm_asset_t specularmap;
+
+	/**
+	 * @brief The tintmap asset.
+	 */
+	cm_asset_t tintmap;
 
 	/**
 	 * @brief Flags for the material.
@@ -224,14 +250,15 @@ typedef struct cm_material_s {
 	uint16_t num_stages;
 } cm_material_t;
 
-cm_material_t *Cm_AllocMaterial(const char *diffuse);
+cm_material_t *Cm_AllocMaterial(const char *name);
+void Cm_ResolveMaterial(cm_material_t *material, cm_asset_context_t context);
 void Cm_FreeMaterial(cm_material_t *material);
 void Cm_FreeMaterialList(cm_material_t **materials);
 
 cm_material_t **Cm_LoadMaterials(const char *path, size_t *count);
-void Cm_WriteMaterials(const char *filename, const cm_material_t **materials, const size_t num_materials);
+void Cm_WriteMaterials(const char *path, const cm_material_t **materials, const size_t num_materials);
 
-void Cm_NormalizeMaterialName(const char *in, char *out, size_t len);
+void Cm_MaterialBasename(const char *in, char *out, size_t len);
 
 #ifdef __CM_LOCAL_H__
 #endif /* __CM_LOCAL_H__ */

--- a/src/collision/cm_model.c
+++ b/src/collision/cm_model.c
@@ -285,11 +285,11 @@ static void Cm_LoadBspAreaPortals(void) {
  */
 static void Cm_LoadBspMaterials(const char *name) {
 
-	char base[MAX_QPATH];
-	StripExtension(Basename(name), base);
+	char path[MAX_QPATH];
+	g_snprintf(path, sizeof(path), "materials/%s.mat", Basename(name));
 
 	GList *materials = NULL;
-	Cm_LoadMaterials(va("materials/%s.mat", base), &materials);
+	Cm_LoadMaterials(path, &materials);
 
 	const bsp_texinfo_t *in = cm_bsp.bsp.texinfo;
 	for (int32_t i = 0; i < cm_bsp.bsp.num_texinfo; i++, in++) {

--- a/src/collision/cm_model.c
+++ b/src/collision/cm_model.c
@@ -85,8 +85,8 @@ static void Cm_LoadBspSurfaces(void) {
 		out->flags = in->flags;
 		out->value = in->value;
 
-		for (size_t i = 0; i < cm_bsp.num_materials; i++) {
-			cm_material_t *material = cm_bsp.materials[i];
+		for (size_t i = 0; i < cm_bsp.materials.count; i++) {
+			cm_material_t *material = cm_bsp.materials.materials[i];
 
 			if (!g_strcmp0(out->name, material->name)) {
 				out->material = material;
@@ -282,12 +282,12 @@ static void Cm_LoadBspAreaPortals(void) {
 /**
  * @brief
  */
-static cm_material_t **Cm_LoadBspMaterials(const char *name, size_t *count) {
+static size_t Cm_LoadBspMaterials(const char *name) {
 
 	char base[MAX_QPATH];
 	StripExtension(Basename(name), base);
 
-	return Cm_LoadMaterials(va("materials/%s.mat", base), count);
+	return Cm_LoadMaterials(va("materials/%s.mat", base), &cm_bsp.materials);
 }
 
 /**
@@ -295,12 +295,7 @@ static cm_material_t **Cm_LoadBspMaterials(const char *name, size_t *count) {
  */
 static void Cm_UnloadBspMaterials(void) {
 
-	for (size_t i = 0; i < cm_bsp.num_materials; i++) {
-		Cm_FreeMaterial(cm_bsp.materials[i]);
-	}
-
-	Cm_FreeMaterialList(cm_bsp.materials);
-	cm_bsp.materials = NULL;
+	Cm_FreeMaterialList(&cm_bsp.materials, true);
 }
 
 /**
@@ -392,7 +387,7 @@ cm_bsp_model_t *Cm_LoadBspModel(const char *name, int64_t *size) {
 
 	Fs_Free(file);
 
-	cm_bsp.materials = Cm_LoadBspMaterials(name, &cm_bsp.num_materials);
+	Cm_LoadBspMaterials(name);
 
 	Cm_LoadBspPlanes();
 	Cm_LoadBspNodes();
@@ -458,8 +453,8 @@ const char *Cm_EntityString(void) {
  * @brief
  */
 const cm_material_t **Cm_MapMaterials(size_t *num_materials) {
-	*num_materials = cm_bsp.num_materials;
-	return (const cm_material_t **) cm_bsp.materials;
+	*num_materials = cm_bsp.materials.count;
+	return (const cm_material_t **) cm_bsp.materials.materials;
 }
 
 /**

--- a/src/collision/cm_model.c
+++ b/src/collision/cm_model.c
@@ -85,14 +85,10 @@ static void Cm_LoadBspSurfaces(void) {
 		out->flags = in->flags;
 		out->value = in->value;
 
-		char material_name[MAX_QPATH];
-		g_snprintf(material_name, sizeof(material_name), "textures/%s", out->name);
-		Cm_NormalizeMaterialName(material_name, material_name, sizeof(material_name));
-
 		for (size_t i = 0; i < cm_bsp.num_materials; i++) {
 			cm_material_t *material = cm_bsp.materials[i];
 
-			if (!g_strcmp0(material->base, material_name)) {
+			if (!g_strcmp0(out->name, material->name)) {
 				out->material = material;
 				break;
 			}

--- a/src/collision/cm_model.h
+++ b/src/collision/cm_model.h
@@ -30,7 +30,6 @@ int32_t Cm_NumClusters(void);
 int32_t Cm_NumModels(void);
 
 const char *Cm_EntityString(void);
-const cm_material_t **Cm_MapMaterials(size_t *num_materials);
 const char *Cm_WorldspawnValue(const char *key);
 
 int32_t Cm_LeafContents(const int32_t leaf_num);
@@ -55,7 +54,8 @@ typedef struct {
 	_Bool *portal_open;
 	int32_t flood_valid;
 
-	cm_material_list_t materials;
+	cm_material_t **materials;
+	size_t num_materials;
 } cm_bsp_t;
 
 cm_bsp_t *Cm_Bsp(void);

--- a/src/collision/cm_model.h
+++ b/src/collision/cm_model.h
@@ -55,8 +55,7 @@ typedef struct {
 	_Bool *portal_open;
 	int32_t flood_valid;
 
-	cm_material_t **materials;
-	size_t num_materials;
+	cm_material_list_t materials;
 } cm_bsp_t;
 
 cm_bsp_t *Cm_Bsp(void);

--- a/src/tools/quemap/Makefile.am
+++ b/src/tools/quemap/Makefile.am
@@ -11,6 +11,7 @@ noinst_HEADERS = \
 	qlight.h \
 	qmat.h \
 	qvis.h \
+	qzip.h \
 	scriptlib.h
 
 quemap_SOURCES = \

--- a/src/tools/quemap/main.c
+++ b/src/tools/quemap/main.c
@@ -130,11 +130,11 @@ static void Init(void) {
 
 	Mem_Init();
 
+	Mon_Init();
+
 	Fs_Init(FS_AUTO_LOAD_ARCHIVES);
 
 	Sem_Init();
-
-	xmlInitParser();
 
 	Com_Print("Quetoo Map %s %s %s %s initialized\n", VERSION, __DATE__, BUILD_HOST, REVISION);
 }
@@ -452,7 +452,7 @@ int32_t main(int32_t argc, char **argv) {
 		}
 
 		if (!g_strcmp0(Com_Argv(i), "-c") || !g_strcmp0(Com_Argv(i), "-connect")) {
-			is_monitor = Mon_Init(Com_Argv(i + 1));
+			is_monitor = Mon_Connect(Com_Argv(i + 1));
 			continue;
 		}
 	}

--- a/src/tools/quemap/map.c
+++ b/src/tools/quemap/map.c
@@ -471,7 +471,7 @@ static _Bool MakeBrushWindings(map_brush_t *ob) {
  */
 static void SetMaterialFlags(side_t *side, map_brush_texture_t *td) {
 
-	const cm_material_t *material = LoadMaterial(td->name);
+	const cm_material_t *material = LoadMaterial(td->name, ASSET_CONTEXT_TEXTURES);
 	if (material) {
 		if (material->contents) {
 			if (side->contents == 0) {

--- a/src/tools/quemap/materials.c
+++ b/src/tools/quemap/materials.c
@@ -54,19 +54,17 @@ void FreeMaterials(void) {
  */
 cm_material_t *LoadMaterial(const char *name) {
 
-	const char *diffuse = va("textures/%s", name);
-
 	for (guint i = 0; i < materials->len; i++) {
 		cm_material_t *material = g_ptr_array_index(materials, i);
-		if (!g_strcmp0(material->diffuse, diffuse)) {
+		if (!g_strcmp0(material->name, name)) {
 			return material;
 		}
 	}
 
-	cm_material_t *material = Cm_AllocMaterial(diffuse);
+	cm_material_t *material = Cm_AllocMaterial(name);
 	g_ptr_array_add(materials, material);
 
-	Com_Debug(DEBUG_ALL, "Loaded material %s\n", diffuse);
+	Com_Debug(DEBUG_ALL, "Loaded material %s\n", name);
 
 	return material;
 }

--- a/src/tools/quemap/materials.c
+++ b/src/tools/quemap/materials.c
@@ -29,14 +29,14 @@ static GPtrArray *materials;
  */
 void LoadMaterials(void) {
 
-	size_t count;
-	cm_material_t **mats = Cm_LoadMaterials(va("materials/%s.mat", map_base), &count);
-	cm_material_t **material = mats;
-
 	materials = g_ptr_array_new_with_free_func((GDestroyNotify) Cm_FreeMaterial);
 	assert(materials);
 
-	for (size_t i = 0; i < count; i++, material++) {
+	cm_material_list_t mats;
+	Cm_LoadMaterials(va("materials/%s.mat", map_base), &mats);
+
+	cm_material_t **material = mats.materials;
+	for (size_t i = 0; i < mats.count; i++, material++) {
 		g_ptr_array_add(materials, *material);
 	}
 }
@@ -74,7 +74,12 @@ cm_material_t *LoadMaterial(const char *name) {
  */
 void WriteMaterialsFile(const char *filename) {
 
-	Cm_WriteMaterials(filename, (const cm_material_t **) materials->pdata, materials->len);
+	const cm_material_list_t mats = {
+		.materials = (cm_material_t **) materials->pdata,
+		.count = materials->len
+	};
 
-	Com_Print("Generated %d materials\n", materials->len);
+	Cm_WriteMaterials(filename, &mats);
+
+	Com_Print("Generated %zd materials\n", mats.count);
 }

--- a/src/tools/quemap/materials.c
+++ b/src/tools/quemap/materials.c
@@ -29,8 +29,11 @@ static GList *materials;
  */
 void LoadMaterials(void) {
 
+	char path[MAX_QPATH];
+	g_snprintf(path, sizeof(path), "materials/%s.mat", map_base);
+
 	materials = NULL;
-	Cm_LoadMaterials(va("materials/%s.mat", map_base), &materials);
+	Cm_LoadMaterials(path, &materials);
 }
 
 /**

--- a/src/tools/quemap/monitor.c
+++ b/src/tools/quemap/monitor.c
@@ -187,13 +187,11 @@ void Mon_SendWinding_(const char *func, mon_level_t level, const vec3_t p[], uin
 }
 
 /**
- * @brief Initialize BSP monitoring facilities (XML over TCP).
+ * @brief Connects to the specified host for XML process monitoring.
  */
-_Bool Mon_Init(const char *host) {
+_Bool Mon_Connect(const char *host) {
 
 	Net_Init();
-
-	memset(&mon_state, 0, sizeof(mon_state));
 
 	if ((mon_state.socket = Net_Connect(host, NULL))) {
 		Mem_InitBuffer(&mon_state.message, mon_state.buffer, sizeof(mon_state.buffer));
@@ -225,6 +223,16 @@ _Bool Mon_Init(const char *host) {
 	}
 
 	return false;
+}
+
+/**
+ * @brief Initialize BSP monitoring facilities (XML over TCP).
+ */
+void Mon_Init(void) {
+
+	memset(&mon_state, 0, sizeof(mon_state));
+
+	xmlInitParser();
 }
 
 /**

--- a/src/tools/quemap/monitor.h
+++ b/src/tools/quemap/monitor.h
@@ -39,5 +39,6 @@ void Mon_SendPoint_(const char *func, mon_level_t level, const vec3_t p, const c
 #define Mon_SendWinding(l, p, n, msg) Mon_SendWinding_(__func__, l, p, n, msg)
 #define Mon_SendPoint(l, p, msg) Mon_SendPoint_(__func__, l, p, msg)
 
-_Bool Mon_Init(const char *host);
+void Mon_Init(void);
+_Bool Mon_Connect(const char *host);
 void Mon_Shutdown(const char *msg);

--- a/src/tools/quemap/qbsp.c
+++ b/src/tools/quemap/qbsp.c
@@ -333,7 +333,7 @@ int32_t BSP_Main(void) {
 
 	const time_t start = time(NULL);
 
-	LoadMaterials();
+	LoadMaterials(va("materials/%s.mat", map_base), ASSET_CONTEXT_TEXTURES, NULL);
 
 	// if onlyents, just grab the entities and re-save
 	if (onlyents) {

--- a/src/tools/quemap/qmat.c
+++ b/src/tools/quemap/qmat.c
@@ -36,17 +36,20 @@ int32_t MAT_Main(void) {
 
 	Bsp_AllocLump(&bsp_file, BSP_LUMP_TEXINFO, MAX_BSP_TEXINFO);
 
-	LoadMaterials();
+	char path[MAX_QPATH];
+	g_snprintf(path, sizeof(path), "materials/%s.mat", map_base);
+
+	LoadMaterials(path, ASSET_CONTEXT_TEXTURES, NULL);
 
 	LoadMapFile(map_name);
 
 	for (int32_t i = 0; i < bsp_file.num_texinfo; i++) {
-		LoadMaterial(bsp_file.texinfo[i].texture);
+		LoadMaterial(bsp_file.texinfo[i].texture, ASSET_CONTEXT_TEXTURES);
 	}
 
 	UnloadScriptFiles();
 
-	WriteMaterialsFile(va("materials/%s.mat", map_base));
+	WriteMaterialsFile(path);
 
 	FreeMaterials();
 

--- a/src/tools/quemap/qzip.h
+++ b/src/tools/quemap/qzip.h
@@ -18,11 +18,10 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
  */
+
 #pragma once
 
-#include "collision/cm_material.h"
+#include "deps/minizip/zip.h"
 
-ssize_t LoadMaterials(const char *path, cm_asset_context_t context, GList **materials);
-cm_material_t *LoadMaterial(const char *diffuse, cm_asset_context_t context);
-ssize_t WriteMaterialsFile(const char *filename);
-void FreeMaterials(void);
+#include "qbsp.h"
+#include "materials.h"


### PR DESCRIPTION
The main goal of this PR is to centralize material asset resolution, so that we have a single code path for gathering all of the file resources that comprise materials. This is important so that quemap and quetoo agree on which assets are required.

Along the way, I decided that mutable materials collections (GList) are really useful, so the generic material loading entry points now use those. The way these functions work now (taking in `GList **`), you can easily merge multiple materials files into a single collection, which might come in handy.

Another fix with this change is that now _every_ texinfo, in collision-land and renderer-land, now has a material, always. This was not the case with the previous implementation. And all of the materials used by a model (all formats) are now available on `r_model_t` directly.

This means that the cgame no longer requires a special entry point to lookup map materials, and the cgame works directly with the renderer's copies of materials, rather than the collision model's copies. This will allow us to edit footstep sounds and other cgame-dependent functionality in the in-game editor.

This is not ready yet, as the actual changes to quemap are not yet pushed. But I wanted to get your input on the changes overall as this shapes up.