### PR TITLE
Use simple bevels, and ensure that brush sides are sorted axial first.

### DIFF
--- a/src/tools/quemap/writebsp.c
+++ b/src/tools/quemap/writebsp.c
@@ -376,42 +376,6 @@ static void EmitBrushes(void) {
 			bs->texinfo = b->sides[j].texinfo;
 		}
 
-		// add any axis planes not contained in the brush to bevel off corners
-		for (int32_t axis = 0; axis < 3; axis++) {
-			for (int32_t side = -1; side <= 1; side += 2) {
-				// add the plane
-				vec3_t normal = Vec3_Zero();
-				normal.xyz[axis] = side;
-
-				float dist;
-				if (side == -1) {
-					dist = -b->bounds.mins.xyz[axis];
-				} else {
-					dist = b->bounds.maxs.xyz[axis];
-				}
-
-				const int32_t plane_num = FindPlane(normal, dist);
-
-				int32_t j;
-				for (j = 0; j < b->num_sides; j++) {
-					if (b->sides[j].plane_num == plane_num) {
-						break;
-					}
-				}
-
-				if (j == b->num_sides) {
-					if (bsp_file.num_brush_sides >= MAX_BSP_BRUSH_SIDES) {
-						Com_Error(ERROR_FATAL, "MAX_BSP_BRUSH_SIDES\n");
-					}
-
-					bsp_file.brush_sides[bsp_file.num_brush_sides].plane_num = plane_num;
-					bsp_file.brush_sides[bsp_file.num_brush_sides].texinfo = bsp_file.brush_sides[bsp_file.num_brush_sides - 1].texinfo;
-					bsp_file.num_brush_sides++;
-					out->num_sides++;
-				}
-			}
-		}
-
 		Progress("Emitting brushes", 100.f * i / num_brushes);
 	}
 }


### PR DESCRIPTION
@Paril Here you go, here is a vastly simplified bevels implementation that:

1. Just ensures that all brushes have 6 axially aligned sides, some of which may be bevels.
2. Ensures that those 6 axially aligned sides are first in every brush.

While I see a few minor artifacts from this change (one small missing stair on Edge), I'm not overly concerned. Because we no longer subdivide the world into 1024x cubes, Edge has been a constant battle with missing faces due to the portal complexity of the large round rooms. I'm confident I can fix this missing stair by just rejiggering hints, and this is not necessarily a new regression.

Let me know if you think this is a good idea, and if this will allow you to port those axial optimizations from Q3's trace.