### PR TITLE
Issue/658 lighting leakage

### DIFF
--- a/Quetoo.xcodeproj/xcshareddata/xcschemes/quemap.xcscheme
+++ b/Quetoo.xcodeproj/xcshareddata/xcschemes/quemap.xcscheme
@@ -78,7 +78,7 @@
          </CommandLineArgument>
          <CommandLineArgument
             argument = "-bsp"
-            isEnabled = "YES">
+            isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
             argument = "--only-ents"
@@ -118,11 +118,11 @@
          </CommandLineArgument>
          <CommandLineArgument
             argument = "-light"
-            isEnabled = "NO">
+            isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument
             argument = "--no-indirect"
-            isEnabled = "NO">
+            isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument
             argument = "--antialias "
@@ -154,7 +154,7 @@
          </CommandLineArgument>
          <CommandLineArgument
             argument = "maps/fragpipe.map"
-            isEnabled = "NO">
+            isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument
             argument = "maps/gehenna.map"

--- a/Quetoo.xcodeproj/xcshareddata/xcschemes/quetoo-all.xcscheme
+++ b/Quetoo.xcodeproj/xcshareddata/xcschemes/quetoo-all.xcscheme
@@ -105,7 +105,7 @@
             isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
-            argument = "+set sv_max_clients 32 +map tokays"
+            argument = "+set sv_max_clients 32 +map fragpipe"
             isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument

--- a/Quetoo.xcodeproj/xcshareddata/xcschemes/quetoo-all.xcscheme
+++ b/Quetoo.xcodeproj/xcshareddata/xcschemes/quetoo-all.xcscheme
@@ -105,7 +105,7 @@
             isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
-            argument = "+set sv_max_clients 32 +map fragpipe"
+            argument = "+set sv_max_clients 32 +map edge"
             isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument

