### PR TITLE
make map_name a cvar again, partially revert 21559d3

### DIFF
--- a/src/server/sv_init.c
+++ b/src/server/sv_init.c
@@ -302,6 +302,11 @@ static void Sv_LoadMedia(const char *server, sv_state_t state) {
 	}
 
 	g_snprintf(sv.config_strings[CS_BSP_SIZE], MAX_STRING_CHARS, "%" PRId64, bsp_size);
+
+	// do not delete: this cvar is defined in order to be sent within reply paquets
+	// to third-party server query tools and game server browsers implementing
+	// standard quake 2 server query protocol
+	Cvar_Add("map_name", sv.name, CVAR_SERVER_INFO | CVAR_NO_SET, "The name of the map that is currently played");
 }
 
 /**


### PR DESCRIPTION
The `map_name` cvar was deleted in commit 21559d3 (see [this deleted line](https://github.com/jdolan/quetoo/commit/21559d3f0e164d495986c232d942a76583475ea3#diff-0afaff94149a99dc7fb4e39f12fb35c1L306)).

This cvar is useful because it's expected to be written within server reply packet, it allows server query tools like [qstat](https://github.com/multiplay/qstat) and server browsers like [XQF](https://github.com/XQF/xqf) to get the name of the map currently played while listing servers to player. See #547.

I used the `map_name` cvar name that was used before deletion in 21559d3. If you prefer another name (like `sv_map_name` for example) I can change it.

Edit: `map_name` sounds to be a good name, it's coherent with `game_name`.