### PR TITLE
Materials changes in order to get the renderer right this time

### DIFF
--- a/Quetoo.xcodeproj/xcshareddata/xcschemes/quemap.xcscheme
+++ b/Quetoo.xcodeproj/xcshareddata/xcschemes/quemap.xcscheme
@@ -118,7 +118,7 @@
          </CommandLineArgument>
          <CommandLineArgument
             argument = "--antialias "
-            isEnabled = "NO">
+            isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument
             argument = "-zip"

--- a/Quetoo.xcodeproj/xcshareddata/xcschemes/quetoo-all.xcscheme
+++ b/Quetoo.xcodeproj/xcshareddata/xcschemes/quetoo-all.xcscheme
@@ -89,24 +89,8 @@
             isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument
-            argument = "+set net_show_packets 3"
-            isEnabled = "NO">
-         </CommandLineArgument>
-         <CommandLineArgument
-            argument = "+set s_volume 0"
-            isEnabled = "NO">
-         </CommandLineArgument>
-         <CommandLineArgument
-            argument = "+set cg_add_entities 0"
-            isEnabled = "YES">
-         </CommandLineArgument>
-         <CommandLineArgument
             argument = "+map torn"
             isEnabled = "YES">
-         </CommandLineArgument>
-         <CommandLineArgument
-            argument = "+map lighttest"
-            isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
             argument = "+set g_cheats 1 +give all "

--- a/Quetoo.xcodeproj/xcshareddata/xcschemes/quetoo-all.xcscheme
+++ b/Quetoo.xcodeproj/xcshareddata/xcschemes/quetoo-all.xcscheme
@@ -66,11 +66,11 @@
          </CommandLineArgument>
          <CommandLineArgument
             argument = "+set r_fullscreen 0 +set r_width 1280 +set r_height 800 +set r_display 0"
-            isEnabled = "YES">
+            isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
             argument = "+set r_fullscreen 1 +set r_width 0 +set r_height 0 +set r_display 1"
-            isEnabled = "NO">
+            isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument
             argument = "+set r_draw_bsp_lightmaps 1 +set r_texture_mode GL_NEAREST"
@@ -95,6 +95,10 @@
          <CommandLineArgument
             argument = "+set s_volume 0"
             isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "+set cg_add_entities 0"
+            isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument
             argument = "+map torn"

