### PR TITLE
#662 Global fog

### DIFF
--- a/src/client/renderer/r_main.c
+++ b/src/client/renderer/r_main.c
@@ -263,9 +263,21 @@ static void R_UpdateUniforms(const r_view_t *view) {
 			const cm_entity_t *fog_color = Cm_EntityValue(worldspawn, "fog_color");
 			const cm_entity_t *fog_density = Cm_EntityValue(worldspawn, "fog_density");
 			const cm_entity_t *fog_depth_range = Cm_EntityValue(worldspawn, "fog_depth_range");
-			r_uniforms.block.fog_color = Vec3_ToVec4(fog_color->vec3, fog_density->value * r_fog_density->value);
-			r_uniforms.block.fog_depth_range = fog_depth_range->parsed & ENTITY_VEC2 ?
-				fog_depth_range->vec2 : Vec2(FOG_DEPTH_NEAR, FOG_DEPTH_FAR);
+
+			r_uniforms.block.fog_density = FOG_DENSITY * r_fog_density->value;
+			r_uniforms.block.fog_depth_range = Vec2(FOG_DEPTH_NEAR, FOG_DEPTH_FAR);
+
+			if (fog_color->parsed & ENTITY_VEC3) {
+				r_uniforms.block.fog_color = Vec3_ToVec4(fog_color->vec3, FOG_DENSITY);
+			}
+
+			if (fog_density->parsed & ENTITY_FLOAT) {
+				r_uniforms.block.fog_color.w = fog_density->value * r_fog_density->value;
+			}
+
+			if (fog_depth_range->parsed & ENTITY_VEC2) {
+				r_uniforms.block.fog_depth_range = fog_depth_range->vec2;
+			}
 		}
 	}
 

--- a/src/client/renderer/r_main.c
+++ b/src/client/renderer/r_main.c
@@ -258,6 +258,14 @@ static void R_UpdateUniforms(const r_view_t *view) {
 
 			r_uniforms.block.lightgrid.view_coordinate = Vec3_ToVec4(Vec3_Divide(pos, size), 0.f);
 			r_uniforms.block.lightgrid.size = Vec3_ToVec4(Vec3i_CastVec3(r_world_model->bsp->lightgrid->size), 0.f);
+
+			const cm_entity_t *worldspawn = r_world_model->bsp->cm->entities[0];
+			const cm_entity_t *fog_color = Cm_EntityValue(worldspawn, "fog_color");
+			const cm_entity_t *fog_density = Cm_EntityValue(worldspawn, "fog_density");
+			const cm_entity_t *fog_depth_range = Cm_EntityValue(worldspawn, "fog_depth_range");
+			r_uniforms.block.fog_color = Vec3_ToVec4(fog_color->vec3, fog_density->value * r_fog_density->value);
+			r_uniforms.block.fog_depth_range = fog_depth_range->parsed & ENTITY_VEC2 ?
+				fog_depth_range->vec2 : Vec2(FOG_DEPTH_NEAR, FOG_DEPTH_FAR);
 		}
 	}
 

--- a/src/client/renderer/r_main.h
+++ b/src/client/renderer/r_main.h
@@ -105,6 +105,9 @@ typedef struct {
 	vec4_t size;
 } r_lightgrid_t;
 
+#define FOG_DEPTH_NEAR 128.0
+#define FOG_DEPTH_FAR 2048.0
+
 /**
  * @brief The uniforms block type.
  */
