### PR TITLE
Paril/lmcache

### DIFF
--- a/Quetoo.vs15/quetoo.vcxproj.user
+++ b/Quetoo.vs15/quetoo.vcxproj.user
@@ -12,9 +12,9 @@
     <LocalDebuggerCommandArguments>+set sv_max_clients 8 +set r_get_error 1 +set g_hook 1 +map edge</LocalDebuggerCommandArguments>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <LocalDebuggerCommandArguments>-p G:\quake2\baseq2 -p G:\quake2\ctf -p G:\quake2\lmctf -p G:\quake2\3tctf</LocalDebuggerCommandArguments>
+    <LocalDebuggerCommandArguments>-p G:\quake2\baseq2 -p G:\quake2\ctf -p G:\quake2\lmctf -p G:\quake2\3tctf +set threads 0 +set sv_max_clients 8 +set g_cheats 1 +set verbose 1</LocalDebuggerCommandArguments>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <LocalDebuggerCommandArguments>-p G:\quake2\baseq2 -p G:\quake2\ctf -p G:\quake2\lmctf -p G:\quake2\3tctf +set threads 0 +set sv_max_clients 8 +map edge</LocalDebuggerCommandArguments>
+    <LocalDebuggerCommandArguments>-p G:\quake2\baseq2 -p G:\quake2\ctf -p G:\quake2\lmctf -p G:\quake2\3tctf +set threads 0 +set sv_max_clients 8 +set g_cheats 1 +set verbose 1</LocalDebuggerCommandArguments>
   </PropertyGroup>
 </Project>

--- a/src/client/renderer/r_atlas.c
+++ b/src/client/renderer/r_atlas.c
@@ -114,8 +114,8 @@ static void R_AtlasPacker_Reserve(r_packer_t *packer, const uint32_t new_nodes) 
  * @brief Initialize an r_packer_t structure. If the packer is already
  * created, clears the packer back to an initial state.
  */