--- a/src/cgame/cgame.h
+++ b/src/cgame/cgame.h
@@ -579,10 +579,9 @@ typedef struct cg_import_s {
 	/**
 	 * @brief Loads the image by `name` into the SDL_Surface `surface`.
 	 * @param name The image name (e.g. `"pics/ch1"`).
-	 * @param surface The surface pointer to return.
-	 * @return True on success, false on error.
+	 * @return The surface, or `NULL` if it could not be loaded.
 	 */
-	_Bool (*LoadSurface)(const char *name, SDL_Surface **surface);
+	SDL_Surface *(*LoadSurface)(const char *name);
 
 	/**
 	 * @brief Loads the image with the given name and type.

--- a/src/cgame/default/ui/controls/CrosshairView.c
+++ b/src/cgame/default/ui/controls/CrosshairView.c
@@ -82,8 +82,8 @@ static void updateBindings(View *self) {
 
 	const int32_t ch = cg_draw_crosshair->value;
 	if (ch) {
-		SDL_Surface *surface;
-		if (cgi.LoadSurface(va("pics/ch%d", ch), &surface)) {
+		SDL_Surface *surface = cgi.LoadSurface(va("pics/ch%d", ch));
+		if (surface) {
 
 			$(this->imageView, setImageWithSurface, surface);
 			SDL_FreeSurface(surface);

--- a/src/cgame/default/ui/play/MapListCollectionView.c
+++ b/src/cgame/default/ui/play/MapListCollectionView.c
@@ -180,8 +180,8 @@ static void enumerateMaps(const char *path, void *data) {
 			if (len) {
 				const char *mapshot = g_list_nth_data(mapshots, RandomRangeu(0, len));
 
-				SDL_Surface *surf;
-				if (cgi.LoadSurface(mapshot, &surf)) {
+				SDL_Surface *surf = cgi.LoadSurface(mapshot);
+				if (surf) {
 					SDL_SetSurfaceBlendMode(surf, SDL_BLENDMODE_NONE);
 					info->mapshot = SDL_CreateRGBSurface(0,
 					                                     this->collectionView.itemSize.w * 2,

--- a/src/client/cl_cgame.c
+++ b/src/client/cl_cgame.c
@@ -244,8 +244,6 @@ void Cl_InitCgame(void) {
 	import.CullBox = R_CullBox;
 	import.CullSphere = R_CullSphere;
 
-	import.ColorFromPalette = Img_ColorFromPalette;
-
 	import.LoadSurface = Img_LoadImage;
 	import.LoadImage = R_LoadImage;
 	import.CreateAtlas = R_CreateAtlas;

--- a/src/client/cl_cgame.c
+++ b/src/client/cl_cgame.c
@@ -244,7 +244,7 @@ void Cl_InitCgame(void) {
 	import.CullBox = R_CullBox;
 	import.CullSphere = R_CullSphere;
 
-	import.LoadSurface = Img_LoadImage;
+	import.LoadSurface = Img_LoadSurface;
 	import.LoadImage = R_LoadImage;
 	import.CreateAtlas = R_CreateAtlas;
 	import.LoadAtlasImage = R_LoadAtlasImage;

--- a/src/client/renderer/r_atlas.c
+++ b/src/client/renderer/r_atlas.c
@@ -47,7 +47,7 @@ r_atlas_t *R_CreateAtlas(const char *name) {
 
 	atlas->media.Free = R_FreeAtlas;
 	atlas->image = (r_image_t *) R_AllocMedia(va("%s image", atlas->media.name), sizeof(r_image_t), MEDIA_IMAGE);
-	atlas->image->type = IT_MASK_CLAMP_EDGE;
+	atlas->image->type = IT_ATLAS;
 
 	R_RegisterDependency((r_media_t *) atlas, (r_media_t *) atlas->image);
 
@@ -67,8 +67,8 @@ r_atlas_image_t *R_LoadAtlasImage(r_atlas_t *atlas, const char *name, r_image_ty
 		atlas_image = (r_atlas_image_t *) R_AllocMedia(name, sizeof(*atlas_image), MEDIA_ATLAS_IMAGE);
 		assert(atlas_image);
 
-		SDL_Surface *surf;
-		if (!Img_LoadImage(name, &surf)) {
+		SDL_Surface *surf = Img_LoadImage(name);
+		if (!surf) {
 			surf = SDL_CreateRGBSurfaceWithFormatFrom(&pixels, 1, 1, 32, 4, SDL_PIXELFORMAT_RGBA32);
 		}
 
@@ -78,10 +78,6 @@ r_atlas_image_t *R_LoadAtlasImage(r_atlas_t *atlas, const char *name, r_image_ty
 		atlas_image->image.type = type;
 		atlas_image->image.width = surf->w;
 		atlas_image->image.height = surf->h;
-
-		if (type & IT_MASK_FILTER) {
-			R_FilterImage(&atlas_image->image, GL_RGBA, surf->pixels);
-		}
 
 		R_RegisterDependency((r_media_t *) atlas_image, (r_media_t *) atlas);
 

--- a/src/client/renderer/r_atlas.c
+++ b/src/client/renderer/r_atlas.c
@@ -67,7 +67,7 @@ r_atlas_image_t *R_LoadAtlasImage(r_atlas_t *atlas, const char *name, r_image_ty
 		atlas_image = (r_atlas_image_t *) R_AllocMedia(name, sizeof(*atlas_image), MEDIA_ATLAS_IMAGE);
 		assert(atlas_image);
 
-		SDL_Surface *surf = Img_LoadImage(name);
+		SDL_Surface *surf = Img_LoadSurface(name);
 		if (!surf) {
 			surf = SDL_CreateRGBSurfaceWithFormatFrom(&pixels, 1, 1, 32, 4, SDL_PIXELFORMAT_RGBA32);
 		}

--- a/src/client/renderer/r_bsp.c
+++ b/src/client/renderer/r_bsp.c
@@ -146,6 +146,7 @@ void R_UpdateVis(void) {
 
 				if (!R_CullBox(node->mins, node->maxs)) {
 					node->vis_frame = r_locals.vis_frame;
+					node->lights = 0;
 					r_view.count_bsp_nodes++;
 				}
 

--- a/src/client/renderer/r_bsp_draw.c
+++ b/src/client/renderer/r_bsp_draw.c
@@ -61,6 +61,7 @@ static struct {
 
 	GLint lights_block;
 	GLuint lights_buffer;
+	GLint lights_mask;
 
 	GLint fog_parameters;
 	GLint fog_color;
@@ -159,6 +160,7 @@ static void R_DrawBspLightgrid(void) {
  */
 static void R_DrawBspDrawElements(const r_bsp_inline_model_t *in, const GPtrArray *draw_elements) {
 
+	const r_bsp_node_t *node = NULL;
 	const r_material_t *material = NULL;
 
 	for (guint i = 0; i < draw_elements->len; i++) {
@@ -171,6 +173,12 @@ static void R_DrawBspDrawElements(const r_bsp_inline_model_t *in, const GPtrArra
 
 		if (draw->node->vis_frame != r_locals.vis_frame) {
 			continue;
+		}
+
+		if (draw->node != node) {
+			node = draw->node;
+			
+			glUniform1i(r_bsp_program.lights_mask, node->lights);
 		}
 
 		if (draw->texinfo->material != material) {
@@ -384,6 +392,7 @@ void R_InitBspProgram(void) {
 	r_bsp_program.lights_block = glGetUniformBlockIndex(r_bsp_program.name, "lights_block");
 	glUniformBlockBinding(r_bsp_program.name, r_bsp_program.lights_block, 0);
 	glGenBuffers(1, &r_bsp_program.lights_buffer);
+	r_bsp_program.lights_mask = glGetUniformLocation(r_bsp_program.name, "lights_mask");
 
 	r_bsp_program.fog_parameters = glGetUniformLocation(r_bsp_program.name, "fog_parameters");
 	r_bsp_program.fog_color = glGetUniformLocation(r_bsp_program.name, "fog_color");

--- a/src/client/renderer/r_context.c
+++ b/src/client/renderer/r_context.c
@@ -27,9 +27,10 @@ r_context_t r_context;
  * @brief
  */
 static void R_SetWindowIcon(void) {
-	SDL_Surface *surf;
 
-	if (!Img_LoadImage("icons/quetoo", &surf)) {
+	SDL_Surface *surf = Img_LoadImage("icons/quetoo");
+
+	if (!surf) {
 		return;
 	}
 

--- a/src/client/renderer/r_context.c
+++ b/src/client/renderer/r_context.c
@@ -28,7 +28,7 @@ r_context_t r_context;
  */
 static void R_SetWindowIcon(void) {
 
-	SDL_Surface *surf = Img_LoadImage("icons/quetoo");
+	SDL_Surface *surf = Img_LoadSurface("icons/quetoo");
 
 	if (!surf) {
 		return;

--- a/src/client/renderer/r_image.c
+++ b/src/client/renderer/r_image.c
@@ -261,7 +261,7 @@ r_image_t *R_LoadImage(const char *name, r_image_type_t type) {
 
 	if (!(image = (r_image_t *) R_FindMedia(key))) {
 
-		SDL_Surface *surf = Img_LoadImage(key);
+		SDL_Surface *surf = Img_LoadSurface(key);
 		if (surf) {
 			image = (r_image_t *) R_AllocMedia(key, sizeof(r_image_t), MEDIA_IMAGE);
 

--- a/src/client/renderer/r_light.c
+++ b/src/client/renderer/r_light.c
@@ -86,11 +86,22 @@ void R_UpdateLights(void) {
 
 		R_MarkLight(in, r_model_state.world->bsp->nodes);
 
-		const r_entity_t *e = r_view.entities;
+		r_entity_t *e = r_view.entities;
 		for (int32_t j = 0; j < r_view.num_entities; j++, e++) {
 
-			if (e->model && e->model->type == MOD_BSP_INLINE) {
-				R_MarkLight(in, e->model->bsp_inline->head_node);
+			if (e->model) {
+				switch (e->model->type) {
+					case MOD_BSP_INLINE:
+						R_MarkLight(in, e->model->bsp_inline->head_node);
+						break;
+					case MOD_MESH:
+						if (Vec3_Distance(e->origin, in->origin) < in->radius) {
+							e->lights |= (1 << (in - r_view.lights));
+						}
+						break;
+					default:
+						break;
+				}
 			}
 		}
 

--- a/src/client/renderer/r_light.c
+++ b/src/client/renderer/r_light.c
@@ -95,7 +95,7 @@ void R_UpdateLights(void) {
 						R_MarkLight(in, e->model->bsp_inline->head_node);
 						break;
 					case MOD_MESH:
-						if (Vec3_Distance(e->origin, in->origin) < in->radius) {
+						if (Vec3_Distance(e->origin, in->origin) < e->model->radius + in->radius) {
 							e->lights |= (1 << (in - r_view.lights));
 						}
 						break;

--- a/src/client/renderer/r_light.c
+++ b/src/client/renderer/r_light.c
@@ -31,6 +31,10 @@ void R_AddLight(const r_light_t *in) {
 		return;
 	}
 
+	if (R_CullSphere(in->origin, in->radius)) {
+		return;
+	}
+
 	r_light_t *out = &r_view.lights[r_view.num_lights++];
 	*out = *in;
 

--- a/src/client/renderer/r_material.c
+++ b/src/client/renderer/r_material.c
@@ -818,8 +818,8 @@ static r_material_t *R_ResolveMaterial(cm_material_t *cm, cm_asset_context_t con
 				normalmap = R_CreateMaterialSurface(diffusemap->w, diffusemap->h, Color32(127, 127, 255, 127));
 			}
 
-			assert(normalmap->w == diffusemap->w);
-			assert(normalmap->h == diffusemap->h);
+			//assert(normalmap->w == diffusemap->w);
+			//assert(normalmap->h == diffusemap->h);
 
 			if (*cm->heightmap.path) {
 				SDL_Surface *heightmap = NULL;
@@ -848,8 +848,8 @@ static r_material_t *R_ResolveMaterial(cm_material_t *cm, cm_asset_context_t con
 				glossmap = R_CreateMaterialSurface(diffusemap->w, diffusemap->h, Color32(127, 127, 127, 127));
 			}
 
-			assert(glossmap->w == diffusemap->w);
-			assert(glossmap->h == diffusemap->h);
+			//assert(glossmap->w == diffusemap->w);
+			//assert(glossmap->h == diffusemap->h);
 
 			if (*cm->specularmap.path) {
 				SDL_Surface *specularmap = NULL;

--- a/src/client/renderer/r_material.c
+++ b/src/client/renderer/r_material.c
@@ -730,7 +730,7 @@ static void R_MaterialKey(const char *name, char *key, size_t len, cm_asset_cont
  */
 static SDL_Surface *R_LoadMaterialSurface(int32_t w, int32_t h, const char *path) {
 
-	SDL_Surface *surface = Img_LoadImage(path);
+	SDL_Surface *surface = Img_LoadSurface(path);
 	if (surface) {
 		if (w || h) {
 			if (surface->w != w || surface->h != h) {
@@ -803,7 +803,7 @@ static r_material_t *R_ResolveMaterial(cm_material_t *cm, cm_asset_context_t con
 
 	SDL_Surface *diffusemap = NULL;
 	if (*cm->diffusemap.path) {
-		if ((diffusemap = Img_LoadImage(cm->diffusemap.path))) {
+		if ((diffusemap = Img_LoadSurface(cm->diffusemap.path))) {
 			Com_Debug(DEBUG_RENDERER, "Loaded diffusemap %s for %s\n", cm->diffusemap.path, cm->basename);
 		} else {
 			Com_Warn("Failed to load diffusemap %s for %s\n", cm->diffusemap.path, cm->basename);

--- a/src/client/renderer/r_material.c
+++ b/src/client/renderer/r_material.c
@@ -818,6 +818,9 @@ static r_material_t *R_ResolveMaterial(cm_material_t *cm, cm_asset_context_t con
 				normalmap = R_CreateMaterialSurface(diffusemap->w, diffusemap->h, Color32(127, 127, 255, 127));
 			}
 
+			assert(normalmap->w == diffusemap->w);
+			assert(normalmap->h == diffusemap->h);
+
 			if (*cm->heightmap.path) {
 				SDL_Surface *heightmap = NULL;
 				if ((heightmap = Img_LoadImage(cm->heightmap.path))) {
@@ -844,6 +847,9 @@ static r_material_t *R_ResolveMaterial(cm_material_t *cm, cm_asset_context_t con
 			} else {
 				glossmap = R_CreateMaterialSurface(diffusemap->w, diffusemap->h, Color32(127, 127, 127, 127));
 			}
+
+			assert(glossmap->w == diffusemap->w);
+			assert(glossmap->h == diffusemap->h);
 
 			if (*cm->specularmap.path) {
 				SDL_Surface *specularmap = NULL;
@@ -889,6 +895,9 @@ static r_material_t *R_ResolveMaterial(cm_material_t *cm, cm_asset_context_t con
 			} else {
 				tintmap = R_CreateMaterialSurface(diffusemap->w, diffusemap->h, Color32(0, 0, 0, 0));
 			}
+
+			assert(tintmap->w == diffusemap->w);
+			assert(tintmap->h == diffusemap->h);
 
 			material->texture->depth = 2;
 

--- a/src/client/renderer/r_mesh_draw.c
+++ b/src/client/renderer/r_mesh_draw.c
@@ -76,6 +76,7 @@ static struct {
 
 	GLuint lights_buffer;
 	GLuint lights_block;
+	GLint lights_mask;
 
 	GLint fog_parameters;
 	GLint fog_color;
@@ -115,6 +116,7 @@ static void R_DrawMeshEntity(const r_entity_t *e) {
 
 	glUniform1f(r_mesh_program.lerp, e->lerp);
 	glUniform4fv(r_mesh_program.color, 1, e->color.xyzw);
+	glUniform1i(r_mesh_program.lights_mask, e->lights);
 
 	const r_mesh_face_t *face = mesh->faces;
 	for (int32_t i = 0; i < mesh->num_faces; i++, face++) {
@@ -327,6 +329,7 @@ void R_InitMeshProgram(void) {
 	r_mesh_program.lights_block = glGetUniformBlockIndex(r_mesh_program.name, "lights_block");
 	glUniformBlockBinding(r_mesh_program.name, r_mesh_program.lights_block, 0);
 	glGenBuffers(1, &r_mesh_program.lights_buffer);
+	r_mesh_program.lights_mask = glGetUniformLocation(r_mesh_program.name, "lights_mask");
 
 	r_mesh_program.fog_parameters = glGetUniformLocation(r_mesh_program.name, "fog_parameters");
 	r_mesh_program.fog_color = glGetUniformLocation(r_mesh_program.name, "fog_color");

--- a/src/client/renderer/r_particle.c
+++ b/src/client/renderer/r_particle.c
@@ -85,6 +85,10 @@ void R_AddParticle(const r_particle_t *p) {
 		return;
 	}
 
+	if (R_CullSphere(p->origin, p->size)) {
+		return;
+	}
+
 	r_particle_vertex_t *out = r_particles.particles + r_view.num_particles;
 
 	out->position = Vec3_ToVec4(p->origin, p->size);

--- a/src/client/renderer/r_sky.c
+++ b/src/client/renderer/r_sky.c
@@ -327,7 +327,7 @@ void R_SetSky(const char *name) {
 		char path[MAX_QPATH];
 
 		g_snprintf(path, sizeof(path), "env/%s%s", name, suf[i]);
-		r_sky.images[i] = R_LoadImage(path, IT_SKY);
+		r_sky.images[i] = R_LoadImage(path, IT_MATERIAL);
 
 		if (r_sky.images[i]->type == IT_NULL) { // try unit1_
 			if (g_strcmp0(name, "unit1_")) {

--- a/src/client/renderer/r_sprite.c
+++ b/src/client/renderer/r_sprite.c
@@ -120,7 +120,10 @@ static _Bool R_CullSprite(r_sprite_vertex_t *out) {
 }
 
 static void R_AddSpriteInternal(const r_buffered_sprite_image_t *image, const float lerp, const color_t color, r_sprite_vertex_t *out) {
-	const _Bool is_current_batch = r_view.num_sprite_images && memcmp(image, &r_view.sprite_images[r_view.num_sprite_images - 1], sizeof(*image)) == 0;
+	const r_buffered_sprite_image_t *current_batch = &r_view.sprite_images[r_view.num_sprite_images - 1];
+	const _Bool is_current_batch = r_view.num_sprite_images &&
+		image->image->texnum == current_batch->image->texnum && ((image->next_image ? image->next_image->texnum : 0) == (current_batch->next_image ? current_batch->next_image->texnum : 0)) &&
+		image->src == current_batch->src && image->dst == current_batch->dst;
 
 	R_ResolveTextureCoordinates(image->image, &out[0].diffusemap, &out[1].diffusemap, &out[2].diffusemap, &out[3].diffusemap);
 

--- a/src/client/renderer/r_sprite.c
+++ b/src/client/renderer/r_sprite.c
@@ -110,7 +110,16 @@ static const r_image_t *R_ResolveSpriteImage(const r_media_t *media, const float
 	return image;
 }
 
-static void R_AddSpriteInternal(const r_buffered_sprite_image_t *image, const color_t color, r_sprite_vertex_t *out) {
+static _Bool R_CullSprite(r_sprite_vertex_t *out) {
+
+	vec3_t mins, maxs;
+
+	Cm_TraceBounds(out[0].position, out[2].position, Vec3_Zero(), Vec3_Zero(), &mins, &maxs);
+
+	return R_CullBox(mins, maxs);
+}
+
+static void R_AddSpriteInternal(const r_buffered_sprite_image_t *image, const float lerp, const color_t color, r_sprite_vertex_t *out) {
 	const _Bool is_current_batch = r_view.num_sprite_images && memcmp(image, &r_view.sprite_images[r_view.num_sprite_images - 1], sizeof(*image)) == 0;
 
 	R_ResolveTextureCoordinates(image->image, &out[0].diffusemap, &out[1].diffusemap, &out[2].diffusemap, &out[3].diffusemap);
@@ -120,8 +129,8 @@ static void R_AddSpriteInternal(const r_buffered_sprite_image_t *image, const co
 	if (image->next_image) {
 		R_ResolveTextureCoordinates(image->next_image, &out[0].next_diffusemap, &out[1].next_diffusemap, &out[2].next_diffusemap, &out[3].next_diffusemap);
 
-		if (image->lerp) {
-			out->next_lerp = image->lerp;
+		if (lerp) {
+			out->next_lerp = lerp;
 		}
 	}
 
@@ -166,6 +175,10 @@ void R_AddSprite(const r_sprite_t *p) {
 	out[2].position = Vec3_Add(Vec3_Add(p->origin, d), r);
 	out[3].position = Vec3_Add(Vec3_Add(p->origin, d), l);
 
+	if (R_CullSprite(out)) {
+		return;
+	}
+
 	const r_image_t *next_image = NULL;
 	float lerp = 0;
 
@@ -186,9 +199,8 @@ void R_AddSprite(const r_sprite_t *p) {
 		.image = image,
 		.src = p->src,
 		.dst = p->dst,
-		.next_image = next_image,
-		.lerp = lerp
-	}, p->color, out);
+		.next_image = next_image
+	}, lerp, p->color, out);
 }
 
 /**
@@ -213,13 +225,16 @@ void R_AddBeam(const r_beam_t *p) {
 	out[2].position = Vec3_Subtract(p->end, right);
 	out[3].position = Vec3_Subtract(p->start, right);
 
+	if (R_CullSprite(out)) {
+		return;
+	}
+
 	R_AddSpriteInternal(&(const r_buffered_sprite_image_t) {
 		.image = image,
 		.src = p->src,
 		.dst = p->dst,
-		.next_image = NULL,
-		.lerp = 0
-	}, p->color, out);
+		.next_image = NULL
+	}, 0, p->color, out);
 	
 	if (!(p->image->type & IT_MASK_CLAMP_EDGE)) {
 		length /= p->image->width * (p->size / p->image->height);

--- a/src/client/renderer/r_types.h
+++ b/src/client/renderer/r_types.h
@@ -809,7 +809,7 @@ typedef struct r_entity_s {
 	int32_t num_skins;
 
 	/**
-	 * @brief Entity effects (`EF_NO_DRAW`, `EF_WEAPON`, ..).
+	 * @brief The entity effects (`EF_NO_DRAW`, `EF_WEAPON`, ..).
 	 */
 	int32_t effects;
 
@@ -827,6 +827,11 @@ typedef struct r_entity_s {
 	 * @brief Tint maps allow users to customize their player skins.
 	 */
 	vec4_t tints[TINT_TOTAL];
+
+	/**
+	 * @brief The entity light mask for dynamic light sources.
+	 */
+	int32_t lights;
 } r_entity_t;
 
 #define WEATHER_NONE        0x0

--- a/src/client/renderer/r_types.h
+++ b/src/client/renderer/r_types.h
@@ -84,8 +84,8 @@ typedef enum {
 	IT_UI =          (1 <<  3),
 	IT_EFFECT =      (1 <<  4) + (IT_MASK_MIPMAP),
 	IT_MATERIAL =    (1 <<  5) + (IT_MASK_MIPMAP),
-	IT_PIC =         (1 <<  6),
-	IT_ATLAS =       (1 <<  7) + (IT_MASK_CLAMP_EDGE),
+	IT_PIC =         (1 <<  6) + (IT_MASK_MIPMAP),
+	IT_ATLAS =       (1 <<  7) + (IT_MASK_MIPMAP | IT_MASK_CLAMP_EDGE),
 	IT_LIGHTMAP =    (1 <<  8) + (IT_MASK_CLAMP_EDGE),
 	IT_LIGHTGRID =   (1 <<  9) + (IT_MASK_CLAMP_EDGE),
 } r_image_type_t;

--- a/src/client/renderer/r_types.h
+++ b/src/client/renderer/r_types.h
@@ -856,11 +856,6 @@ typedef struct {
 	 * @brief Animation interpolation next image
 	 */
 	const r_image_t *next_image;
-
-	/**
-	 * @brief Animation interpolation frac
-	 */
-	float lerp;
 } r_buffered_sprite_image_t;
 
 /**

--- a/src/client/renderer/r_types.h
+++ b/src/client/renderer/r_types.h
@@ -73,30 +73,21 @@ typedef enum {
 
 // high bits OR'ed with image categories, flags are bits 24..31
 #define IT_MASK_MIPMAP		1 << 24
-#define IT_MASK_FILTER		1 << 25
-#define IT_MASK_MULTIPLY	1 << 26
-#define IT_MASK_CLAMP_EDGE  1 << 27
+#define IT_MASK_CLAMP_EDGE  1 << 25
 #define IT_MASK_FLAGS		(IT_MASK_MIPMAP | IT_MASK_FILTER | IT_MASK_MULTIPLY)
 
 // image categories (bits 0..23) + flags are making image types
 typedef enum {
 	IT_NULL =        (1 <<  0),
 	IT_PROGRAM =     (1 <<  1),
-	IT_FONT =        (1 <<  2) + (IT_MASK_FILTER),
-	IT_UI =          (1 <<  3) + (IT_MASK_FILTER),
-	IT_EFFECT =      (1 <<  4) + (IT_MASK_MIPMAP | IT_MASK_FILTER),
-	IT_DIFFUSE =     (1 <<  5) + (IT_MASK_MIPMAP | IT_MASK_FILTER),
-	IT_LIGHTMAP =    (1 <<  6) + (IT_MASK_FILTER),
-	IT_LIGHTGRID =   (1 <<  7) + (IT_MASK_FILTER | IT_MASK_CLAMP_EDGE),
-	IT_STAINMAP =    (1 <<  8) + (IT_MASK_FILTER),
-	IT_NORMALMAP =   (1 <<  9) + (IT_MASK_MIPMAP | IT_MASK_FILTER),
-	IT_GLOSSMAP =    (1 << 10) + (IT_MASK_MIPMAP | IT_MASK_FILTER),
-	IT_ENVMAP =      (1 << 11) + (IT_MASK_MIPMAP | IT_MASK_FILTER),
-	IT_FLARE =       (1 << 12) + (IT_MASK_MIPMAP | IT_MASK_FILTER | IT_MASK_MULTIPLY),
-	IT_SKY =         (1 << 13) + (IT_MASK_MIPMAP | IT_MASK_FILTER),
-	IT_PIC =         (1 << 14) + (IT_MASK_MIPMAP | IT_MASK_FILTER),
-	IT_ATLAS =       (1 << 15) + (IT_MASK_MIPMAP),
-	IT_TINTMAP =     (1 << 16) + (IT_MASK_MIPMAP | IT_MASK_FILTER)
+	IT_FONT =        (1 <<  2),
+	IT_UI =          (1 <<  3),
+	IT_EFFECT =      (1 <<  4) + (IT_MASK_MIPMAP),
+	IT_MATERIAL =    (1 <<  5) + (IT_MASK_MIPMAP),
+	IT_PIC =         (1 <<  6),
+	IT_ATLAS =       (1 <<  7) + (IT_MASK_CLAMP_EDGE),
+	IT_LIGHTMAP =    (1 <<  8) + (IT_MASK_CLAMP_EDGE),
+	IT_LIGHTGRID =   (1 <<  9) + (IT_MASK_CLAMP_EDGE),
 } r_image_type_t;
 
 /**
@@ -123,10 +114,6 @@ typedef struct {
 	 */
 	GLuint texnum;
 
-	/**
-	 * @brief The average color of the image.
-	 */
-	vec3_t color;
 } r_image_t;
 
 /**
@@ -204,14 +191,12 @@ typedef struct r_material_s {
 	struct cm_material_s *cm; // the parsed material
 
 	// renderer-local stuff parsed from cm
-	r_image_t *diffusemap;
-	r_image_t *normalmap;
-	r_image_t *glossmap;
-	r_image_t *tintmap;
-
-	uint32_t time;
+	r_image_t *texture;
 
 	r_stage_t *stages;
+
+	uint32_t time; // when the material was last animated
+
 } r_material_t;
 
 typedef struct {
@@ -348,7 +333,7 @@ typedef struct r_bsp_node_s {
 	int32_t num_draw_elements;
 	r_bsp_draw_elements_t *draw_elements;
 
-	int64_t lights;
+	int64_t lights; // TODO: This is not used, but it should be a bitmask of light sources per node.
 } r_bsp_node_t;
 
 /**
@@ -365,7 +350,7 @@ typedef struct {
 	vec3_t maxs;
 
 	struct r_bsp_node_s *parent;
-	struct r_model_s *model;
+	struct r_bsp_inline_model_s *model;
 
 	int32_t vis_frame;
 

--- a/src/client/renderer/r_types.h
+++ b/src/client/renderer/r_types.h
@@ -333,7 +333,7 @@ typedef struct r_bsp_node_s {
 	int32_t num_draw_elements;
 	r_bsp_draw_elements_t *draw_elements;
 
-	int64_t lights; // TODO: This is not used, but it should be a bitmask of light sources per node.
+	int32_t lights;
 } r_bsp_node_t;
 
 /**
@@ -728,9 +728,9 @@ typedef struct {
 	float intensity;
 } r_light_t;
 
-#define MAX_LIGHTS			0x40
+#define MAX_LIGHTS			0x20
 
-#define MAX_ENTITY_SKINS 8
+#define MAX_ENTITY_SKINS 	0x8
 
 /**
  * @brief Entities provide a means to add model instances to the view. Entity

--- a/src/client/renderer/shaders/bsp_fs.glsl
+++ b/src/client/renderer/shaders/bsp_fs.glsl
@@ -19,24 +19,12 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
  */
 
-#define TEXTURE_DIFFUSEMAP               0
-#define TEXTURE_NORMALMAP                1
-#define TEXTURE_GLOSSMAP                 2
-#define TEXTURE_LIGHTMAP                 3
-
-#define TEXTURE_MASK_DIFFUSEMAP         (1 << TEXTURE_DIFFUSEMAP)
-#define TEXTURE_MASK_NORMALMAP          (1 << TEXTURE_NORMALMAP)
-#define TEXTURE_MASK_GLOSSMAP           (1 << TEXTURE_GLOSSMAP)
-#define TEXTURE_MASK_LIGHTMAP           (1 << TEXTURE_LIGHTMAP)
-#define TEXTURE_MASK_ALL                0xff
+#define TEXTURE_MATERIAL                 0
+#define TEXTURE_LIGHTMAP                 1
 
 #define MAX_HARDNESS 16
 
-uniform int textures;
-
-uniform sampler2D texture_diffusemap;
-uniform sampler2D texture_normalmap;
-uniform sampler2D texture_glossmap;
+uniform sampler2DArray texture_material;
 uniform sampler2DArray texture_lightmap;
 
 uniform float alpha_threshold;
@@ -63,107 +51,37 @@ in vertex_data {
 out vec4 out_color;
 
 /**
- * @brief Highpasses the heightmap to approximate ambient occlusion.
- */
-float gen_cavity(vec4 normalmap) {
-	float height_a = normalmap.a;
-	float height_b = texture(texture_normalmap, vertex.diffusemap, 4).a;
-	float ao = (height_a - height_b) * 0.5 + 0.5;
-	return ao * smoothstep(0.8, 1.0, normalmap.z);
-}
-
-/**
-* @brief For materials without a gloss texture.
-*/
-float gen_gloss(vec4 diffusemap) {
-	float gloss = grayscale(diffusemap.rgb) * 0.875 + 0.125;
-	return saturate(pow(gloss * 3.0, 4.0));
-}
-
-/**
-* @brief For materials without a gloss texture.
-*/
-float auto_glossmap(vec4 normalmap, vec4 diffusemap) {
-	float gloss = gen_gloss(diffusemap) * 0.333 + 0.333;
-	float cavity = gen_cavity(normalmap);
-	return saturate((gloss + cavity) - 0.333);
-}
-
-/**
  * @brief
  */
 void main(void) {
 	
 	float _specular = specular * 100.0; // fudge the numbers to match the old specular model... kinda...
-	
+
+	vec4 diffusemap = texture(texture_material, vec3(vertex.diffusemap, 0));
+	vec4 normalmap = texture(texture_material, vec3(vertex.diffusemap, 1));
+	vec4 glossmap = texture(texture_material, vec3(vertex.diffusemap, 2));
+
+	diffusemap *= vertex.color;
+
+	if (diffusemap.a < alpha_threshold) {
+		discard;
+	}
+
 	mat3 tbn = mat3(normalize(vertex.tangent), normalize(vertex.bitangent), normalize(vertex.normal));
-	
-	vec3 light_diffuse = vec3(0.0);
-	vec3 light_specular = vec3(0.0);
+	vec3 normal = normalize(tbn * ((normalmap.xyz * 2.0 - 1.0) * vec3(bump, bump, 1.0)));
 
-	vec4 diffusemap;
-	if ((textures & TEXTURE_MASK_DIFFUSEMAP) == TEXTURE_MASK_DIFFUSEMAP) {
-		diffusemap = texture(texture_diffusemap, vertex.diffusemap) * vertex.color;
+	vec3 ambient = texture(texture_lightmap, vec3(vertex.lightmap, 0)).rgb;
+	vec3 diffuse = texture(texture_lightmap, vec3(vertex.lightmap, 1)).rgb;
+	vec3 radiosity = texture(texture_lightmap, vec3(vertex.lightmap, 2)).rgb;
+	vec3 diffuse_dir = texture(texture_lightmap, vec3(vertex.lightmap, 3)).xyz;
 
-		if (diffusemap.a < alpha_threshold) {
-			discard;
-		}
-	} else {
-		diffusemap = vertex.color;
-	}
+	diffuse_dir = normalize(tbn * (diffuse_dir * 2.0 - 1.0));
 
-	vec4 normalmap;
-	float toksvig;
-	if ((textures & TEXTURE_MASK_NORMALMAP) == TEXTURE_MASK_NORMALMAP) {
-		
-		vec4 normalmap_raw_0, normalmap_raw_1;
-		normalmap_raw_0 = texture(texture_normalmap, vertex.diffusemap);
-		normalmap_raw_0.xyz = normalmap_raw_0.xyz * 2.0 - 1.0;
-		normalmap_raw_1 = texture(texture_normalmap, vertex.diffusemap, 1);
-		normalmap_raw_1.xyz = normalmap_raw_1.xyz * 2.0 - 1.0;
-		
-		normalmap = normalize(normalmap_raw_0) * vec4(bump, bump, 1.0, 1.0);
-		normalmap.xyz = normalize(normalmap.xyz);
-		
-		// take the minimum of 2 mip samples to prevent shimmering / crawlies on detailed textures :|
-		// sadly this looks like arse on some materials, I think using precomputed textures would fix it
-		float toksvig_0 = 1.0 / (1.0 + _specular * ((1.0 / saturate(length(normalmap_raw_0.xyz))) - 1.0));
-		float toksvig_1 = 1.0 / (1.0 + _specular * ((1.0 / saturate(length(normalmap_raw_1.xyz))) - 1.0));
-		toksvig = min(toksvig_0, toksvig_1);
-		
-	} else {
-		normalmap = vec4(0.0, 0.0, 1.0, 0.5);
-		toksvig = 1.0;
-	}
+	vec3 light_diffuse = diffuse * max(dot(diffuse_dir, normal), 0.0) + ambient + radiosity;
+	vec3 light_specular = brdf_blinn(normalize(-vertex.position), diffuse_dir, normal, diffuse, glossmap.a, _specular);
+	light_specular = min(light_specular * 0.2 * glossmap.xyz * hardness, MAX_HARDNESS);
 
-	vec3 normal = normalize(tbn * normalmap.xyz);
-
-	float glossmap;
-	if ((textures & TEXTURE_MASK_GLOSSMAP) == TEXTURE_MASK_GLOSSMAP) {
-		glossmap = texture(texture_glossmap, vertex.diffusemap).r;
-	} else {
-		glossmap = auto_glossmap(normalmap, diffusemap);
-	}
-
-	vec3 stainmap;
-	if ((textures & TEXTURE_MASK_LIGHTMAP) == TEXTURE_MASK_LIGHTMAP) {
-		vec3 ambient = texture(texture_lightmap, vec3(vertex.lightmap, 0)).rgb;
-		vec3 diffuse = texture_bicubic(texture_lightmap, vec3(vertex.lightmap, 1)).rgb;
-		vec3 radiosity = texture(texture_lightmap, vec3(vertex.lightmap, 2)).rgb;
-		
-		vec3 diffuse_dir = texture_bicubic(texture_lightmap, vec3(vertex.lightmap, 3)).xyz;
-		diffuse_dir = normalize(diffuse_dir * 2.0 - 1.0);
-		diffuse_dir = normalize(tbn * diffuse_dir);
-
-		light_diffuse = diffuse * max(dot(diffuse_dir, normal), 0.0) + ambient + radiosity;
-		light_specular = brdf_blinn(normalize(-vertex.position), diffuse_dir, normal, diffuse, glossmap * toksvig, _specular);
-		light_specular = min(light_specular * 0.2 * glossmap * hardness, MAX_HARDNESS);
-
-		stainmap = texture_bicubic(texture_lightmap, vec3(vertex.lightmap, 4)).rgb;
-	} else {
-		light_diffuse = vec3(1.0);
-		stainmap = vec3(1.0);
-	}
+	vec3 stainmap = texture_bicubic(texture_lightmap, vec3(vertex.lightmap, 4)).rgb;
 
 	dynamic_light(vertex.position, normal, 64, light_diffuse, light_specular);
 	

--- a/src/client/renderer/shaders/lights.glsl
+++ b/src/client/renderer/shaders/lights.glsl
@@ -19,7 +19,7 @@
 * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 */
 
-#define MAX_LIGHTS 64
+#define MAX_LIGHTS 32
 
 struct light {
 	vec4 origin;
@@ -30,6 +30,8 @@ layout (std140) uniform lights_block {
 	light lights[MAX_LIGHTS];
 };
 
+uniform int lights_mask;
+
 /**
  * @brief
  */
@@ -38,11 +40,15 @@ void dynamic_light(in vec3 position, in vec3 normal, in float specular_exponent,
 
 	for (int i = 0; i < MAX_LIGHTS; i++) {
 
+		if ((lights_mask & (1 << i)) == 0) {
+			continue;
+		}
+
 		float radius = lights[i].origin.w;
 		if (radius == 0.0) {
 			continue;
 		}
-		
+
 		float intensity = lights[i].color.w;
 		if (intensity == 0.0) {
 			continue;

--- a/src/client/ui/editor/EditorView.c
+++ b/src/client/ui/editor/EditorView.c
@@ -45,7 +45,9 @@ static EditorView *initWithFrame(EditorView *self, const SDL_Rect *frame) {
 			MakeOutlet("name", &self->name),
 			MakeOutlet("diffusemap", &self->diffusemap),
 			MakeOutlet("normalmap", &self->normalmap),
+			MakeOutlet("heightmap", &self->heightmap),
 			MakeOutlet("glossmap", &self->glossmap),
+			MakeOutlet("specularmap", &self->specularmap),
 			MakeOutlet("bumpmap", &self->bump),
 			MakeOutlet("hardness", &self->hardness),
 			MakeOutlet("specular", &self->specular),
@@ -74,7 +76,9 @@ static void setMaterial(EditorView *self, r_material_t *material) {
 		$(self->name, setDefaultText, self->material->cm->basename);
 		$(self->diffusemap, setDefaultText, self->material->cm->diffusemap.name);
 		$(self->normalmap, setDefaultText, self->material->cm->normalmap.name);
+		$(self->heightmap, setDefaultText, self->material->cm->heightmap.name);
 		$(self->glossmap, setDefaultText, self->material->cm->glossmap.name);
+		$(self->specularmap, setDefaultText, self->material->cm->specularmap.name);
 
 		$(self->bump, setValue, (double) self->material->cm->bump);
 		$(self->hardness, setValue, (double) self->material->cm->hardness);
@@ -84,7 +88,9 @@ static void setMaterial(EditorView *self, r_material_t *material) {
 		$(self->name, setDefaultText, NULL);
 		$(self->diffusemap, setDefaultText, NULL);
 		$(self->normalmap, setDefaultText, NULL);
+		$(self->heightmap, setDefaultText, NULL);
 		$(self->glossmap, setDefaultText, NULL);
+		$(self->specularmap, setDefaultText, NULL);
 
 		$(self->bump, setValue, DEFAULT_BUMP);
 		$(self->hardness, setValue, DEFAULT_HARDNESS);

--- a/src/client/ui/editor/EditorView.h
+++ b/src/client/ui/editor/EditorView.h
@@ -72,9 +72,19 @@ struct EditorView {
 	TextView *normalmap;
 
 	/**
+	 * @brief The heightmap texture.
+	 */
+	TextView *heightmap;
+
+	/**
 	 * @brief The glossmap texture.
 	 */
 	TextView *glossmap;
+
+	/**
+	 * @brief The specularmap texture.
+	 */
+	TextView *specularmap;
 
 	/**
 	 * @brief The bump slider.

--- a/src/client/ui/editor/EditorView.json
+++ b/src/client/ui/editor/EditorView.json
@@ -52,7 +52,31 @@
                     "identifier": "normalmap"
                   }
                 },
+				{
+                  "class": "Input",
+                  "label": {
+                    "text": {
+                      "text": "Heightmap texture"
+                    }
+                  },
+                  "control": {
+                    "class": "TextView",
+                    "identifier": "heightmap"
+                  }
+                },
                 {
+                  "class": "Input",
+                  "label": {
+                    "text": {
+                      "text": "Glossmap texture"
+                    }
+                  },
+                  "control": {
+                    "class": "TextView",
+                    "identifier": "glossmap"
+                  }
+                },
+				{
                   "class": "Input",
                   "label": {
                     "text": {
@@ -61,7 +85,7 @@
                   },
                   "control": {
                     "class": "TextView",
-                    "identifier": "glossmap"
+                    "identifier": "specularmap"
                   }
                 },
                 {

--- a/src/collision/cm_material.c
+++ b/src/collision/cm_material.c
@@ -785,6 +785,14 @@ ssize_t Cm_LoadMaterials(const char *path, GList **materials) {
 			}
 		}
 
+		if (!g_strcmp0(token, "specularmap")) {
+
+			if (!Parse_Token(&parser, PARSE_NO_WRAP, m->specularmap.name, sizeof(m->specularmap.name))) {
+				Cm_MaterialWarn(path, &parser, "Missing path or too many characters");
+				continue;
+			}
+		}
+
 		if (!g_strcmp0(token, "tintmap")) {
 
 			if (!Parse_Token(&parser, PARSE_NO_WRAP, m->tintmap.name, sizeof(m->tintmap.name))) {
@@ -1100,7 +1108,8 @@ _Bool Cm_ResolveMaterial(cm_material_t *material, cm_asset_context_t context) {
 
 	Cm_ResolveMaterialAsset(material, &material->normalmap, context, (const char *[]) { "_nm", "_norm", "_local", "_bump", NULL });
 	Cm_ResolveMaterialAsset(material, &material->heightmap, context, (const char *[]) { "_h", "_height", NULL });
-	Cm_ResolveMaterialAsset(material, &material->glossmap, context, (const char *[]) { "_s", "_gloss", "_spec", NULL });
+	Cm_ResolveMaterialAsset(material, &material->glossmap, context, (const char *[]) { "_g", "_gloss", NULL });
+	Cm_ResolveMaterialAsset(material, &material->specularmap, context, (const char *[]) { "_s", "_spec", NULL });
 	Cm_ResolveMaterialAsset(material, &material->tintmap, context, (const char *[]) { "_tint", NULL });
 
 	cm_stage_t *stage = material->stages;
@@ -1208,6 +1217,9 @@ static void Cm_WriteMaterial(const cm_material_t *material, file_t *file) {
 	}
 	if (*material->glossmap.name) {
 		Fs_Print(file, "\tglossmap %s\n", material->glossmap.name);
+	}
+	if (*material->specularmap.name) {
+		Fs_Print(file, "\tspecularmap %s\n", material->specularmap.name);
 	}
 	if (*material->tintmap.name) {
 		Fs_Print(file, "\ttintmap %s\n", material->tintmap.name);

--- a/src/collision/cm_material.h
+++ b/src/collision/cm_material.h
@@ -179,6 +179,11 @@ typedef struct cm_material_s {
 	cm_asset_t glossmap;
 
 	/**
+	 * @brief The specularmap asset.
+	 */
+	cm_asset_t specularmap;
+
+	/**
 	 * @brief The tintmap asset.
 	 */
 	cm_asset_t tintmap;

--- a/src/image.c
+++ b/src/image.c
@@ -22,10 +22,9 @@
 #include "image.h"
 
 /**
- * @brief Loads the specified image from the game filesystem and populates
- * the provided SDL_Surface.
+ * @brief Loads the specified image from the game filesystem.
  */
-static SDL_Surface *Img_LoadTypedImage(const char *name, const char *type) {
+static SDL_Surface *Img_LoadSurface_(const char *name, const char *type) {
 	SDL_Surface *surf = NULL;
 
 	char path[MAX_QPATH];
@@ -57,9 +56,7 @@ static SDL_Surface *Img_LoadTypedImage(const char *name, const char *type) {
 }
 
 /**
- * @brief Loads the specified image from the game filesystem and populates
- * the provided SDL_Surface. Image formats are tried in the order they appear
- * in TYPES.
+ * @brief Loads the specified image from the game filesystem, trying all supported formats.
  */
 SDL_Surface *Img_LoadSurface(const char *name) {
 	const char *img_formats[] = { "tga", "png", "jpg", NULL };
@@ -68,7 +65,7 @@ SDL_Surface *Img_LoadSurface(const char *name) {
 	StripExtension(name, basename);
 
 	for (const char **fmt = img_formats; *fmt; fmt++) {
-		SDL_Surface *surf = Img_LoadTypedImage(basename, *fmt);
+		SDL_Surface *surf = Img_LoadSurface_(basename, *fmt);
 		if (surf) {
 			return surf;
 		}

--- a/src/image.c
+++ b/src/image.c
@@ -61,7 +61,7 @@ static SDL_Surface *Img_LoadTypedImage(const char *name, const char *type) {
  * the provided SDL_Surface. Image formats are tried in the order they appear
  * in TYPES.
  */
-SDL_Surface *Img_LoadImage(const char *name) {
+SDL_Surface *Img_LoadSurface(const char *name) {
 	const char *img_formats[] = { "tga", "png", "jpg", NULL };
 
 	char basename[MAX_QPATH];

--- a/src/image.h
+++ b/src/image.h
@@ -30,7 +30,7 @@
 /**
  * @brief Loads an image by the specified Quake path to the given surface.
  */
-SDL_Surface *Img_LoadImage(const char *name);
+SDL_Surface *Img_LoadSurface(const char *name);
 
 /**
 * @brief Write pixel data to a PNG file.

--- a/src/image.h
+++ b/src/image.h
@@ -27,28 +27,10 @@
 
 #include <SDL_image.h>
 
-#define IMG_PALETTE_SIZE 256
-typedef uint32_t img_palette_t[IMG_PALETTE_SIZE];
-
-/**
- * @brief The 8-bit lookup palette, mapping 0-255 to RGB colors.
- */
-extern img_palette_t img_palette;
-
 /**
  * @brief Loads an image by the specified Quake path to the given surface.
  */
-_Bool Img_LoadImage(const char *name, SDL_Surface **surf);
-
-/**
- * @brief Initializes the 8-bit lookup palette.
- */
-void Img_InitPalette(void);
-
-/**
- * @brief Resolves an RGB color value for the given value.
- */
-color_t Img_ColorFromPalette(uint8_t c);
+SDL_Surface *Img_LoadImage(const char *name);
 
 /**
 * @brief Write pixel data to a PNG file.

--- a/src/tools/quemap/material.c
+++ b/src/tools/quemap/material.c
@@ -79,7 +79,7 @@ SDL_Surface *LoadAsset(const cm_asset_t *asset) {
 
 	SDL_Surface *surf = g_hash_table_lookup(assets, (void *) asset->path);
 	if (surf == NULL) {
-		surf = Img_LoadImage(asset->path);
+		surf = Img_LoadSurface(asset->path);
 		if (surf) {
 			g_hash_table_insert(assets, (void *) asset->path, surf);
 		}

--- a/src/tools/quemap/material.c
+++ b/src/tools/quemap/material.c
@@ -79,7 +79,8 @@ SDL_Surface *LoadAsset(const cm_asset_t *asset) {
 
 	SDL_Surface *surf = g_hash_table_lookup(assets, (void *) asset->path);
 	if (surf == NULL) {
-		if (Img_LoadImage(asset->path, &surf)) {
+		surf = Img_LoadImage(asset->path);
+		if (surf) {
 			g_hash_table_insert(assets, (void *) asset->path, surf);
 		}
 	}

--- a/src/tools/quemap/qzip.c
+++ b/src/tools/quemap/qzip.c
@@ -145,6 +145,7 @@ static void AddMaterial(const cm_material_t *material) {
 		AddAsset(&material->normalmap);
 		AddAsset(&material->heightmap);
 		AddAsset(&material->glossmap);
+		AddAsset(&material->specularmap);
 		AddAsset(&material->tintmap);
 
 		for (const cm_stage_t *stage = material->stages; stage; stage = stage->next) {


### PR DESCRIPTION
 * Glossmap and specularmap are now both properly supported.
 * Normalmap and heightmap are now both properly supported.
 * Specularmap, if present, is uploaded into the glossmap alpha channel.
 * Heightmap, if present, is uploaded into the normalmap alpha channel.
 * All world and mesh materials are array textures with 3 layers: diffusemap, normalmap, glossmap
 * Texture unit management is much simpler: single bind to change materials
 * Image types greatly reduced, as many are now IT_MATERIAL.
 * Refactor image loading API to return an SDL_Surface, finally.
 * Kill off the last dingleberries of the color palette.