@@ -145,9 +148,19 @@ typedef struct {
 		r_lightgrid_t lightgrid;
 
 		/**
+		 * @brief The global fog color (RGB, density).
+		 */
+		vec4_t fog_color;
+
+		/**
 		 * @brief The depth range, in world units.
 		 */
 		vec2_t depth_range;
+
+		/**
+		 * @brief The global fog depth range, in world units.
+		 */
+		vec2_t fog_depth_range;
 
 		/**
 		 * @brief The view type, e.g. VIEW_MAIN.

--- a/src/client/renderer/r_main.h
+++ b/src/client/renderer/r_main.h
@@ -105,8 +105,9 @@ typedef struct {
 	vec4_t size;
 } r_lightgrid_t;
 
-#define FOG_DEPTH_NEAR 128.0
-#define FOG_DEPTH_FAR 2048.0
+#define FOG_DENSITY    1.f
+#define FOG_DEPTH_NEAR 128.f
+#define FOG_DEPTH_FAR  2048.f
 
 /**
  * @brief The uniforms block type.

--- a/src/client/renderer/shaders/bsp_fs.glsl
+++ b/src/client/renderer/shaders/bsp_fs.glsl
@@ -125,6 +125,7 @@ void main(void) {
 		out_bloom.a = out_color.a;
 
 		lightgrid_fog(out_color, texture_lightgrid_fog, vertex.position, vertex.lightgrid);
+		global_fog(out_color, vertex.position);
 
 		//out_color.rgb = caustic;
 		//out_color.rgb = texture(texture_lightgrid_diffuse, vertex.lightgrid).rgb;

--- a/src/client/renderer/shaders/common.glsl
+++ b/src/client/renderer/shaders/common.glsl
@@ -283,3 +283,14 @@ void dynamic_light(in vec3 position, in vec3 normal, in float specular_exponent,
 		}
 	}
 }
+
+/**
+ * @brief
+ */
+void global_fog(inout vec4 color, in vec3 position) {
+
+	float dist = clamp(0.0, length(position) - fog_depth_range.x, fog_depth_range.y);
+	float frac = dist / (fog_depth_range.y - fog_depth_range.x);
+
+	color.rgb += fog_color.rgb * frac * fog_color.a;
+}

--- a/src/client/renderer/shaders/lightgrid.glsl
+++ b/src/client/renderer/shaders/lightgrid.glsl
@@ -68,7 +68,7 @@ vec3 lightgrid_uvw(in vec3 position) {
 void lightgrid_fog(inout vec4 color, in sampler3D lightgrid_fog_sampler,
 				   in vec3 position, in vec3 lightgrid_uvw) {
 
-	if (fog_density == 0.0) {
+	if (fog_samples == 0) {
 		return;
 	}
 

--- a/src/client/renderer/shaders/mesh_fs.glsl
+++ b/src/client/renderer/shaders/mesh_fs.glsl
@@ -104,7 +104,7 @@ void main(void) {
 
 		// fog 
 		// out_color.rgb *= 1.0 - vertex.fog.a; // black? sigh.
-		out_color.rgb += vertex.fog.rgb;
+		out_color.rgb += vertex.fog.rgb * out_color.a;
 
 	} else {
 

--- a/src/client/renderer/shaders/mesh_vs.glsl
+++ b/src/client/renderer/shaders/mesh_vs.glsl
@@ -102,6 +102,7 @@ void main(void) {
 
 		vertex.fog = vec4(0.0, 0.0, 0.0, 1.0);
 		lightgrid_fog(vertex.fog, texture_lightgrid_fog, vertex.position, lightgrid_uvw);
+		global_fog(vertex.fog, vertex.position);
 	}
 
 	gl_Position = projection3D * vec4(vertex.position, 1.0);

--- a/src/client/renderer/shaders/sky_fs.glsl
+++ b/src/client/renderer/shaders/sky_fs.glsl
@@ -42,7 +42,7 @@ void main(void) {
 	out_bloom.a = out_color.a;
 
 	lightgrid_fog(out_color, texture_lightgrid_fog, vertex.position, vertex.lightgrid);
-	global_fog(out_color, min(vertex.position * 2.f, vec3(fog_depth_range.y)));
+	global_fog(out_color, vec3(fog_depth_range.y));
 	
 	out_color = postprocess(out_color);
 }

--- a/src/client/renderer/shaders/sky_fs.glsl
+++ b/src/client/renderer/shaders/sky_fs.glsl
@@ -42,6 +42,7 @@ void main(void) {
 	out_bloom.a = out_color.a;
 
 	lightgrid_fog(out_color, texture_lightgrid_fog, vertex.position, vertex.lightgrid);
-
+	global_fog(out_color, min(vertex.position * 2.f, vec3(fog_depth_range.y)));
+	
 	out_color = postprocess(out_color);
 }

--- a/src/client/renderer/shaders/sprite_fs.glsl
+++ b/src/client/renderer/shaders/sprite_fs.glsl
@@ -46,6 +46,7 @@ void main(void) {
 		vertex.lerp);
 
 	out_color = texture_color * vertex.color;
+	out_color.rgb += vertex.fog.rgb * out_color.a;
 
 	out_color = color_filter(out_color);
 	

--- a/src/client/renderer/shaders/sprite_vs.glsl
+++ b/src/client/renderer/shaders/sprite_vs.glsl
@@ -100,6 +100,8 @@ void main(void) {
 
 	vertex.fog = vec4(0.0, 0.0, 0.0, 1.0);
 	lightgrid_fog(vertex.fog, texture_lightgrid_fog, vertex.position, lightgrid_uvw);
+	global_fog(vertex.fog, vertex.position);
+
 	sprite_lighting(vertex.position, vec3(0.0, 0.0, 1.0)); // TODO: actual normals
 
 	gl_Position = projection3D * view * position;

--- a/src/client/renderer/shaders/uniforms.glsl
+++ b/src/client/renderer/shaders/uniforms.glsl
@@ -79,9 +79,19 @@ layout (std140) uniform uniforms_block {
 	lightgrid_t lightgrid;
 
 	/**
+	 * @brief The global fog color (RGB, density).
+	 */
+	vec4 fog_color;
+
+	/**
 	 * @brief The depth range, in world units.
 	 */
 	vec2 depth_range;
+
+	/**
+	 * @brief The global fog depth range, in world units.
+	 */
+	vec2 fog_depth_range;
 
 	/**
 	 * @brief The view type, e.g. VIEW_MAIN.
@@ -119,12 +129,12 @@ layout (std140) uniform uniforms_block {
 	float modulate;
 
 	/**
-	 * @brief The fog density scalar.
+	 * @brief The volumetric fog density scalar.
 	 */
 	float fog_density;
 
 	/**
-	 * @brief The number of fog samples per fragment (quality).
+	 * @brief The number of volumetric fog samples per fragment (quality).
 	 */
 	int fog_samples;
 

--- a/src/collision/cm_entity.c
+++ b/src/collision/cm_entity.c
@@ -66,6 +66,9 @@ GList *Cm_LoadEntities(const char *entity_string) {
 					case 1:
 						pair->parsed |= ENTITY_FLOAT;
 						break;
+					case 2:
+						pair->parsed |= ENTITY_VEC2;
+						break;
 					case 3:
 						pair->parsed |= ENTITY_VEC3;
 						break;

--- a/src/collision/cm_types.h
+++ b/src/collision/cm_types.h
@@ -138,14 +138,19 @@ typedef enum {
 	ENTITY_FLOAT = 0x4,
 
 	/**
+	 * @brief A two component vector value is available.
+	 */
+	ENTITY_VEC2 = 0x8,
+
+	/**
 	 * @brief A three component vector value is available.
 	 */
-	ENTITY_VEC3 = 0x8,
+	ENTITY_VEC3 = 0x10,
 
 	/**
 	 * @brief A four component vector is available.
 	 */
-	ENTITY_VEC4 = 0x10,
+	ENTITY_VEC4 = 0x20,
 
 } cm_entity_parsed_t;
 
@@ -188,6 +193,11 @@ typedef struct cm_entity_s {
 		 * @brief The entity pair value, as a float.
 		 */
 		float value;
+
+		/**
+		 * @brief The entity pair value, as a two component vector.
+		 */
+		vec2_t vec2;
 
 		/**
 		 * @brief The entity pair value, as a three component vector.

--- a/src/tools/quemap/fog.c
+++ b/src/tools/quemap/fog.c
@@ -113,52 +113,7 @@ static void FogSetPermutationVector(fog_t *fog) {
 static void FogForEntity(const cm_entity_t *entity) {
 
 	const char *class_name = Cm_EntityValue(entity, "classname")->string;
-	if (!g_strcmp0(class_name, "worldspawn")) {
-
-		if (Cm_EntityValue(entity, "fog_absorption")->parsed ||
-			Cm_EntityValue(entity, "fog_color")->parsed ||
-			Cm_EntityValue(entity, "fog_density")->parsed ||
-			Cm_EntityValue(entity, "fog_noise")->parsed ||
-			Cm_EntityValue(entity, "fog_frequency")->parsed ||
-			Cm_EntityValue(entity, "fog_amplitude")->parsed ||
-			Cm_EntityValue(entity, "fog_lacunarity")->parsed ||
-			Cm_EntityValue(entity, "fog_persistence")->parsed ||
-			Cm_EntityValue(entity, "fog_octaves")->parsed ||
-			Cm_EntityValue(entity, "fog_seed")->parsed ||
-			Cm_EntityValue(entity, "fog_offset")->parsed) {
-
-			fog_t fog = {};
-			fog.type = FOG_GLOBAL;
-			fog.entity = entity;
-			
-			if (Cm_EntityValue(entity, "fog_absorption")->parsed & ENTITY_FLOAT) {
-				fog.absorption = Cm_EntityValue(entity, "fog_absorption")->value;
-			} else {
-				fog.absorption = FOG_ABSORPTION;
-			}
-
-			const cm_entity_t *color = Cm_EntityValue(entity, "fog_color");
-			if (color->parsed & ENTITY_VEC3) {
-				fog.color = color->vec3;
-			} else {
-				fog.color = FOG_COLOR;
-			}
-
-			fog.density = Cm_EntityValue(entity, "fog_density")->value ?: FOG_DENSITY;
-			fog.noise = Cm_EntityValue(entity, "fog_noise")->value ?: FOG_NOISE;
-			fog.frequency = Cm_EntityValue(entity, "fog_frequency")->value ?: FOG_FREQUENCY;
-			fog.amplitude = Cm_EntityValue(entity, "fog_amplitude")->value ?: FOG_AMPLITUDE;
-			fog.lacunarity = Cm_EntityValue(entity, "fog_lacunarity")->value ?: FOG_LACUNARITY;
-			fog.persistence = Cm_EntityValue(entity, "fog_persistence")->value ?: FOG_PERSISTENCE;
-			fog.octaves = Cm_EntityValue(entity, "fog_octaves")->integer ?: FOG_OCTAVES;
-			fog.seed = Cm_EntityValue(entity, "fog_seed")->integer ?: FOG_SEED;
-			fog.offset = (Cm_EntityValue(entity, "fog_offset")->parsed & ENTITY_VEC3) ? Cm_EntityValue(entity, "fog_offset")->vec3 : FOG_OFFSET;
-
-			FogSetPermutationVector(&fog);
-
-			g_array_append_val(fogs, fog);
-		}
-	} else if (!g_strcmp0(class_name, "misc_fog")) {
+	if (!g_strcmp0(class_name, "misc_fog")) {
 
 		fog_t fog = {};
 		fog.type = FOG_VOLUME;
@@ -184,7 +139,8 @@ static void FogForEntity(const cm_entity_t *entity) {
 		fog.persistence = Cm_EntityValue(entity, "persistence")->value ?: FOG_PERSISTENCE;
 		fog.octaves = Cm_EntityValue(entity, "octaves")->integer ?: FOG_OCTAVES;
 		fog.seed = Cm_EntityValue(entity, "seed")->integer ?: FOG_SEED;
-		fog.offset = (Cm_EntityValue(entity, "offset")->parsed & ENTITY_VEC3) ? Cm_EntityValue(entity, "offset")->vec3 : FOG_OFFSET;
+		fog.offset = (Cm_EntityValue(entity, "offset")->parsed & ENTITY_VEC3) ?
+			Cm_EntityValue(entity, "offset")->vec3 : FOG_OFFSET;
 
 		fog.brushes = Cm_EntityBrushes(entity);
 


### PR DESCRIPTION
This PR addresses #662 and reintroduces an OpenGL 1.x style fog, specified in `worldspawn` with a few keys. Mappers can specify color, density, start and end (depth range). Mappers can still create a global volumetric fog if they want noise, light absorption, etc. But this solves sky boxes not looking correctly fogged, and generally things in the distance not fogging correctly as well. It coexists just fine with the volumetric fog. Here's an example:

```
"fog_density" "1"
"fog_color" "0.996 0.741 0.500"
```

![quetoo043](https://user-images.githubusercontent.com/643118/152002203-30e5c80a-a672-44de-832c-c58760339dc6.png)

cc @Panjoo 

