### PR TITLE
Hide the crosshair while the player is dead

### DIFF
--- a/src/cgame/default/cg_hud.c
+++ b/src/cgame/default/cg_hud.c
@@ -611,6 +611,10 @@ static void Cg_DrawCrosshair(const player_state_t *ps) {
 		return; // spectating
 	}
 
+	if (!ps->stats[STAT_WEAPONS]) {
+		return; // dead
+	}
+
 	if (center_print.time > cgi.client->unclamped_time) {
 		return;
 	}


### PR DESCRIPTION
The crosshair is no longer displayed while the player is dead.