--- a/src/client/renderer/shaders/bsp_fs.glsl
+++ b/src/client/renderer/shaders/bsp_fs.glsl
@@ -128,6 +128,8 @@ void main(void) {
 
 		//out_color.rgb = caustic;
 		//out_color.rgb = texture(texture_lightgrid_diffuse, vertex.lightgrid).rgb;
+		//out_color.rgb = diffuse + ambient;
+		//out_color.rgb = sample_lightmap(2).xyz;
 	} else {
 
 		if ((stage.flags & STAGE_WARP) == STAGE_WARP) {

--- a/src/collision/cm_material.h
+++ b/src/collision/cm_material.h
@@ -232,7 +232,7 @@ typedef struct {
 #define DEFAULT_BLOOM 1.f
 #define DEFAULT_ALPHA_TEST .5f
 #define DEFAULT_LIGHT 300.f
-#define DEFAULT_PATCH_SIZE 32
+#define DEFAULT_PATCH_SIZE 64
 
 /**
  * @brief Materials define the rendering attributes of textures.

--- a/src/collision/cm_material.h
+++ b/src/collision/cm_material.h
@@ -232,7 +232,7 @@ typedef struct {
 #define DEFAULT_BLOOM 1.f
 #define DEFAULT_ALPHA_TEST .5f
 #define DEFAULT_LIGHT 300.f
-#define DEFAULT_PATCH_SIZE 64
+#define DEFAULT_PATCH_SIZE 32
 
 /**
  * @brief Materials define the rendering attributes of textures.

--- a/src/collision/cm_polylib.c
+++ b/src/collision/cm_polylib.c
@@ -110,6 +110,38 @@ float Cm_WindingArea(const cm_winding_t *w) {
 }
 
 /**
+ * @brief Calculates the distance from `p` to `w`.
+ * @see https://stackoverflow.com/questions/849211/shortest-distance-between-a-point-and-a-line-segment
+ */
+float Cm_DistanceToWinding(const cm_winding_t *w, const vec3_t p) {
+
+	float distance = FLT_MAX;
+
+	for (int32_t i = 0; i < w->num_points; i++) {
+
+		const vec3_t a = w->points[(i + 0) % w->num_points];
+		const vec3_t b = w->points[(i + 1) % w->num_points];
+
+		const float dist_squared = Vec3_DistanceSquared(a, b);
+		if (dist_squared == 0.f) {
+			return Vec3_Distance(a, p);
+		}
+
+		const vec3_t pa = Vec3_Subtract(p, a);
+		const vec3_t ba = Vec3_Subtract(b, a);
+
+		const float f = Maxf(0.f, Minf(1.f, Vec3_Dot(pa, ba) / dist_squared));
+		const float dist = Vec3_Distance(p, Vec3_Fmaf(a, f, ba));
+
+		if (dist < distance) {
+			distance = dist;
+		}
+	}
+
+	return distance;
+}
+
+/**
  * @brief
  */
 void Cm_PlaneForWinding(const cm_winding_t *w, vec3_t *normal, double *dist) {

--- a/src/collision/cm_polylib.h
+++ b/src/collision/cm_polylib.h
@@ -65,6 +65,7 @@ cm_winding_t *Cm_ReverseWinding(const cm_winding_t *w);
 box3_t Cm_WindingBounds(const cm_winding_t *w);
 vec3_t Cm_WindingCenter(const cm_winding_t *w);
 float Cm_WindingArea(const cm_winding_t *w);
+float Cm_DistanceToWinding(const cm_winding_t *w, const vec3_t p);
 cm_winding_t *Cm_WindingForPlane(const vec3_t normal, double dist);
 cm_winding_t *Cm_WindingForFace(const bsp_file_t *file, const bsp_face_t *face);
 void Cm_PlaneForWinding(const cm_winding_t *w, vec3_t *normal, double *dist);

--- a/src/collision/cm_test.c
+++ b/src/collision/cm_test.c
@@ -89,6 +89,14 @@ cm_bsp_plane_t Cm_TransformPlane(const mat4_t matrix, const cm_bsp_plane_t plane
 }
 
 /**
+ * @return The `point` projected onto `plane`.
+ */
+vec3_t Cm_ProjectPointToPlane(const vec3_t point, const cm_bsp_plane_t *plane) {
+	const float dist = Cm_DistanceToPlane(point, plane);
+	return Vec3_Subtract(point, Vec3_Scale(plane->normal, dist));
+}
+
+/**
  * @return `true` if `point` resides inside `brush`, `false` otherwise.
  */
 _Bool Cm_PointInsideBrush(const vec3_t point, const cm_bsp_brush_t *brush) {

--- a/src/collision/cm_test.h
+++ b/src/collision/cm_test.h
@@ -36,6 +36,8 @@ int32_t Cm_SignBitsForNormal(const vec3_t normal);
 cm_bsp_plane_t Cm_Plane(const vec3_t normal, float dist);
 cm_bsp_plane_t Cm_TransformPlane(const mat4_t matrix, const cm_bsp_plane_t plane);
 
+vec3_t Cm_ProjectPointToPlane(const vec3_t point, const cm_bsp_plane_t *plane);
+
 int32_t Cm_BoxOnPlaneSide(const box3_t bounds, const cm_bsp_plane_t *plane);
 _Bool Cm_PointInsideBrush(const vec3_t point, const cm_bsp_brush_t *brush);
 

--- a/src/tests/check_cm_polylib.c
+++ b/src/tests/check_cm_polylib.c
@@ -353,6 +353,26 @@ START_TEST(check_Cm_Barycentric) {
 
 } END_TEST
 
+START_TEST(check_Cm_DistanceToWinding) {
+
+	cm_winding_t *w = Cm_AllocWinding(3);
+	w->num_points = 3;
+
+	w->points[0] = Vec3(0.f, 0.f, 0.f);
+	w->points[1] = Vec3(0.f, 1.f, 0.f);
+	w->points[2] = Vec3(1.f, 0.f, 0.f);
+
+	ck_assert_float_eq(0.f, Cm_DistanceToWinding(w, w->points[0]));
+	ck_assert_float_eq(0.f, Cm_DistanceToWinding(w, w->points[1]));
+	ck_assert_float_eq(0.f, Cm_DistanceToWinding(w, w->points[2]));
+
+	ck_assert_float_eq(.5f, Cm_DistanceToWinding(w, Vec3(.5f, .5f, 0.f)));
+	ck_assert_float_eq(1.f, Cm_DistanceToWinding(w, Vec3(0.f, 2.f, 0.f)));
+
+	Cm_FreeWinding(w);
+
+} END_TEST
+
 /**
  * @brief Test entry point.
  */
@@ -395,6 +415,13 @@ int32_t main(int32_t argc, char **argv) {
 		TCase *tcase = tcase_create("Cm_Barycentric");
 		tcase_add_checked_fixture(tcase, setup, teardown);
 		tcase_add_test(tcase, check_Cm_Barycentric);
+		suite_add_tcase(suite, tcase);
+	}
+
+	{
+		TCase *tcase = tcase_create("Cm_DistanceToWinding");
+		tcase_add_checked_fixture(tcase, setup, teardown);
+		tcase_add_test(tcase, check_Cm_DistanceToWinding);
 		suite_add_tcase(suite, tcase);
 	}
 

--- a/src/tests/check_cm_polylib.c
+++ b/src/tests/check_cm_polylib.c
@@ -386,13 +386,16 @@ int32_t main(int32_t argc, char **argv) {
 
 	{
 		TCase *tcase = tcase_create("Cm_TriangleArea");
+		tcase_add_checked_fixture(tcase, setup, teardown);
 		tcase_add_test(tcase, check_Cm_TriangleArea);
 		suite_add_tcase(suite, tcase);
 	}
 
 	{
 		TCase *tcase = tcase_create("Cm_Barycentric");
+		tcase_add_checked_fixture(tcase, setup, teardown);
 		tcase_add_test(tcase, check_Cm_Barycentric);
+		suite_add_tcase(suite, tcase);
 	}
 
 	int32_t failed = Test_Run(suite);

--- a/src/tools/quemap/light.c
+++ b/src/tools/quemap/light.c
@@ -340,6 +340,8 @@ static void LightForPatch(const patch_t *patch) {
 	light.atten = LIGHT_ATTEN_INVERSE_SQUARE;
 	light.size = sqrtf(Cm_WindingArea(patch->winding));
 	light.origin = Vec3_Fmaf(Cm_WindingCenter(patch->winding), 4.f, plane->normal);
+	light.face = patch->face;
+	light.plane = plane;
 
 	if (Light_PointContents(light.origin, 0) & CONTENTS_SOLID) {
 		return;
@@ -354,7 +356,6 @@ static void LightForPatch(const patch_t *patch) {
 	}
 
 	light.radius = (brush_side->value ?: DEFAULT_LIGHT) * lightscale_patch;
-	light.face = patch->face;
 
 	GArray *points = g_array_new(false, false, sizeof(vec3_t));
 	g_array_append_val(points, light.origin);
@@ -512,12 +513,17 @@ void BuildDirectLights(void) {
  */
 static void LightForLightmappedPatch(const lightmap_t *lm, const patch_t *patch) {
 
+	const bsp_brush_side_t *brush_side = &bsp_file.brush_sides[patch->face->brush_side];
+	const bsp_plane_t *plane = &bsp_file.planes[brush_side->plane];
+
 	light_t light = {};
 
 	light.type = LIGHT_INDIRECT;
 	light.atten = LIGHT_ATTEN_INVERSE_SQUARE;
 	light.size = sqrtf(Cm_WindingArea(patch->winding));
 	light.origin = Vec3_Fmaf(Cm_WindingCenter(patch->winding), 4.f, lm->plane->normal);
+	light.face = patch->face;
+	light.plane = plane;
 
 	if (Light_PointContents(light.origin, 0) & CONTENTS_SOLID) {
 		return;

--- a/src/tools/quemap/light.c
+++ b/src/tools/quemap/light.c
@@ -161,8 +161,6 @@ static void LightForEntity_light_sun(const cm_entity_t *entity, light_t *light) 
 	}
 
 	light->size = Cm_EntityValue(entity, "_size")->value ?: LIGHT_SIZE_SUN;
-
-	g_array_append_val(lights, light);
 }
 
 /**
@@ -187,7 +185,6 @@ static void LightForEntity_light(const cm_entity_t *entity, light_t *light) {
 		light->atten = Cm_EntityValue(entity, "atten")->integer;
 	}
 
-	g_array_append_val(lights, light);
 }
 
 /**

--- a/src/tools/quemap/light.c
+++ b/src/tools/quemap/light.c
@@ -143,11 +143,11 @@ static void LightForEntity_light_sun(const cm_entity_t *entity, light_t *light) 
 
 	light->type = LIGHT_SUN;
 	light->atten = LIGHT_ATTEN_NONE;
-	light->origin = Vec3_Zero();
+	light->origin = Cm_EntityValue(entity, "origin")->vec3;
+	light->color = Cm_EntityValue(entity, "_color")->vec3;
+	light->radius = LIGHT_RADIUS;
 
-	if (Cm_EntityValue(entity, "_color")->parsed & ENTITY_VEC3) {
-		light->color = Cm_EntityValue(entity, "_color")->vec3;
-	} else {
+	if (Vec3_Equal(Vec3_Zero(), light->color)) {
 		light->color = LIGHT_COLOR;
 	}
 

--- a/src/tools/quemap/light.c
+++ b/src/tools/quemap/light.c
@@ -334,14 +334,15 @@ static void LightForPatch(const patch_t *patch) {
 	const bsp_brush_side_t *brush_side = &bsp_file.brush_sides[patch->face->brush_side];
 	const bsp_plane_t *plane = &bsp_file.planes[brush_side->plane];
 
-	light_t light = {};
-
-	light.type = LIGHT_PATCH;
-	light.atten = LIGHT_ATTEN_INVERSE_SQUARE;
-	light.size = sqrtf(Cm_WindingArea(patch->winding));
-	light.origin = Vec3_Fmaf(Cm_WindingCenter(patch->winding), 4.f, plane->normal);
-	light.face = patch->face;
-	light.plane = plane;
+	light_t light = {
+		.type = LIGHT_PATCH,
+		.atten = LIGHT_ATTEN_INVERSE_SQUARE,
+		.size = sqrtf(Cm_WindingArea(patch->winding)),
+		.origin = Vec3_Fmaf(Cm_WindingCenter(patch->winding), 4.f, plane->normal),
+		.face = patch->face,
+		.plane = plane,
+		.model = patch->model,
+	};
 
 	if (Light_PointContents(light.origin, 0) & CONTENTS_SOLID) {
 		return;
@@ -516,14 +517,15 @@ static void LightForLightmappedPatch(const lightmap_t *lm, const patch_t *patch)
 	const bsp_brush_side_t *brush_side = &bsp_file.brush_sides[patch->face->brush_side];
 	const bsp_plane_t *plane = &bsp_file.planes[brush_side->plane];
 
-	light_t light = {};
-
-	light.type = LIGHT_INDIRECT;
-	light.atten = LIGHT_ATTEN_INVERSE_SQUARE;
-	light.size = sqrtf(Cm_WindingArea(patch->winding));
-	light.origin = Vec3_Fmaf(Cm_WindingCenter(patch->winding), 4.f, lm->plane->normal);
-	light.face = patch->face;
-	light.plane = plane;
+	light_t light = {
+		.type = LIGHT_INDIRECT,
+		.atten = LIGHT_ATTEN_INVERSE_SQUARE,
+		.size = sqrtf(Cm_WindingArea(patch->winding)),
+		.origin = Vec3_Fmaf(Cm_WindingCenter(patch->winding), 4.f, lm->plane->normal),
+		.face = patch->face,
+		.plane = plane,
+		.model = patch->model,
+	};
 
 	if (Light_PointContents(light.origin, 0) & CONTENTS_SOLID) {
 		return;
@@ -573,8 +575,6 @@ static void LightForLightmappedPatch(const lightmap_t *lm, const patch_t *patch)
 
 	lightmap = ColorNormalize(lightmap);
 	light.color = Vec3_Multiply(lightmap, GetMaterialColor(lm->brush_side->material));
-
-	light.face = patch->face;
 
 	GArray *points = g_array_new(false, false, sizeof(vec3_t));
 	g_array_append_val(points, light.origin);

--- a/src/tools/quemap/light.h
+++ b/src/tools/quemap/light.h
@@ -106,9 +106,14 @@ typedef struct {
 	int32_t num_points;
 
 	/**
-	 * @brief The light source face for indirect lights.
+	 * @brief The light source face for patch and indirect lights.
 	 */
 	const bsp_face_t *face;
+
+	/**
+	 * @brief The light source plane for patch and indirect lights.
+	 */
+	const bsp_plane_t *plane;
 } light_t;
 
 extern GPtrArray *node_lights[MAX_BSP_NODES];

--- a/src/tools/quemap/light.h
+++ b/src/tools/quemap/light.h
@@ -29,7 +29,8 @@
 #define LIGHT_ANGLE_UP -1.f
 #define LIGHT_ANGLE_DOWN -2.f
 #define LIGHT_CONE 22.5f
-#define LIGHT_SIZE_SUN 256.f
+#define LIGHT_SUN_DIST 1024.f
+#define LIGHT_SIZE_SUN 32.f
 #define LIGHT_SIZE_STEP 16.f
 
 typedef enum {
@@ -53,7 +54,6 @@ typedef enum {
  * @brief BSP light sources may come from entities or emissive surfaces.
  */
 typedef struct {
-
 	/**
 	 * @brief The type.
 	 */
@@ -93,6 +93,17 @@ typedef struct {
 	 * @brief The size of the light, in world units, to simulate area lights.
 	 */
 	float size;
+
+	/**
+	 * @brief The sample points (origins) to be traced to for this light.
+	 * @remarks For directional lights, these are directional vectors, not points.
+	 */
+	vec3_t *points;
+
+	/**
+	 * @brief The number of sample points.
+	 */
+	int32_t num_points;
 
 	/**
 	 * @brief The light source face for indirect lights.

--- a/src/tools/quemap/light.h
+++ b/src/tools/quemap/light.h
@@ -114,6 +114,11 @@ typedef struct {
 	 * @brief The light source plane for patch and indirect lights.
 	 */
 	const bsp_plane_t *plane;
+
+	/**
+	 * @brief The light source model for patch and indirect lights.
+	 */
+	const bsp_model_t *model;
 } light_t;
 
 extern GPtrArray *node_lights[MAX_BSP_NODES];

--- a/src/tools/quemap/light.h
+++ b/src/tools/quemap/light.h
@@ -95,6 +95,11 @@ typedef struct {
 	float size;
 
 	/**
+	 * @brief The bounds of the light source.
+	 */
+	box3_t bounds;
+
+	/**
 	 * @brief The sample points (origins) to be traced to for this light.
 	 * @remarks For directional lights, these are directional vectors, not points.
 	 */

--- a/src/tools/quemap/lightgrid.c
+++ b/src/tools/quemap/lightgrid.c
@@ -333,6 +333,10 @@ static void LightgridLuxel_Spot(const light_t *light, luxel_t *luxel, float scal
  */
 static void LightgridLuxel_Patch(const light_t *light, luxel_t *luxel, float scale) {
 
+	if (light->model != bsp_file.models) {
+		return;
+	}
+
 	if (Vec3_Dot(luxel->origin, light->plane->normal) - light->plane->dist <= 0.f) {
 		return;
 	}
@@ -376,6 +380,10 @@ static void LightgridLuxel_Patch(const light_t *light, luxel_t *luxel, float sca
  */
 static void LightgridLuxel_Indirect(const light_t *light, luxel_t *luxel, float scale) {
 
+	if (light->model != bsp_file.models) {
+		return;
+	}
+	
 	if (Vec3_Dot(luxel->origin, light->plane->normal) - light->plane->dist <= 0.f) {
 		return;
 	}

--- a/src/tools/quemap/lightgrid.c
+++ b/src/tools/quemap/lightgrid.c
@@ -400,15 +400,9 @@ static void LightgridLuxel_Indirect(const light_t *light, luxel_t *luxel, float 
 
 	for (int32_t i = 0; i < light->num_points; i++) {
 
-		float dist;
-		const vec3_t dir = Vec3_NormalizeLength(points[i], &dist);
+		const float dist = Vec3_Distance(points[i], luxel->origin);
 		if (dist > light->radius) {
 			break;
-		}
-
-		const float dot = Vec3_Dot(dir, luxel->normal);
-		if (dot <= 0.f) {
-			continue;
 		}
 
 		const cm_trace_t trace = Light_Trace(luxel->origin, light->points[i], 0, CONTENTS_SOLID);
@@ -418,7 +412,7 @@ static void LightgridLuxel_Indirect(const light_t *light, luxel_t *luxel, float 
 
 		const float atten = Clampf(1.f - dist / light->radius, 0.f, 1.f);
 
-		intensity = light->radius * dot * atten * atten;
+		intensity = light->radius * atten * atten;
 		break;
 	}
 

--- a/src/tools/quemap/lightgrid.c
+++ b/src/tools/quemap/lightgrid.c
@@ -371,8 +371,8 @@ static void LightgridLuxel_Patch(const light_t *light, luxel_t *luxel, float sca
 		break;
 	}
 
-	luxel->diffuse = Vec3_Fmaf(luxel->diffuse, intensity, light->color);
-	luxel->direction = Vec3_Fmaf(luxel->direction, intensity, dir);
+	luxel->diffuse = Vec3_Fmaf(luxel->diffuse, intensity * scale, light->color);
+	luxel->direction = Vec3_Fmaf(luxel->direction, intensity * scale, dir);
 }
 
 /**
@@ -416,7 +416,7 @@ static void LightgridLuxel_Indirect(const light_t *light, luxel_t *luxel, float 
 		break;
 	}
 
-	luxel->radiosity[bounce] = Vec3_Fmaf(luxel->radiosity[bounce], intensity, light->color);
+	luxel->radiosity[bounce] = Vec3_Fmaf(luxel->radiosity[bounce], intensity * scale, light->color);
 }
 
 /**

--- a/src/tools/quemap/lightgrid.c
+++ b/src/tools/quemap/lightgrid.c
@@ -238,7 +238,7 @@ static void LightgridLuxel_Point(const light_t *light, luxel_t *luxel, float sca
 		float dist;
 		dir = Vec3_NormalizeLength(points[i], &dist);
 		if (dist > light->radius) {
-			break;
+			return;
 		}
 
 		const cm_trace_t trace = Light_Trace(luxel->origin, light->points[i], 0, CONTENTS_SOLID);
@@ -289,7 +289,7 @@ static void LightgridLuxel_Spot(const light_t *light, luxel_t *luxel, float scal
 		float dist;
 		dir = Vec3_NormalizeLength(points[i], &dist);
 		if (dist > light->radius) {
-			break;
+			return;
 		}
 
 		const float cone_dot = Vec3_Dot(dir, Vec3_Negate(light->normal));
@@ -357,7 +357,7 @@ static void LightgridLuxel_Patch(const light_t *light, luxel_t *luxel, float sca
 		float dist;
 		dir = Vec3_NormalizeLength(points[i], &dist);
 		if (dist > light->radius) {
-			break;
+			return;
 		}
 
 		const cm_trace_t trace = Light_Trace(luxel->origin, light->points[i], 0, CONTENTS_SOLID);
@@ -383,7 +383,7 @@ static void LightgridLuxel_Indirect(const light_t *light, luxel_t *luxel, float 
 	if (light->model != bsp_file.models) {
 		return;
 	}
-	
+
 	if (Vec3_Dot(luxel->origin, light->plane->normal) - light->plane->dist <= 0.f) {
 		return;
 	}

--- a/src/tools/quemap/lightgrid.c
+++ b/src/tools/quemap/lightgrid.c
@@ -87,6 +87,8 @@ static void BuildLightgridLuxels(void) {
 				l->s = s;
 				l->t = t;
 				l->u = u;
+
+				l->direction = Vec3_Up();
 			}
 		}
 	}

--- a/src/tools/quemap/lightgrid.c
+++ b/src/tools/quemap/lightgrid.c
@@ -237,11 +237,8 @@ static void LightLightgridLuxel(const GPtrArray *lights, luxel_t *luxel, float s
 			float exposure = 0.f;
 
 			for (size_t i = 0; i < lengthof(points); i++) {
-
 				const vec3_t point = Vec3_Fmaf(luxel->origin, 256.f, points[i]);
-
 				const cm_trace_t trace = Light_Trace(luxel->origin, point, 0, CONTENTS_SOLID);
-
 				exposure += sample_fraction * trace.fraction;
 			}
 
@@ -249,58 +246,26 @@ static void LightLightgridLuxel(const GPtrArray *lights, luxel_t *luxel, float s
 
 		} else if (light->type == LIGHT_SUN) {
 
-			const vec3_t sun_origin = Vec3_Fmaf(luxel->origin, -MAX_WORLD_DIST, light->normal);
-
-			cm_trace_t trace = Light_Trace(luxel->origin, sun_origin, 0, CONTENTS_SOLID);
-			if (!(trace.surface & SURF_SKY)) {
-				float exposure = 0.f;
-
-				const int32_t num_samples = ceilf(light->size / LIGHT_SIZE_STEP);
-				for (int32_t i = 0; i < num_samples; i++) {
-
-					const vec3_t points[] = CUBE_8;
-					for (size_t j = 0; j < lengthof(points); j++) {
-
-						const vec3_t point = Vec3_Fmaf(sun_origin, i * LIGHT_SIZE_STEP, points[j]);
-
-						trace = Light_Trace(luxel->origin, point, 0, CONTENTS_SOLID);
-						if (!(trace.surface & SURF_SKY)) {
-							continue;
-						}
-
-						exposure += 1.f / num_samples;
-						break;
-					}
+			int32_t samples = 0;
+			for (int32_t i = 0; i < light->num_points; i++) {
+				const vec3_t end = Vec3_Fmaf(luxel->origin, -MAX_WORLD_DIST, light->points[i]);
+				const cm_trace_t trace = Light_Trace(luxel->origin, end, 0, CONTENTS_SOLID);
+				if (trace.surface & SURF_SKY) {
+					samples++;
 				}
-
-				intensity *= exposure;
 			}
+
+			intensity *= (samples / (float) light->num_points);
 
 		} else {
-			cm_trace_t trace = Light_Trace(luxel->origin, light->origin, 0, CONTENTS_SOLID);
-			if (trace.fraction < 1.f) {
-				float exposure = 0.f;
-
-				const int32_t num_samples = ceilf(light->size / LIGHT_SIZE_STEP);
-				for (int32_t i = 0; i < num_samples; i++) {
-
-					const vec3_t points[] = CUBE_8;
-					for (size_t j = 0; j < lengthof(points); j++) {
-
-						const vec3_t point = Vec3_Fmaf(light->origin, (i + 1) * LIGHT_SIZE_STEP, points[j]);
-
-						trace = Light_Trace(luxel->origin, point, 0, CONTENTS_SOLID);
-						if (trace.fraction < 1.f) {
-							continue;
-						}
-
-						exposure += 1.f / num_samples;
-						break;
-					}
+			int32_t samples = 0;
+			for (int32_t i = 0; i < light->num_points; i++) {
+				if (Light_Trace(luxel->origin, light->points[i], 0, CONTENTS_SOLID).fraction == 1.f) {
+					samples++;
 				}
-
-				intensity *= exposure;
 			}
+
+			intensity *= (samples / (float) light->num_points);
 		}
 
 		intensity *= scale;

--- a/src/tools/quemap/lightmap.c
+++ b/src/tools/quemap/lightmap.c
@@ -497,8 +497,8 @@ static void LightmapLuxel_Patch(const light_t *light, const lightmap_t *lightmap
 		break;
 	}
 
-	luxel->diffuse = Vec3_Fmaf(luxel->diffuse, intensity, light->color);
-	luxel->direction = Vec3_Fmaf(luxel->direction, intensity, dir);
+	luxel->diffuse = Vec3_Fmaf(luxel->diffuse, intensity * scale, light->color);
+	luxel->direction = Vec3_Fmaf(luxel->direction, intensity * scale, dir);
 }
 
 /**
@@ -552,7 +552,7 @@ static void LightmapLuxel_Indirect(const light_t *light, const lightmap_t *light
 		break;
 	}
 
-	luxel->radiosity[bounce] = Vec3_Fmaf(luxel->radiosity[bounce], intensity, light->color);
+	luxel->radiosity[bounce] = Vec3_Fmaf(luxel->radiosity[bounce], intensity * scale, light->color);
 }
 
 /**

--- a/src/tools/quemap/lightmap.c
+++ b/src/tools/quemap/lightmap.c
@@ -661,14 +661,6 @@ void DirectLightmap(int32_t face_num) {
  */
 void IndirectLightmap(int32_t face_num) {
 
-	const vec2_t offsets[] = {
-		Vec2(+0.0f, +0.0f), Vec2(-1.0f, -1.0f), Vec2(+0.0f, -1.0f),
-		Vec2(+1.0f, -1.0f), Vec2(-1.0f, +0.0f), Vec2(+1.0f, +0.0f),
-		Vec2(-1.0f, +1.0f), Vec2(+0.0f, +1.0f), Vec2(+1.0f, +1.0f),
-	};
-
-	const float weight = antialias ? 1.f / lengthof(offsets) : 1.f;
-
 	const lightmap_t *lm = &lightmaps[face_num];
 
 	if (lm->brush_side->surface & SURF_MASK_NO_LIGHTMAP) {
@@ -680,27 +672,11 @@ void IndirectLightmap(int32_t face_num) {
 	luxel_t *l = lm->luxels;
 	for (size_t i = 0; i < lm->num_luxels; i++, l++) {
 
-		float contribution = 0.f;
-
-		for (size_t j = 0; j < lengthof(offsets) && contribution < 1.f; j++) {
-
-			const float soffs = offsets[j].x;
-			const float toffs = offsets[j].y;
-
-			if (ProjectLightmapLuxel(lm, l, soffs, toffs) == CONTENTS_SOLID) {
-				continue;
-			}
-
-			contribution += weight;
-
-			LightmapLuxel(lights, lm, l, weight);
+		if (ProjectLightmapLuxel(lm, l, 0.f, 0.f) == CONTENTS_SOLID) {
+			continue;
 		}
 
-		if (contribution > 0.f) {
-			if (contribution < 1.f) {
-				l->radiosity[bounce] = Vec3_Scale(l->radiosity[bounce], 1.f / contribution);
-			}
-		}
+		LightmapLuxel(lights, lm, l, 1.f);
 	}
 }
 
@@ -756,14 +732,6 @@ static void CausticsLightmapLuxel(luxel_t *luxel, float scale) {
  */
 void CausticsLightmap(int32_t face_num) {
 
-	const vec2_t offsets[] = {
-		Vec2(+0.0f, +0.0f), Vec2(-1.0f, -1.0f), Vec2(+0.0f, -1.0f),
-		Vec2(+1.0f, -1.0f), Vec2(-1.0f, +0.0f), Vec2(+1.0f, +0.0f),
-		Vec2(-1.0f, +1.0f), Vec2(+0.0f, +1.0f), Vec2(+1.0f, +1.0f),
-	};
-
-	const float weight = antialias ? 1.f / lengthof(offsets) : 1.f;
-
 	const lightmap_t *lm = &lightmaps[face_num];
 
 	if (lm->brush_side->surface & SURF_MASK_NO_LIGHTMAP) {
@@ -773,27 +741,11 @@ void CausticsLightmap(int32_t face_num) {
 	luxel_t *l = lm->luxels;
 	for (size_t i = 0; i < lm->num_luxels; i++, l++) {
 
-		float contribution = 0.f;
-
-		for (size_t j = 0; j < lengthof(offsets) && contribution < 1.f; j++) {
-
-			const float soffs = offsets[j].x;
-			const float toffs = offsets[j].y;
-
-			if (ProjectLightmapLuxel(lm, l, soffs, toffs) == CONTENTS_SOLID) {
-				continue;
-			}
-
-			contribution += weight;
-
-			CausticsLightmapLuxel(l, weight);
+		if (ProjectLightmapLuxel(lm, l, 0.f, 0.f) == CONTENTS_SOLID) {
+			continue;
 		}
 
-		if (contribution > 0.f) {
-			if (contribution < 1.f) {
-				l->caustics = Vec3_Scale(l->caustics, 1.f / contribution);
-			}
-		}
+		CausticsLightmapLuxel(l, 1.f);
 	}
 }
 

--- a/src/tools/quemap/lightmap.c
+++ b/src/tools/quemap/lightmap.c
@@ -506,7 +506,7 @@ static void LightmapLuxel_Patch(const light_t *light, const lightmap_t *lightmap
  */
 static void LightmapLuxel_Indirect(const light_t *light, const lightmap_t *lightmap, luxel_t *luxel, float scale) {
 
-	if (light->face == lightmap->face) {
+	if (light->plane == lightmap->plane) {
 		return;
 	}
 

--- a/src/tools/quemap/lightmap.c
+++ b/src/tools/quemap/lightmap.c
@@ -90,6 +90,8 @@ static void BuildLightmapLuxels(lightmap_t *lm) {
 
 			l->s = s;
 			l->t = t;
+
+			l->direction = Vec3_Up();
 		}
 	}
 }

--- a/src/tools/quemap/lightmap.c
+++ b/src/tools/quemap/lightmap.c
@@ -454,6 +454,10 @@ static void LightmapLuxel_Spot(const light_t *light, const lightmap_t *lightmap,
  */
 static void LightmapLuxel_Patch(const light_t *light, const lightmap_t *lightmap, luxel_t *luxel, float scale) {
 
+	if (light->model != bsp_file.models && light->model != lightmap->model) {
+		return;
+	}
+
 	if (Vec3_Dot(luxel->origin, light->plane->normal) - light->plane->dist <= 0.f) {
 		return;
 	}
@@ -503,6 +507,10 @@ static void LightmapLuxel_Patch(const light_t *light, const lightmap_t *lightmap
 static void LightmapLuxel_Indirect(const light_t *light, const lightmap_t *lightmap, luxel_t *luxel, float scale) {
 
 	if (light->face == lightmap->face) {
+		return;
+	}
+
+	if (light->model != bsp_file.models && light->model != lightmap->model) {
 		return;
 	}
 

--- a/src/tools/quemap/lightmap.c
+++ b/src/tools/quemap/lightmap.c
@@ -349,7 +349,7 @@ static void LightmapLuxel_Point(const light_t *light, const lightmap_t *lightmap
 		float dist;
 		dir = Vec3_NormalizeLength(points[i], &dist);
 		if (dist > light->radius) {
-			break;
+			return;
 		}
 
 		const float dot = Vec3_Dot(dir, luxel->normal);
@@ -405,7 +405,7 @@ static void LightmapLuxel_Spot(const light_t *light, const lightmap_t *lightmap,
 		float dist;
 		dir = Vec3_NormalizeLength(points[i], &dist);
 		if (dist > light->radius) {
-			break;
+			return;
 		}
 
 		const float dot = Vec3_Dot(dir, luxel->normal);
@@ -478,7 +478,7 @@ static void LightmapLuxel_Patch(const light_t *light, const lightmap_t *lightmap
 		float dist;
 		dir = Vec3_NormalizeLength(points[i], &dist);
 		if (dist > light->radius) {
-			break;
+			return;
 		}
 
 		const float dot = Vec3_Dot(dir, luxel->normal);
@@ -533,7 +533,7 @@ static void LightmapLuxel_Indirect(const light_t *light, const lightmap_t *light
 		float dist;
 		const vec3_t dir = Vec3_NormalizeLength(points[i], &dist);
 		if (dist > light->radius) {
-			break;
+			return;
 		}
 
 		const float dot = Vec3_Dot(dir, luxel->normal);

--- a/src/tools/quemap/lightmap.c
+++ b/src/tools/quemap/lightmap.c
@@ -250,20 +250,6 @@ static int32_t ProjectLightmapLuxel(const lightmap_t *lm, luxel_t *l, float soff
 }
 
 /**
- * @brief qsort comparator that sorts light->points by distance to the current luxel.
- */
-static int32_t LightmapLuxel_cmp(const void *a, const void *b) {
-
-	const vec3_t *a_point = (vec3_t *) a;
-	const vec3_t *b_point = (vec3_t *) b;
-
-	const float a_dist = Vec3_LengthSquared(*a_point);
-	const float b_dist = Vec3_LengthSquared(*b_point);
-
-	return (int32_t) (a_dist - b_dist);
-}
-
-/**
  * @brief
  */
 static void LightmapLuxel_Ambient(const light_t *light, const lightmap_t *lightmap, luxel_t *luxel, float scale) {
@@ -308,7 +294,6 @@ static void LightmapLuxel_Ambient(const light_t *light, const lightmap_t *lightm
 static void LightmapLuxel_Sun(const light_t *light, const lightmap_t *lightmap, luxel_t *luxel, float scale) {
 
 	for (int32_t i = 0; i < light->num_points; i++) {
-
 		const vec3_t dir = Vec3_Negate(light->points[i]);
 
 		const float dot = Vec3_Dot(dir, luxel->normal);
@@ -332,179 +317,149 @@ static void LightmapLuxel_Sun(const light_t *light, const lightmap_t *lightmap, 
  * @brief
  */
 static void LightmapLuxel_Point(const light_t *light, const lightmap_t *lightmap, luxel_t *luxel, float scale) {
+	vec3_t dir;
 
-	vec3_t points[light->num_points];
-
-	for (int32_t i = 0; i < light->num_points; i++) {
-		points[i] = Vec3_Subtract(light->points[i], luxel->origin);
+	float dist = Vec3_DistanceDir(light->origin, luxel->origin, &dir);
+	dist = Maxf(0.f, dist - light->size * .5f);
+	if (dist > light->radius) {
+		return;
 	}
 
-	qsort(points, light->num_points, sizeof(vec3_t), LightmapLuxel_cmp);
+	const float dot = Vec3_Dot(dir, luxel->normal);
+	if (dot <= 0.f) {
+		return;
+	}
 
-	float intensity = 0.f;
-	vec3_t dir = Vec3_Up();
+	float atten = 1.f;
+
+	switch (light->atten) {
+		case LIGHT_ATTEN_NONE:
+			break;
+		case LIGHT_ATTEN_LINEAR:
+			atten = Clampf(1.f - dist / light->radius, 0.f, 1.f);
+			break;
+		case LIGHT_ATTEN_INVERSE_SQUARE:
+			atten = Clampf(1.f - dist / light->radius, 0.f, 1.f);
+			atten *= atten;
+			break;
+	}
+
+	const float intensity = light->radius * dot * atten * scale;
 
 	for (int32_t i = 0; i < light->num_points; i++) {
-
-		float dist;
-		dir = Vec3_NormalizeLength(points[i], &dist);
-		if (dist > light->radius) {
-			return;
-		}
-
-		const float dot = Vec3_Dot(dir, luxel->normal);
-		if (dot <= 0.f) {
-			continue;
-		}
 
 		const cm_trace_t trace = Light_Trace(luxel->origin, light->points[i], lightmap->model->head_node, CONTENTS_SOLID);
 		if (trace.fraction < 1.f) {
 			continue;
 		}
 
-		float atten = 1.f;
-
-		switch (light->atten) {
-			case LIGHT_ATTEN_NONE:
-				break;
-			case LIGHT_ATTEN_LINEAR:
-				atten = Clampf(1.f - dist / light->radius, 0.f, 1.f);
-				break;
-			case LIGHT_ATTEN_INVERSE_SQUARE:
-				atten = Clampf(1.f - dist / light->radius, 0.f, 1.f);
-				atten *= atten;
-				break;
-		}
-
-		intensity = light->radius * dot * atten;
+		luxel->diffuse = Vec3_Fmaf(luxel->diffuse, intensity, light->color);
+		luxel->direction = Vec3_Fmaf(luxel->direction, intensity, dir);
 		break;
 	}
-
-	luxel->diffuse = Vec3_Fmaf(luxel->diffuse, intensity * scale, light->color);
-	luxel->direction = Vec3_Fmaf(luxel->direction, intensity * scale, dir);
 }
 
 /**
  * @brief
  */
 static void LightmapLuxel_Spot(const light_t *light, const lightmap_t *lightmap, luxel_t *luxel, float scale) {
+	vec3_t dir;
 
-	vec3_t points[light->num_points];
-
-	for (int32_t i = 0; i < light->num_points; i++) {
-		points[i] = Vec3_Subtract(light->points[i], luxel->origin);
+	float dist = Vec3_DistanceDir(light->origin, luxel->origin, &dir);
+	dist = Maxf(0.f, dist - light->size * .5f);
+	if (dist > light->radius) {
+		return;
 	}
 
-	qsort(points, light->num_points, sizeof(vec3_t), LightmapLuxel_cmp);
+	const float dot = Vec3_Dot(dir, luxel->normal);
+	if (dot <= 0.f) {
+		return;
+	}
 
-	float intensity = 0.f;
-	vec3_t dir = Vec3_Up();
+	const float cone_dot = Vec3_Dot(dir, Vec3_Negate(light->normal));
+	const float thresh = cosf(light->theta);
+	const float smooth = 0.03f;
+	const float cutoff = Smoothf(cone_dot, thresh - smooth, thresh + smooth);
+
+	if (cutoff <= 0.f) {
+		return;
+	}
+
+	float atten = 1.f;
+
+	switch (light->atten) {
+		case LIGHT_ATTEN_NONE:
+			break;
+		case LIGHT_ATTEN_LINEAR:
+			atten = Clampf(1.f - dist / light->radius, 0.f, 1.f);
+			break;
+		case LIGHT_ATTEN_INVERSE_SQUARE:
+			atten = Clampf(1.f - dist / light->radius, 0.f, 1.f);
+			atten *= atten;
+			break;
+	}
+
+	const float intensity = light->radius * dot * cutoff * atten * scale;
 
 	for (int32_t i = 0; i < light->num_points; i++) {
-
-		float dist;
-		dir = Vec3_NormalizeLength(points[i], &dist);
-		if (dist > light->radius) {
-			return;
-		}
-
-		const float dot = Vec3_Dot(dir, luxel->normal);
-		if (dot <= 0.f) {
-			continue;
-		}
-
-		const float cone_dot = Vec3_Dot(dir, Vec3_Negate(light->normal));
-		const float thresh = cosf(light->theta);
-		const float smooth = 0.03f;
-		const float cutoff = Smoothf(cone_dot, thresh - smooth, thresh + smooth);
-
-		if (cutoff <= 0.f) {
-			continue;
-		}
 
 		const cm_trace_t trace = Light_Trace(luxel->origin, light->points[i], lightmap->model->head_node, CONTENTS_SOLID);
 		if (trace.fraction < 1.f) {
 			continue;
 		}
 
-		float atten = 1.f;
-
-		switch (light->atten) {
-			case LIGHT_ATTEN_NONE:
-				break;
-			case LIGHT_ATTEN_LINEAR:
-				atten = Clampf(1.f - dist / light->radius, 0.f, 1.f);
-				break;
-			case LIGHT_ATTEN_INVERSE_SQUARE:
-				atten = Clampf(1.f - dist / light->radius, 0.f, 1.f);
-				atten *= atten;
-				break;
-		}
-
-		intensity = light->radius * dot * cutoff * atten;
+		luxel->diffuse = Vec3_Fmaf(luxel->diffuse, intensity, light->color);
+		luxel->direction = Vec3_Fmaf(luxel->direction, intensity, dir);
 		break;
 	}
-
-	luxel->diffuse = Vec3_Fmaf(luxel->diffuse, intensity * scale, light->color);
-	luxel->direction = Vec3_Fmaf(luxel->direction, intensity * scale, dir);
 }
 
 /**
  * @brief
  */
 static void LightmapLuxel_Patch(const light_t *light, const lightmap_t *lightmap, luxel_t *luxel, float scale) {
+	vec3_t dir;
 
 	if (light->model != bsp_file.models && light->model != lightmap->model) {
 		return;
 	}
 
-	if (Vec3_Dot(luxel->origin, light->plane->normal) - light->plane->dist <= 0.f) {
+	if (Vec3_Dot(luxel->origin, light->plane->normal) - light->plane->dist < -luxel_size) {
 		return;
 	}
 
-	vec3_t points[light->num_points];
-
-	for (int32_t i = 0; i < light->num_points; i++) {
-		points[i] = Vec3_Subtract(light->points[i], luxel->origin);
+	float dist = Vec3_DistanceDir(light->origin, luxel->origin, &dir);
+	dist = Maxf(0.f, dist - light->size * .5f);
+	if (dist > light->radius) {
+		return;
 	}
 
-	qsort(points, light->num_points, sizeof(vec3_t), LightmapLuxel_cmp);
+	const float dot = Vec3_Dot(dir, luxel->normal);
+	if (dot <= 0.f) {
+		return;
+	}
 
-	float intensity = 0.f;
-	vec3_t dir = Vec3_Up();
+	const float atten = Clampf(1.f - dist / light->radius, 0.f, 1.f);
+	const float intensity = light->radius * dot * atten * atten * scale;
 
 	for (int32_t i = 0; i < light->num_points; i++) {
-
-		float dist;
-		dir = Vec3_NormalizeLength(points[i], &dist);
-		if (dist > light->radius) {
-			return;
-		}
-
-		const float dot = Vec3_Dot(dir, luxel->normal);
-		if (dot <= 0.f) {
-			continue;
-		}
 
 		const cm_trace_t trace = Light_Trace(luxel->origin, light->points[i], lightmap->model->head_node, CONTENTS_SOLID);
 		if (trace.fraction < 1.f) {
 			continue;
 		}
 
-		const float atten = Clampf(1.f - dist / light->radius, 0.f, 1.f);
-
-		intensity = light->radius * dot * atten * atten;
+		luxel->diffuse = Vec3_Fmaf(luxel->diffuse, intensity, light->color);
+		luxel->direction = Vec3_Fmaf(luxel->direction, intensity, dir);
 		break;
 	}
-
-	luxel->diffuse = Vec3_Fmaf(luxel->diffuse, intensity * scale, light->color);
-	luxel->direction = Vec3_Fmaf(luxel->direction, intensity * scale, dir);
 }
 
 /**
  * @brief
  */
 static void LightmapLuxel_Indirect(const light_t *light, const lightmap_t *lightmap, luxel_t *luxel, float scale) {
+	vec3_t dir;
 
 	if (light->plane == lightmap->plane) {
 		return;
@@ -514,45 +469,34 @@ static void LightmapLuxel_Indirect(const light_t *light, const lightmap_t *light
 		return;
 	}
 
-	if (Vec3_Dot(luxel->origin, light->plane->normal) - light->plane->dist <= 0.f) {
+	if (Vec3_Dot(luxel->origin, light->plane->normal) - light->plane->dist < -luxel_size) {
 		return;
 	}
 
-	vec3_t points[light->num_points];
-
-	for (int32_t i = 0; i < light->num_points; i++) {
-		points[i] = Vec3_Subtract(light->points[i], luxel->origin);
+	float dist = Vec3_DistanceDir(light->origin, luxel->origin, &dir);
+	dist = Maxf(0.f, dist - light->size * .5f);
+	if (dist > light->radius) {
+		return;
 	}
 
-	qsort(points, light->num_points, sizeof(vec3_t), LightmapLuxel_cmp);
+	const float dot = Vec3_Dot(dir, luxel->normal);
+	if (dot <= 0.f) {
+		return;
+	}
 
-	float intensity = 0.f;
+	const float atten = Clampf(1.f - dist / light->radius, 0.f, 1.f);
+	const float intensity = light->radius * dot * atten * atten * scale;
 
 	for (int32_t i = 0; i < light->num_points; i++) {
-
-		float dist;
-		const vec3_t dir = Vec3_NormalizeLength(points[i], &dist);
-		if (dist > light->radius) {
-			return;
-		}
-
-		const float dot = Vec3_Dot(dir, luxel->normal);
-		if (dot <= 0.f) {
-			continue;
-		}
 
 		const cm_trace_t trace = Light_Trace(luxel->origin, light->points[i], lightmap->model->head_node, CONTENTS_SOLID);
 		if (trace.fraction < 1.f) {
 			continue;
 		}
 
-		const float atten = Clampf(1.f - dist / light->radius, 0.f, 1.f);
-
-		intensity = light->radius * dot * atten * atten;
+		luxel->radiosity[bounce] = Vec3_Fmaf(luxel->radiosity[bounce], intensity, light->color);
 		break;
 	}
-
-	luxel->radiosity[bounce] = Vec3_Fmaf(luxel->radiosity[bounce], intensity * scale, light->color);
 }
 
 /**

--- a/src/tools/quemap/main.c
+++ b/src/tools/quemap/main.c
@@ -315,7 +315,7 @@ static void PrintHelpMessage(void) {
 
 	Com_Print("-light             LIGHT stage options:\n");
 	Com_Print(" --antialias - calculate extra lighting samples and average them\n");
-	Com_Print(" --indirect - calculate indirect lighting\n");
+	Com_Print(" --no-indirect - skip indirect lighting\n");
 	Com_Print(" --bounce <integer> - indirect lighting bounces (default 1)\n");
 	Com_Print(" --radiosity <float> - radiosity level (default 0.125)\n");
 	Com_Print(" --brightness <float> - brightness (default 1.0)\n");

--- a/src/tools/quemap/patch.c
+++ b/src/tools/quemap/patch.c
@@ -28,10 +28,12 @@ patch_t *patches;
 /**
  * @brief
  */
-static patch_t *BuildPatch(const bsp_face_t *face, const vec3_t origin, cm_winding_t *w) {
+static patch_t *BuildPatch(const bsp_model_t *model, const bsp_face_t *face,
+						   const vec3_t origin, cm_winding_t *w) {
 
 	patch_t *patch = &patches[face - bsp_file.faces];
 
+	patch->model = model;
 	patch->face = face;
 	patch->origin = origin;
 	patch->winding = w;
@@ -70,15 +72,15 @@ void BuildPatches(void) {
 
 	for (int32_t i = 0; i < bsp_file.num_models; i++) {
 
-		const bsp_model_t *mod = &bsp_file.models[i];
+		const bsp_model_t *model = &bsp_file.models[i];
 		const cm_entity_t *ent = EntityForModel(i);
 
 		// inline models need to be offset into their in-use position
 		const vec3_t origin = Cm_EntityValue(ent, "origin")->vec3;
 
-		for (int32_t j = 0; j < mod->num_faces; j++) {
+		for (int32_t j = 0; j < model->num_faces; j++) {
 
-			const int32_t face_num = mod->first_face + j;
+			const int32_t face_num = model->first_face + j;
 			const bsp_face_t *face = &bsp_file.faces[face_num];
 
 			cm_winding_t *w = Cm_WindingForFace(&bsp_file, face);
@@ -87,7 +89,7 @@ void BuildPatches(void) {
 				w->points[k] = Vec3_Add(w->points[k], origin);
 			}
 
-			BuildPatch(face, origin, w);
+			BuildPatch(model, face, origin, w);
 		}
 	}
 }
@@ -129,6 +131,7 @@ static void SubdividePatch_r(patch_t *patch) {
 
 	// create a new patch
 	patch_t *p = (patch_t *) Mem_TagMalloc(sizeof(*p), MEM_TAG_PATCH);
+	p->model = patch->model;
 	p->face = patch->face;
 
 	p->origin = patch->origin;

--- a/src/tools/quemap/patch.h
+++ b/src/tools/quemap/patch.h
@@ -25,6 +25,7 @@
 #include "polylib.h"
 
 typedef struct patch_s {
+	const bsp_model_t *model;
 	const bsp_face_t *face;
 	vec3_t origin;
 	cm_winding_t *winding;


### PR DESCRIPTION
Okay, here goes:

![quetoo015](https://user-images.githubusercontent.com/643118/151684595-709fbb90-5370-4739-830a-d2f58bcf8b45.jpg)
![quetoo016](https://user-images.githubusercontent.com/643118/151684599-f9ccf8ab-3318-4d07-b4c6-b43f30a682f8.jpg)
![quetoo017](https://user-images.githubusercontent.com/643118/151684601-da9b954e-3e39-4b98-8298-81daba4ce8c5.jpg)
![quetoo018](https://user-images.githubusercontent.com/643118/151684604-035267da-6a34-4e5b-b6ab-d98bde27280e.jpg)
![quetoo019](https://user-images.githubusercontent.com/643118/151684608-5ed2046b-acab-49d4-9e43-488dbf25c820.jpg)
![quetoo020](https://user-images.githubusercontent.com/643118/151684612-9ea2b9e3-0a26-41f3-a4ce-fa9d5eb9c34e.jpg)
![quetoo021](https://user-images.githubusercontent.com/643118/151684615-47eea965-352f-4156-ac3b-cab2aa80829f.jpg)

These are all using the unmodified `fragpipe.map` that is in Git. No changes to the map or materials have been made at all. Things that are fixed:

_Background: since we added the `_size` code over a year ago, every light source is actually a collection of points, not just a single point. I refer to these as "sample points." This enables a lot of nice looking effects, but complicates the code._

1. Light bleed. This was due to the old light `_size` code that generated sample points around the light origin. This code checked each point for solid / not solid, but did not run a trace from the light origin to the sample point. So if a sample point got projected through a wall into a valid position, it would still be used. This is no longer the case. I trace from the light origin to each light sample point to ensure it is valid.
2. Indirect lights no longer light their neighbors. There was already a check to not self-light. But because patch lights project their sample points out a few units from the wall, they were actually lighting their neighbors. This was the cause of the "Why is the red light climbing all the way up this wall?" and also "Why is this large floor peppered in hot spots?"
3. Patch size deficiencies. The old code calculated attenuation from the light origin, not from the light sample point in question. This resulted in hot spots and cool spots near large face lights, and required you to dial `patch_size` down to get nice looking face lights. The new code now correctly calculates attenuation based on the actual light sample point being checked.
4. Sunlight now diffuses correctly, and does not require a massive `_size` to do it. The old code pushed the sun origin `MAX_WORLD_DIST` away, so even a `_size` of 512 units wasn't going to produce much variation. Sun `_size` now kicks in at a distance of 1024 units, and so even the default sun `_size` of 32 units produces nice soft edges. You can crank this up to get nice looking penumbrae. 

Optimizations:

1. For point lights, spot lights, patch lights and indirect lights: rather than calculating sample points over and over for every single luxel, I calculate these up front when the light is created. For sun lights, I calculate a bouquet of directional vectors.
2. When lighting a luxel, the light sample points are first sorted by distance, and tried in order. The first sample point with a successful trace is used, giving the best possible attenuation for that luxel. If we reach a sample point for which the luxel is out of range, we can break early.
3. For patch and indirect lights, use the face plane to perform a sidedness check against the luxel origin. This allows us to skip a *ton* of traces.
4. Kind of covered in fixes above, but, by not lighting coplanar neighbors, indirect lighting got a nice boost.
5. Don't bother antialiasing indirect lighting. It's just not necessary.

The bake you're looking at is a full compile (`quemap -light --antialias maps/fragpipe.map`) and took 129s on a 5 year old laptop.