### PR TITLE
Use lowercase for Windows includes. This is required for cross compilation

### DIFF
--- a/src/server/sv_admin.c
+++ b/src/server/sv_admin.c
@@ -20,7 +20,7 @@
  */
 
 #if defined(_WIN32)
-	#include <WinSock2.h> // for htons
+	#include <winsock2.h> // for htons
 #endif
 
 #include "sv_local.h"

--- a/src/server/sv_console.c
+++ b/src/server/sv_console.c
@@ -23,7 +23,7 @@
 #include <signal.h>
 
 #if defined(_WIN32)
-	#include <WinSock2.h> // for AllocConsole
+	#include <winsock2.h> // for AllocConsole
 #endif
 
 #include "sv_local.h"

--- a/src/server/sv_master.c
+++ b/src/server/sv_master.c
@@ -20,7 +20,7 @@
  */
 
 #if defined(_WIN32)
-	#include <WinSock2.h> // for htons
+	#include <winsock2.h> // for htons
 #endif
 
 #include "sv_local.h"

--- a/src/sys.c
+++ b/src/sys.c
@@ -26,8 +26,8 @@
 #include <signal.h>
 
 #if defined(_WIN32)
-	#include <Windows.h>
-	#include <ShlObj.h>
+	#include <windows.h>
+	#include <shlobj.h>
 #endif
 
 #if defined(__APPLE__)


### PR DESCRIPTION
Fixes Mingw build for cross compile.