-void R_AtlasPacker_InitPacker(r_packer_t *packer, const uint32_t max_width, const uint32_t max_height,
-                              const uint32_t root_width, const uint32_t root_height, const uint32_t initial_size) {
+void R_AtlasPacker_InitPacker(r_packer_t *packer, const uint16_t max_width, const uint16_t max_height,
+                              const uint16_t root_width, const uint16_t root_height, const uint32_t initial_size) {
 
 	packer->max_width = max_width;
 	packer->max_height = max_height;
@@ -152,8 +152,8 @@ void R_AtlasPacker_FreePacker(r_packer_t *packer) {
 /**
  * @brief Finds a free node that is big enough to hold us.
  */
-r_packer_node_t *R_AtlasPacker_FindNode(r_packer_t *packer, const uint32_t root, const uint32_t width,
-                                        const uint32_t height) {
+r_packer_node_t *R_AtlasPacker_FindNode(r_packer_t *packer, const uint32_t root, const uint16_t width,
+                                        const uint16_t height) {
 
 	uint32_t node_queue[packer->num_nodes];
 	uint32_t node_index = 1;
@@ -185,8 +185,8 @@ r_packer_node_t *R_AtlasPacker_FindNode(r_packer_t *packer, const uint32_t root,
 /**
  * @brief Split a packer node into two, assigning the first to the image.
  */
-r_packer_node_t *R_AtlasPacker_SplitNode(r_packer_t *packer, r_packer_node_t *node, const uint32_t width,
-        const uint32_t height) {
+r_packer_node_t *R_AtlasPacker_SplitNode(r_packer_t *packer, r_packer_node_t *node, const uint16_t width,
+        const uint16_t height) {
 	const uintptr_t index = (uintptr_t) (node - packer->nodes);
 
 	node->down = packer->num_nodes;
@@ -228,7 +228,7 @@ r_packer_node_t *R_AtlasPacker_SplitNode(r_packer_t *packer, r_packer_node_t *no
 /**
  * @brief Grow the packer in the specified direction.
  */
-static r_packer_node_t *R_AtlasPacker_Grow(r_packer_t *packer, const uint32_t width, const uint32_t height,
+static r_packer_node_t *R_AtlasPacker_Grow(r_packer_t *packer, const uint16_t width, const uint16_t height,
         const _Bool grow_direction) {
 	const uint32_t new_root_id = packer->num_nodes;
 	const uint32_t new_connect_id = packer->num_nodes + 1;
@@ -287,7 +287,7 @@ static r_packer_node_t *R_AtlasPacker_Grow(r_packer_t *packer, const uint32_t wi
 /**
  * @brief Checks to see where the packer should grow into next. This keeps the atlas square.
  */
-r_packer_node_t *R_AtlasPacker_GrowNode(r_packer_t *packer, const uint32_t width, const uint32_t height) {
+r_packer_node_t *R_AtlasPacker_GrowNode(r_packer_t *packer, const uint16_t width, const uint16_t height) {
 	const r_packer_node_t *root = &packer->nodes[packer->root];
 
 	const _Bool canGrowDown = (width <= root->width);
@@ -394,8 +394,8 @@ static void R_GenerateAtlasMips(r_atlas_t *atlas, r_atlas_params_t *params) {
 	for (uint16_t i = 0; i < params->num_mips; i++) {
 		const uint16_t mip_scale = 1 << i;
 
-		const uint32_t mip_width = params->width / mip_scale;
-		const uint32_t mip_height = params->height / mip_scale;
+		const uint16_t mip_width = params->width / mip_scale;
+		const uint16_t mip_height = params->height / mip_scale;
 
 		R_BindDiffuseTexture(atlas->image.texnum);
 
@@ -427,8 +427,8 @@ static void R_GenerateAtlasMips(r_atlas_t *atlas, r_atlas_params_t *params) {
 			// push them into the atlas
 			R_BindDiffuseTexture(atlas->image.texnum);
 
-			const uint32_t subimage_x = image->position[0] / mip_scale;
-			const uint32_t subimage_y = image->position[1] / mip_scale;
+			const uint16_t subimage_x = image->position[0] / mip_scale;
+			const uint16_t subimage_y = image->position[1] / mip_scale;
 
 			glTexSubImage2D(GL_TEXTURE_2D, i, subimage_x, subimage_y, image_mip_width, image_mip_height, GL_RGBA, GL_UNSIGNED_BYTE,
 			                subimage_pixels);

--- a/src/client/renderer/r_atlas.c
+++ b/src/client/renderer/r_atlas.c
@@ -100,21 +100,21 @@ const r_atlas_image_t *R_GetAtlasImageFromAtlas(const r_atlas_t *atlas, const r_
 /**
  * @brief See if we have enough space for n number of nodes.
  */
-static void R_AtlasPacker_Reserve(r_packer_t *packer, const uint32_t new_nodes) {
+static void R_AtlasPacker_Reserve(r_atlas_packer_t *packer, const uint32_t new_nodes) {
 
 	// make sure we have at least n new entries
 	if (packer->num_alloc_nodes <= packer->num_nodes + new_nodes) {
 
 		packer->num_alloc_nodes = (packer->num_nodes + new_nodes) * 2;
-		packer->nodes = Mem_Realloc(packer->nodes, sizeof(r_packer_node_t) * packer->num_alloc_nodes);
+		packer->nodes = Mem_Realloc(packer->nodes, sizeof(r_atlas_packer_node_t) * packer->num_alloc_nodes);
 	}
 }
 
 /**
- * @brief Initialize an r_packer_t structure. If the packer is already
+ * @brief Initialize an r_atlas_packer_t structure. If the packer is already
  * created, clears the packer back to an initial state.
  */
-void R_AtlasPacker_InitPacker(r_packer_t *packer, const uint16_t max_width, const uint16_t max_height,
+void R_AtlasPacker_InitPacker(r_atlas_packer_t *packer, const uint16_t max_width, const uint16_t max_height,
                               const uint16_t root_width, const uint16_t root_height, const uint32_t initial_size) {
 
 	packer->max_width = max_width;
@@ -129,7 +129,7 @@ void R_AtlasPacker_InitPacker(r_packer_t *packer, const uint16_t max_width, cons
 		packer->num_nodes = 0;
 	}
 
-	packer->nodes[0] = (const r_packer_node_t) {
+	packer->nodes[0] = (const r_atlas_packer_node_t) {
 		.width = root_width,
 		 .height = root_height,
 		  .right = -1,
@@ -143,7 +143,7 @@ void R_AtlasPacker_InitPacker(r_packer_t *packer, const uint16_t max_width, cons
 /**
  * @brief Free data created by R_AtlasPacker_InitPacker
  */
-void R_AtlasPacker_FreePacker(r_packer_t *packer) {
+void R_AtlasPacker_FreePacker(r_atlas_packer_t *packer) {
 
 	Mem_Free(packer->nodes);
 	packer->nodes = NULL;
@@ -152,7 +152,7 @@ void R_AtlasPacker_FreePacker(r_packer_t *packer) {
 /**
  * @brief Finds a free node that is big enough to hold us.
  */
-r_packer_node_t *R_AtlasPacker_FindNode(r_packer_t *packer, const uint32_t root, const uint16_t width,
+r_atlas_packer_node_t *R_AtlasPacker_FindNode(r_atlas_packer_t *packer, const uint32_t root, const uint16_t width,
                                         const uint16_t height) {
 
 	uint32_t node_queue[packer->num_nodes];
@@ -163,7 +163,7 @@ r_packer_node_t *R_AtlasPacker_FindNode(r_packer_t *packer, const uint32_t root,
 	do {
 
 		uint32_t node_id = node_queue[--node_index];
-		r_packer_node_t *node = &packer->nodes[node_id];
+		r_atlas_packer_node_t *node = &packer->nodes[node_id];
 
 		// TODO: this line is still hot. It's better without the boolean,
 		// but it's weird that this line causes the worst.
@@ -185,14 +185,14 @@ r_packer_node_t *R_AtlasPacker_FindNode(r_packer_t *packer, const uint32_t root,
 /**
  * @brief Split a packer node into two, assigning the first to the image.
  */
-r_packer_node_t *R_AtlasPacker_SplitNode(r_packer_t *packer, r_packer_node_t *node, const uint16_t width,
+r_atlas_packer_node_t *R_AtlasPacker_SplitNode(r_atlas_packer_t *packer, r_atlas_packer_node_t *node, const uint16_t width,
         const uint16_t height) {
 	const uintptr_t index = (uintptr_t) (node - packer->nodes);
 
 	node->down = packer->num_nodes;
 	node->right = packer->num_nodes + 1;
 
-	const r_packer_node_t down_node = (const r_packer_node_t) {
+	const r_atlas_packer_node_t down_node = (const r_atlas_packer_node_t) {
 		.width = node->width,
 		 .height = node->height - height,
 		  .x = node->x,
@@ -201,7 +201,7 @@ r_packer_node_t *R_AtlasPacker_SplitNode(r_packer_t *packer, r_packer_node_t *no
 		     .down = -1
 	};
 
-	const r_packer_node_t right_node = (const r_packer_node_t) {
+	const r_atlas_packer_node_t right_node = (const r_atlas_packer_node_t) {
 		.width = node->width - width,
 		 .height = height,
 		  .x = node->x + width,
@@ -228,24 +228,24 @@ r_packer_node_t *R_AtlasPacker_SplitNode(r_packer_t *packer, r_packer_node_t *no
 /**
  * @brief Grow the packer in the specified direction.
  */
-static r_packer_node_t *R_AtlasPacker_Grow(r_packer_t *packer, const uint16_t width, const uint16_t height,
+static r_atlas_packer_node_t *R_AtlasPacker_Grow(r_atlas_packer_t *packer, const uint16_t width, const uint16_t height,
         const _Bool grow_direction) {
 	const uint32_t new_root_id = packer->num_nodes;
 	const uint32_t new_connect_id = packer->num_nodes + 1;
-	const r_packer_node_t *old_root = &packer->nodes[packer->root];
+	const r_atlas_packer_node_t *old_root = &packer->nodes[packer->root];
 
 	R_AtlasPacker_Reserve(packer, 2);
 
 	if (grow_direction == GROW_RIGHT) {
 
-		packer->nodes[new_root_id] = (const r_packer_node_t) {
+		packer->nodes[new_root_id] = (const r_atlas_packer_node_t) {
 			.width = old_root->width + width,
 			 .height = old_root->height,
 			  .down = packer->root,
 			   .right = new_connect_id
 		};
 
-		packer->nodes[new_connect_id] = (const r_packer_node_t) {
+		packer->nodes[new_connect_id] = (const r_atlas_packer_node_t) {
 			.width = width,
 			 .height = old_root->height,
 			  .x = old_root->width,
@@ -255,14 +255,14 @@ static r_packer_node_t *R_AtlasPacker_Grow(r_packer_t *packer, const uint16_t wi
 		};
 	} else {
 
-		packer->nodes[new_root_id] = (const r_packer_node_t) {
+		packer->nodes[new_root_id] = (const r_atlas_packer_node_t) {
 			.width = old_root->width,
 			 .height = old_root->height + height,
 			  .right = packer->root,
 			   .down = new_connect_id
 		};
 
-		packer->nodes[new_connect_id] = (const r_packer_node_t) {
+		packer->nodes[new_connect_id] = (const r_atlas_packer_node_t) {
 			.width = old_root->width,
 			 .height = height,
 			  .x = 0,
@@ -275,7 +275,7 @@ static r_packer_node_t *R_AtlasPacker_Grow(r_packer_t *packer, const uint16_t wi
 	packer->num_nodes += 2;
 	packer->root = new_root_id;
 
-	r_packer_node_t *node = R_AtlasPacker_FindNode(packer, packer->root, width, height);
+	r_atlas_packer_node_t *node = R_AtlasPacker_FindNode(packer, packer->root, width, height);
 
 	if (node != NULL) {
 		return R_AtlasPacker_SplitNode(packer, node, width, height);
@@ -287,8 +287,8 @@ static r_packer_node_t *R_AtlasPacker_Grow(r_packer_t *packer, const uint16_t wi
 /**
  * @brief Checks to see where the packer should grow into next. This keeps the atlas square.
  */
-r_packer_node_t *R_AtlasPacker_GrowNode(r_packer_t *packer, const uint16_t width, const uint16_t height) {
-	const r_packer_node_t *root = &packer->nodes[packer->root];
+r_atlas_packer_node_t *R_AtlasPacker_GrowNode(r_atlas_packer_t *packer, const uint16_t width, const uint16_t height) {
+	const r_atlas_packer_node_t *root = &packer->nodes[packer->root];
 
 	const _Bool canGrowDown = (width <= root->width);
 	const _Bool canGrowRight = (height <= root->height);
@@ -328,7 +328,7 @@ static void R_StitchAtlas(r_atlas_t *atlas, r_atlas_params_t *params) {
 	params->width = params->height = 0;
 
 	// setup base packer parameters
-	r_packer_t packer;
+	r_atlas_packer_t packer;
 	memset(&packer, 0, sizeof(packer));
 
 	r_atlas_image_t *image = (r_atlas_image_t *) atlas->images->data;
@@ -337,7 +337,7 @@ static void R_StitchAtlas(r_atlas_t *atlas, r_atlas_params_t *params) {
 
 	// stitch!
 	for (uint16_t i = 0; i < atlas->images->len; i++, image++) {
-		r_packer_node_t *node = R_AtlasPacker_FindNode(&packer, packer.root, image->input_image->width,
+		r_atlas_packer_node_t *node = R_AtlasPacker_FindNode(&packer, packer.root, image->input_image->width,
 		                        image->input_image->height);
 
 		if (node != NULL) {
@@ -529,18 +529,18 @@ void R_CompileAtlas(r_atlas_t *atlas) {
 /**
  * @brief Serialize a packer to a file.
  */
-void R_AtlasPacker_Serialize(const r_packer_t *packer, file_t *file) {
+void R_AtlasPacker_Serialize(const r_atlas_packer_t *packer, file_t *file) {
 	
 	Fs_Write(file, &packer->num_nodes, sizeof(packer->num_nodes), 1);
 	Fs_Write(file, &packer->root, sizeof(packer->root), 1);
-	Fs_Write(file, packer->nodes, sizeof(r_packer_node_t), packer->num_nodes);
+	Fs_Write(file, packer->nodes, sizeof(r_atlas_packer_node_t), packer->num_nodes);
 }
 
 /**
  * @brief Unserialize packer from a file into the specified packer.
  * @returns bool if packer in file was invalid.
  */
-_Bool R_AtlasPacker_Unserialize(file_t *file, r_packer_t *packer) {
+_Bool R_AtlasPacker_Unserialize(file_t *file, r_atlas_packer_t *packer) {
 
 	// read the header
 	if (!Fs_Read(file, &packer->num_nodes, sizeof(packer->num_nodes), 1) ||
@@ -557,15 +557,15 @@ _Bool R_AtlasPacker_Unserialize(file_t *file, r_packer_t *packer) {
 	}
 
 	// see if the file even has enough room for this packer
-	if ((packer->num_nodes * sizeof(r_packer_node_t)) > (size_t) (Fs_FileLength(file) - Fs_Tell(file))) {
+	if ((packer->num_nodes * sizeof(r_atlas_packer_node_t)) > (size_t) (Fs_FileLength(file) - Fs_Tell(file))) {
 		return false;
 	}
 
 	// good to go!
-	packer->nodes = Mem_Malloc(sizeof(r_packer_node_t) * packer->num_nodes);
+	packer->nodes = Mem_Malloc(sizeof(r_atlas_packer_node_t) * packer->num_nodes);
 
 	// fatal somehow
-	if (Fs_Read(file, packer->nodes, sizeof(r_packer_node_t), packer->num_nodes) != packer->num_nodes) {
+	if (Fs_Read(file, packer->nodes, sizeof(r_atlas_packer_node_t), packer->num_nodes) != packer->num_nodes) {
 		R_AtlasPacker_FreePacker(packer);
 		return false;
 	}

--- a/src/client/renderer/r_atlas.h
+++ b/src/client/renderer/r_atlas.h
@@ -41,15 +41,15 @@ typedef struct {
 } r_packer_node_t;
 
 typedef struct {
-	uint32_t max_width;
-	uint32_t max_height;
-
+	// required if only reading
+	uint32_t num_nodes;
 	r_packer_node_t *nodes;
-	uint32_t num_nodes, num_alloc_nodes;
-
 	uint32_t root;
 
+	// required for writing
+	uint32_t num_alloc_nodes;
 	_Bool keep_square;
+	uint32_t max_width, max_height;
 } r_packer_t;
 
 void R_AtlasPacker_InitPacker(r_packer_t *packer, const uint32_t max_width, const uint32_t max_height,
@@ -60,6 +60,8 @@ r_packer_node_t *R_AtlasPacker_SplitNode(r_packer_t *packer, r_packer_node_t *no
         const uint32_t height);
 r_packer_node_t *R_AtlasPacker_FindNode(r_packer_t *packer, const uint32_t root, const uint32_t width,
                                         const uint32_t height);
+void R_AtlasPacker_Serialize(const r_packer_t *packer, file_t *file);
+_Bool R_AtlasPacker_Unserialize(file_t *file, r_packer_t *packer);
 
 void R_InitAtlas(void);
 

--- a/src/client/renderer/r_atlas.h
+++ b/src/client/renderer/r_atlas.h
@@ -38,30 +38,30 @@ typedef struct {
 
 	uint32_t right;
 	uint32_t down; // nodes to the right/below this one
-} r_packer_node_t;
+} r_atlas_packer_node_t;
 
 typedef struct {
 	// required if only reading
 	uint32_t num_nodes;
-	r_packer_node_t *nodes;
+	r_atlas_packer_node_t *nodes;
 	uint32_t root;
 
 	// required for writing
 	uint32_t num_alloc_nodes;
 	_Bool keep_square;
 	uint16_t max_width, max_height;
-} r_packer_t;
+} r_atlas_packer_t;
 
-void R_AtlasPacker_InitPacker(r_packer_t *packer, const uint16_t max_width, const uint16_t max_height,
+void R_AtlasPacker_InitPacker(r_atlas_packer_t *packer, const uint16_t max_width, const uint16_t max_height,
                               const uint16_t root_width, const uint16_t root_height, const uint32_t initial_size);
-void R_AtlasPacker_FreePacker(r_packer_t *packer);
-r_packer_node_t *R_AtlasPacker_GrowNode(r_packer_t *packer, const uint16_t width, const uint16_t height);
-r_packer_node_t *R_AtlasPacker_SplitNode(r_packer_t *packer, r_packer_node_t *node, const uint16_t width,
+void R_AtlasPacker_FreePacker(r_atlas_packer_t *packer);
+r_atlas_packer_node_t *R_AtlasPacker_GrowNode(r_atlas_packer_t *packer, const uint16_t width, const uint16_t height);
+r_atlas_packer_node_t *R_AtlasPacker_SplitNode(r_atlas_packer_t *packer, r_atlas_packer_node_t *node, const uint16_t width,
         const uint16_t height);
-r_packer_node_t *R_AtlasPacker_FindNode(r_packer_t *packer, const uint32_t root, const uint16_t width,
+r_atlas_packer_node_t *R_AtlasPacker_FindNode(r_atlas_packer_t *packer, const uint32_t root, const uint16_t width,
                                         const uint16_t height);
-void R_AtlasPacker_Serialize(const r_packer_t *packer, file_t *file);
-_Bool R_AtlasPacker_Unserialize(file_t *file, r_packer_t *packer);
+void R_AtlasPacker_Serialize(const r_atlas_packer_t *packer, file_t *file);
+_Bool R_AtlasPacker_Unserialize(file_t *file, r_atlas_packer_t *packer);
 
 void R_InitAtlas(void);
 

--- a/src/client/renderer/r_atlas.h
+++ b/src/client/renderer/r_atlas.h
@@ -31,10 +31,10 @@ void R_CompileAtlas(r_atlas_t *atlas);
 #ifdef __R_LOCAL_H__
 
 typedef struct {
-	uint32_t width;
-	uint32_t height;
-	uint32_t x;
-	uint32_t y;
+	uint16_t width;
+	uint16_t height;
+	uint16_t x;
+	uint16_t y;
 
 	uint32_t right;
 	uint32_t down; // nodes to the right/below this one
@@ -49,17 +49,17 @@ typedef struct {
 	// required for writing
 	uint32_t num_alloc_nodes;
 	_Bool keep_square;
-	uint32_t max_width, max_height;
+	uint16_t max_width, max_height;
 } r_packer_t;
 
-void R_AtlasPacker_InitPacker(r_packer_t *packer, const uint32_t max_width, const uint32_t max_height,
-                              const uint32_t root_width, const uint32_t root_height, const uint32_t initial_size);
+void R_AtlasPacker_InitPacker(r_packer_t *packer, const uint16_t max_width, const uint16_t max_height,
+                              const uint16_t root_width, const uint16_t root_height, const uint32_t initial_size);
 void R_AtlasPacker_FreePacker(r_packer_t *packer);
-r_packer_node_t *R_AtlasPacker_GrowNode(r_packer_t *packer, const uint32_t width, const uint32_t height);
-r_packer_node_t *R_AtlasPacker_SplitNode(r_packer_t *packer, r_packer_node_t *node, const uint32_t width,
-        const uint32_t height);
-r_packer_node_t *R_AtlasPacker_FindNode(r_packer_t *packer, const uint32_t root, const uint32_t width,
-                                        const uint32_t height);
+r_packer_node_t *R_AtlasPacker_GrowNode(r_packer_t *packer, const uint16_t width, const uint16_t height);
+r_packer_node_t *R_AtlasPacker_SplitNode(r_packer_t *packer, r_packer_node_t *node, const uint16_t width,
+        const uint16_t height);
+r_packer_node_t *R_AtlasPacker_FindNode(r_packer_t *packer, const uint32_t root, const uint16_t width,
+                                        const uint16_t height);
 void R_AtlasPacker_Serialize(const r_packer_t *packer, file_t *file);
 _Bool R_AtlasPacker_Unserialize(file_t *file, r_packer_t *packer);
 

--- a/src/client/renderer/r_bsp_model.c
+++ b/src/client/renderer/r_bsp_model.c
@@ -339,7 +339,7 @@ static void R_LoadBspSurfaces(r_bsp_model_t *bsp) {
 		// lastly lighting info
 		const int32_t ofs = in->light_ofs;
 		const byte *data = (ofs == -1) ? NULL : bsp->file->lightmap_data + ofs;
-
+	
 		// to create the lightmap and deluxemap
 		R_CreateBspSurfaceLightmap(bsp, out, data);
 

--- a/src/client/renderer/r_main.c
+++ b/src/client/renderer/r_main.c
@@ -80,6 +80,7 @@ cvar_t *r_stainmaps;
 cvar_t *r_supersample;
 cvar_t *r_texture_mode;
 cvar_t *r_swap_interval;
+cvar_t *r_lmcache;
 cvar_t *r_warp;
 cvar_t *r_width;
 cvar_t *r_windowed_height;
@@ -510,6 +511,7 @@ static void R_InitLocal(void) {
 	r_stainmaps = Cvar_Add("r_stainmaps", "1.0", CVAR_ARCHIVE, "Controls persistent stain effects.");
 	r_swap_interval = Cvar_Add("r_swap_interval", "1", CVAR_ARCHIVE | CVAR_R_CONTEXT, "Controls vertical refresh synchronization. 0 disables, 1 enables, -1 enables adaptive VSync.");
 	r_texture_mode = Cvar_Add("r_texture_mode", "GL_LINEAR_MIPMAP_LINEAR", CVAR_ARCHIVE | CVAR_R_MEDIA, "Specifies the active texture filtering mode");
+	r_lmcache = Cvar_Add("r_lmcache", "1", CVAR_ARCHIVE, "Controls whether or not the lightmap cache is used. Improve map loading times at the expense of a bit more hard drive usage.");
 	r_warp = Cvar_Add("r_warp", "1", CVAR_ARCHIVE, "Controls warping surface effects (e.g. water)");
 	r_width = Cvar_Add("r_width", "0", CVAR_ARCHIVE | CVAR_R_CONTEXT, NULL);
 	r_windowed_height = Cvar_Add("r_windowed_height", "1024", CVAR_ARCHIVE | CVAR_R_CONTEXT, NULL);

--- a/src/client/renderer/r_main.c
+++ b/src/client/renderer/r_main.c
@@ -80,7 +80,7 @@ cvar_t *r_stainmaps;
 cvar_t *r_supersample;
 cvar_t *r_texture_mode;
 cvar_t *r_swap_interval;
-cvar_t *r_lmcache;
+cvar_t *r_lightmap_cache;
 cvar_t *r_warp;
 cvar_t *r_width;
 cvar_t *r_windowed_height;
@@ -511,7 +511,7 @@ static void R_InitLocal(void) {
 	r_stainmaps = Cvar_Add("r_stainmaps", "1.0", CVAR_ARCHIVE, "Controls persistent stain effects.");
 	r_swap_interval = Cvar_Add("r_swap_interval", "1", CVAR_ARCHIVE | CVAR_R_CONTEXT, "Controls vertical refresh synchronization. 0 disables, 1 enables, -1 enables adaptive VSync.");
 	r_texture_mode = Cvar_Add("r_texture_mode", "GL_LINEAR_MIPMAP_LINEAR", CVAR_ARCHIVE | CVAR_R_MEDIA, "Specifies the active texture filtering mode");
-	r_lmcache = Cvar_Add("r_lmcache", "1", CVAR_ARCHIVE, "Controls whether or not the lightmap cache is used. Improve map loading times at the expense of a bit more hard drive usage.");
+	r_lightmap_cache = Cvar_Add("r_lightmap_cache", "1", CVAR_ARCHIVE, "Controls whether or not the lightmap cache is used. Improve map loading times at the expense of a bit more hard drive usage.");
 	r_warp = Cvar_Add("r_warp", "1", CVAR_ARCHIVE, "Controls warping surface effects (e.g. water)");
 	r_width = Cvar_Add("r_width", "0", CVAR_ARCHIVE | CVAR_R_CONTEXT, NULL);
 	r_windowed_height = Cvar_Add("r_windowed_height", "1024", CVAR_ARCHIVE | CVAR_R_CONTEXT, NULL);

--- a/src/client/renderer/r_main.h
+++ b/src/client/renderer/r_main.h
@@ -58,6 +58,7 @@ extern cvar_t *r_stainmaps;
 extern cvar_t *r_supersample;
 extern cvar_t *r_texture_mode;
 extern cvar_t *r_swap_interval;
+extern cvar_t *r_lmcache;
 extern cvar_t *r_warp;
 extern cvar_t *r_width;
 extern cvar_t *r_windowed_height;

--- a/src/client/renderer/r_main.h
+++ b/src/client/renderer/r_main.h
@@ -58,7 +58,7 @@ extern cvar_t *r_stainmaps;
 extern cvar_t *r_supersample;
 extern cvar_t *r_texture_mode;
 extern cvar_t *r_swap_interval;
-extern cvar_t *r_lmcache;
+extern cvar_t *r_lightmap_cache;
 extern cvar_t *r_warp;
 extern cvar_t *r_width;
 extern cvar_t *r_windowed_height;

--- a/src/collision/cm_model.c
+++ b/src/collision/cm_model.c
@@ -405,6 +405,7 @@ cm_bsp_model_t *Cm_LoadBspModel(const char *name, int64_t *size) {
 	// structures out of the raw file data
 	if (size) {
 		cm_bsp.size = *size = Bsp_Size(file);
+		cm_bsp.mod_time = Fs_LastModTime(name);
 	}
 
 	g_strlcpy(cm_bsp.name, name, sizeof(cm_bsp.name));

--- a/src/collision/cm_model.h
+++ b/src/collision/cm_model.h
@@ -39,6 +39,7 @@ int32_t Cm_LeafArea(const int32_t leaf_num);
 typedef struct {
 	char name[MAX_QPATH];
 	int64_t size;
+	int64_t mod_time;
 	bsp_file_t bsp;
 
 	cm_bsp_plane_t *planes;

--- a/src/filesystem.c
+++ b/src/filesystem.c
@@ -371,6 +371,14 @@ _Bool Fs_Rename(const char *source, const char *dest) {
 }
 
 /**
+ * @brief Fetch the "last modified" time for the specified file.
+ */
+int64_t Fs_LastModTime(const char *filename) {
+	return PHYSFS_getLastModTime(filename);
+}
+
+
+/**
  * @brief Unlinks (deletes) the specified file.
  */
 _Bool Fs_Unlink(const char *filename) {

--- a/src/filesystem.h
+++ b/src/filesystem.h
@@ -62,6 +62,7 @@ int64_t Fs_FileLength(file_t *file);
 int64_t Fs_Tell(file_t *file);
 int64_t Fs_Write(file_t *file, const void *buffer, size_t size, size_t count);
 int64_t Fs_Load(const char *filename, void **buffer);
+int64_t Fs_LastModTime(const char *filename);
 void Fs_Free(void *buffer);
 _Bool Fs_Rename(const char *source, const char *dest);
 _Bool Fs_Unlink(const char *filename);


### PR DESCRIPTION
This is more of a test concept, but it's cool to see in action. This adds a lightmap cache, which caches lightmap atlas outputs in your local game folder. It increases map load times by approximately 14x on subsequent loads (Wake down from 4300 ms to 340 ms, for instance). Fairly simple code for these returns, just not sure how you feel about the idea of a cache for this kind of thing. Let me know how you feel about it.