### PR TITLE
Fix ./configure --without-tools

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -322,10 +322,11 @@ dnl --------------------------
 
 AC_MSG_CHECKING(which tools to build)
 
-TOOLS="quemap quetoo-master quetoo-update"
+ALL_TOOLS="quemap quetoo-master quetoo-update"
+TOOLS=${ALL_TOOLS}
 
 AC_ARG_WITH(tools,
-	AS_HELP_STRING([--with-tools='quemap quetoo-master quetoo-update...'],
+	AS_HELP_STRING([--with-tools='${ALL_TOOLS}...'],
 		[build specified tools]
 	)
 )
@@ -336,6 +337,10 @@ fi
 
 if test ${TOOLS} = "no"; then
         TOOLS=""
+fi
+
+if test ${TOOLS} = "yes"; then
+        TOOLS="${ALL_TOOLS}"
 fi
 
 AC_SUBST(TOOLS)

--- a/configure.ac
+++ b/configure.ac
@@ -335,7 +335,7 @@ if test "x${with_tools}" != x; then
 fi
 
 if test ${TOOLS} = "no"; then
-        TOOLS="quetoo-master quetoo-update"
+        TOOLS=""
 fi
 
 AC_SUBST(TOOLS)

--- a/configure.ac
+++ b/configure.ac
@@ -334,6 +334,10 @@ if test "x${with_tools}" != x; then
 	TOOLS="${with_tools}"
 fi
 
+if test ${TOOLS} = "no"; then
+        TOOLS="quetoo-master quetoo-update"
+fi
+
 AC_SUBST(TOOLS)
 AC_MSG_RESULT($TOOLS)
 


### PR DESCRIPTION
This makes `./configure --without-tools` compile everything except `quemap`.

This fixes #551.