### PR TITLE
Clamp the console height variable to a sane value

### DIFF
--- a/src/client/cl_console.c
+++ b/src/client/cl_console.c
@@ -129,7 +129,7 @@ void Cl_DrawConsole(void) {
 
 	R_BindFont("small", &cw, &ch);
 
-	height = r_context.height * (cls.state == CL_ACTIVE ? cl_console_height->value : 1.0);
+	height = r_context.height * (cls.state == CL_ACTIVE ? Clamp(cl_console_height->value, 0.1, 1.0) : 1.0);
 
 	cl_console.width = r_context.width / cw;
 	cl_console.height = (height / ch) - 1;


### PR DESCRIPTION
This fixes #535.

![quetoo_clamp_console_height](https://user-images.githubusercontent.com/180032/36951109-c21e7abe-1fff-11e8-9bbf-920cc6ab750b.png)