### PR TITLE
Programmatically generate occlusion queries

### DIFF
--- a/Quetoo.xcodeproj/xcshareddata/xcschemes/quemap.xcscheme
+++ b/Quetoo.xcodeproj/xcshareddata/xcschemes/quemap.xcscheme
@@ -158,7 +158,7 @@
          </CommandLineArgument>
          <CommandLineArgument
             argument = "maps/darkzone.map"
-            isEnabled = "NO">
+            isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument
             argument = "maps/edge.map"
@@ -190,7 +190,7 @@
          </CommandLineArgument>
          <CommandLineArgument
             argument = "maps/pits.map"
-            isEnabled = "YES">
+            isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
             argument = "maps/lavatomb.map"

--- a/Quetoo.xcodeproj/xcshareddata/xcschemes/quetoo-all.xcscheme
+++ b/Quetoo.xcodeproj/xcshareddata/xcschemes/quetoo-all.xcscheme
@@ -89,6 +89,10 @@
             isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
+            argument = "+set r_draw_occlusion_queries 1"
+            isEnabled = "YES">
+         </CommandLineArgument>
+         <CommandLineArgument
             argument = "+set r_texture_storage 0"
             isEnabled = "YES">
          </CommandLineArgument>

--- a/src/cgame/cgame.h
+++ b/src/cgame/cgame.h
@@ -738,23 +738,6 @@ typedef struct cg_import_s {
 	void (*InitView)(r_view_t *view);
 
 	/**
-	 * @brief Creates an occlusion query with the specified bounds.
-	 * @remarks The returned query should be destroyed when no longer needed.
-	 */
-	r_occlusion_query_t (*CreateOcclusionQuery)(const box3_t bounds);
-
-	/*
-	 * @brief Destroys the specified occlusion query.
-	 */
-	void (*DestroyOcclusionQuery)(r_occlusion_query_t *query);
-
-	/**
-	 * @brief Add an occlusion query to the scene.
-	 * @remarks Occlusion queries must be added in `Cg_PrepareView` and not `Cg_PopulateView`.
-	 */
-	void (*AddOcclusionQuery)(r_view_t *view, r_occlusion_query_t *query);
-
-	/**
 	 * @return True if the bounding box is culled or occluded, false otherwise.
 	 */
 	_Bool (*CulludeBox)(const r_view_t *view, const box3_t bounds);

--- a/src/cgame/cgame.h
+++ b/src/cgame/cgame.h
@@ -738,10 +738,21 @@ typedef struct cg_import_s {
 	void (*InitView)(r_view_t *view);
 
 	/**
+	 * @brief Creates an occlusion query with the specified bounds.
+	 * @remarks The returned query should be destroyed when no longer needed.
+	 */
+	r_occlusion_query_t (*CreateOcclusionQuery)(const box3_t bounds);
+
+	/*
+	 * @brief Destroys the specified occlusion query.
+	 */
+	void (*DestroyOcclusionQuery)(r_occlusion_query_t *query);
+
+	/**
 	 * @brief Add an occlusion query to the scene.
 	 * @remarks Occlusion queries must be added in `Cg_PrepareView` and not `Cg_PopulateView`.
 	 */
-	void (*AddOcclusionQuery)(r_view_t *view, const box3_t bounds);
+	void (*AddOcclusionQuery)(r_view_t *view, r_occlusion_query_t *query);
 
 	/**
 	 * @return True if the bounding box is culled or occluded, false otherwise.

--- a/src/cgame/default/cg_entity.c
+++ b/src/cgame/default/cg_entity.c
@@ -158,12 +158,6 @@ void Cg_LoadEntities(void) {
 void Cg_FreeEntities(void) {
 
 	if (cg_entities) {
-
-		cg_entity_t *e = (cg_entity_t *) cg_entities->data;
-		for (guint i = 0; i < cg_entities->len; i++, e++) {
-			cgi.DestroyOcclusionQuery(&e->query);
-		}
-
 		g_array_free(cg_entities, true);
 		cg_entities = NULL;
 	}

--- a/src/cgame/default/cg_entity.c
+++ b/src/cgame/default/cg_entity.c
@@ -158,6 +158,12 @@ void Cg_LoadEntities(void) {
 void Cg_FreeEntities(void) {
 
 	if (cg_entities) {
+
+		cg_entity_t *e = (cg_entity_t *) cg_entities->data;
+		for (guint i = 0; i < cg_entities->len; i++, e++) {
+			cgi.DestroyOcclusionQuery(&e->query);
+		}
+
 		g_array_free(cg_entities, true);
 		cg_entities = NULL;
 	}
@@ -334,7 +340,7 @@ void Cg_AddEntities(const cl_frame_t *frame) {
 		Cg_AddEntity(ent);
 	}
 
-	// and client-side entities too
+	// and client side entities too
 	cg_entity_t *e = (cg_entity_t *) cg_entities->data;
 	for (guint i = 0; i < cg_entities->len; i++, e++) {
 

--- a/src/cgame/default/cg_entity.h
+++ b/src/cgame/default/cg_entity.h
@@ -88,6 +88,11 @@ struct cg_entity_s {
 	box3_t bounds;
 
 	/**
+	 * @brief The entity occlusion query.
+	 */
+	r_occlusion_query_t query;
+
+	/**
 	 * @brief The entity's target, if any.
 	 */
 	const cm_entity_t *target;

--- a/src/cgame/default/cg_entity.h
+++ b/src/cgame/default/cg_entity.h
@@ -88,11 +88,6 @@ struct cg_entity_s {
 	box3_t bounds;
 
 	/**
-	 * @brief The entity occlusion query.
-	 */
-	r_occlusion_query_t query;
-
-	/**
 	 * @brief The entity's target, if any.
 	 */
 	const cm_entity_t *target;

--- a/src/cgame/default/cg_entity_misc.c
+++ b/src/cgame/default/cg_entity_misc.c
@@ -134,6 +134,8 @@ static void Cg_misc_dust_Init(cg_entity_t *self) {
 
 		dust->num_origins += brush_origins;
 	}
+
+	self->query = cgi.CreateOcclusionQuery(self->bounds);
 }
 
 /**
@@ -240,6 +242,7 @@ static void Cg_misc_flame_Init(cg_entity_t *self) {
 	flame->radius = cgi.EntityValue(self->def, "radius")->value ?: 16.f;
 
 	self->bounds = Box3_FromCenterRadius(self->origin, flame->radius * 16.f);
+	self->query = cgi.CreateOcclusionQuery(self->bounds);
 
 	const char *sound = cgi.EntityValue(self->def, "sound")->nullable_string;
 	if (sound) {
@@ -377,6 +380,7 @@ static void Cg_misc_light_Init(cg_entity_t *self) {
 	g_strlcpy(data->style.string, style, sizeof(data->style.string));
 
 	self->bounds = Box3_FromCenterRadius(self->origin, data->light.radius);
+	self->query = cgi.CreateOcclusionQuery(self->bounds);
 }
 
 /**

--- a/src/cgame/default/cg_entity_misc.c
+++ b/src/cgame/default/cg_entity_misc.c
@@ -111,6 +111,7 @@ static void Cg_misc_dust_Init(cg_entity_t *self) {
 	for (guint i = 0; i < brushes->len; i++) {
 
 		const cm_bsp_brush_t *brush = g_ptr_array_index(brushes, i);
+		self->bounds = Box3_Union(self->bounds, brush->bounds);
 
 		const vec3_t brush_size = Box3_Size(brush->bounds);
 		const int32_t brush_origins = Maxi(Vec3_Length(brush_size) * dust->density, 1);
@@ -127,7 +128,6 @@ static void Cg_misc_dust_Init(cg_entity_t *self) {
 			const vec3_t point = Box3_RandomPoint(brush->bounds);
 
 			if (cgi.PointInsideBrush(point, brush)) {
-				self->bounds = Box3_Append(self->bounds, point);
 				dust->origins[j++] = point;
 			}
 		}
@@ -257,6 +257,10 @@ static void Cg_misc_flame_Init(cg_entity_t *self) {
 static void Cg_misc_flame_Think(cg_entity_t *self) {
 
 	cg_flame_t *flame = self->data;
+
+	if (cgi.CulludeBox(cgi.view, self->bounds)) {
+		return;
+	}
 
 	const float r = flame->radius;
 	const float s = Clampf(r / 64.f, .125f, 1.f);

--- a/src/cgame/default/cg_entity_misc.c
+++ b/src/cgame/default/cg_entity_misc.c
@@ -134,8 +134,6 @@ static void Cg_misc_dust_Init(cg_entity_t *self) {
 
 		dust->num_origins += brush_origins;
 	}
-
-	self->query = cgi.CreateOcclusionQuery(self->bounds);
 }
 
 /**
@@ -242,7 +240,6 @@ static void Cg_misc_flame_Init(cg_entity_t *self) {
 	flame->radius = cgi.EntityValue(self->def, "radius")->value ?: 16.f;
 
 	self->bounds = Box3_FromCenterRadius(self->origin, flame->radius * 16.f);
-	self->query = cgi.CreateOcclusionQuery(self->bounds);
 
 	const char *sound = cgi.EntityValue(self->def, "sound")->nullable_string;
 	if (sound) {
@@ -380,7 +377,6 @@ static void Cg_misc_light_Init(cg_entity_t *self) {
 	g_strlcpy(data->style.string, style, sizeof(data->style.string));
 
 	self->bounds = Box3_FromCenterRadius(self->origin, data->light.radius);
-	self->query = cgi.CreateOcclusionQuery(self->bounds);
 }
 
 /**

--- a/src/cgame/default/cg_light.c
+++ b/src/cgame/default/cg_light.c
@@ -81,15 +81,7 @@ static void Cg_AddBspLights(void) {
 				break;
 		}
 
-		if (l->shadow == 0.f) {
-			continue;
-		}
-
-		if (Box3_Radius(l->bounds) < 64.f) {
-			continue;
-		}
-
-		if (l->query.result == 0) {
+		if (l->shadow == 0.f || Box3_Radius(l->bounds) < 64.f) {
 			continue;
 		}
 
@@ -217,7 +209,7 @@ void Cg_AddLights(void) {
 
 	Cg_AddBspLights();
 
-	Cg_AddAmbientLights();
+	//Cg_AddAmbientLights();
 }
 
 /**

--- a/src/cgame/default/cg_light.c
+++ b/src/cgame/default/cg_light.c
@@ -147,7 +147,6 @@ static void Cg_AddAmbientLights(void) {
 
 		if (IS_BSP_INLINE_MODEL(e->model)) {
 			const r_bsp_inline_model_t *in = e->model->bsp_inline;
-
 			const cm_entity_t *cm = cgi.EntityValue(in->def, "classname");
 			if (!g_strcmp0(cm->string, "func_rotating") ||
 				!g_strcmp0(cm->string, "func_door_rotating")) {
@@ -209,7 +208,7 @@ void Cg_AddLights(void) {
 
 	Cg_AddBspLights();
 
-	//Cg_AddAmbientLights();
+	Cg_AddAmbientLights();
 }
 
 /**

--- a/src/cgame/default/cg_light.c
+++ b/src/cgame/default/cg_light.c
@@ -89,6 +89,10 @@ static void Cg_AddBspLights(void) {
 			continue;
 		}
 
+		if (l->query.result == 0) {
+			continue;
+		}
+
 		cgi.AddLight(cgi.view, &(const r_light_t) {
 			.type = l->type,
 			.atten = l->atten,

--- a/src/cgame/default/cg_light.h
+++ b/src/cgame/default/cg_light.h
@@ -63,11 +63,6 @@ typedef struct {
 	 * @brief The time when this light was added.
 	 */
 	uint32_t time;
-
-	/**
-	 * @brief The light occlusion query.
-	 */
-	r_occlusion_query_t query;
 } cg_light_t;
 
 void Cg_AddLight(const cg_light_t *s);

--- a/src/cgame/default/cg_light.h
+++ b/src/cgame/default/cg_light.h
@@ -64,6 +64,10 @@ typedef struct {
 	 */
 	uint32_t time;
 
+	/**
+	 * @brief The light occlusion query.
+	 */
+	r_occlusion_query_t query;
 } cg_light_t;
 
 void Cg_AddLight(const cg_light_t *s);

--- a/src/cgame/default/cg_view.c
+++ b/src/cgame/default/cg_view.c
@@ -290,70 +290,6 @@ static void Cg_UpdateAngles(const player_state_t *ps0, const player_state_t *ps1
 }
 
 /**
- * @brief
- */
-static void Cg_AddOcclusionQueries(const cl_frame_t *frame) {
-
-	const r_model_t *mod = cgi.WorldModel();
-
-	// add brush queries
-	r_occlusion_query_t *query = mod->bsp->occlusion_queries;
-	for (int32_t i = 0; i < mod->bsp->num_occlusion_queries; i++, query++) {
-		cgi.AddOcclusionQuery(cgi.view, query);
-	}
-
-	// and light queries
-	r_bsp_light_t *light = mod->bsp->lights;
-	for (int32_t i = 0; i < mod->bsp->num_lights; i++, light++) {
-
-		switch (light->type) {
-			case LIGHT_INVALID:
-			case LIGHT_AMBIENT:
-			case LIGHT_SUN:
-			case LIGHT_INDIRECT:
-				continue;
-			default:
-				break;
-		}
-
-		if (light->shadow == 0.f) {
-			continue;
-		}
-
-		if (Box3_Radius(light->bounds) < 64.f) {
-			continue;
-		}
-
-		cgi.AddOcclusionQuery(cgi.view, &light->query);
-	}
-
-	// and server side entity queries
-//	for (int32_t i = 0; i < frame->num_entities; i++) {
-//
-//		const uint32_t snum = (frame->entity_state + i) & ENTITY_STATE_MASK;
-//		const entity_state_t *s = &cgi.client->entity_states[snum];
-//
-//		cl_entity_t *ent = &cgi.client->entities[s->number];
-//
-//		if (ent->current.model1) {
-//			if (ent->query.name == 0) {
-//				ent->query = cgi.CreateOcclusionQuery(ent->abs_bounds);
-//			}
-//			cgi.AddOcclusionQuery(cgi.view, &ent->query);
-//		}
-//	}
-
-	// and client side queries too
-	cg_entity_t *e = (cg_entity_t *) cg_entities->data;
-	for (guint i = 0; i < cg_entities->len; i++, e++) {
-
-		if (e->query.name) {
-			cgi.AddOcclusionQuery(cgi.view, &e->query);
-		}
-	}
-}
-
-/**
  * @brief Updates the view origin, angles, and field of view.
  */
 void Cg_PrepareView(const cl_frame_t *frame) {
@@ -385,8 +321,6 @@ void Cg_PrepareView(const cl_frame_t *frame) {
 	Cg_UpdateFov();
 
 	Cg_UpdateBob(ps1);
-
-	Cg_AddOcclusionQueries(frame);
 
 	cgi.view->contents = cgi.PointContents(cgi.view->origin);
 

--- a/src/cgame/default/cg_view.c
+++ b/src/cgame/default/cg_view.c
@@ -292,21 +292,21 @@ static void Cg_UpdateAngles(const player_state_t *ps0, const player_state_t *ps1
 /**
  * @brief
  */
-static void Cg_AddOcclusionQueries(void) {
+static void Cg_AddOcclusionQueries(const cl_frame_t *frame) {
 
 	const r_model_t *mod = cgi.WorldModel();
 
-	const cm_bsp_brush_t *b = mod->bsp->cm->brushes;
-	for (int32_t i = 0; i < mod->bsp->cm->file->num_brushes; i++, b++) {
-		if (b->contents & CONTENTS_OCCLUSION_QUERY) {
-			cgi.AddOcclusionQuery(cgi.view, b->bounds);
-		}
+	// add brush queries
+	r_occlusion_query_t *query = mod->bsp->occlusion_queries;
+	for (int32_t i = 0; i < mod->bsp->num_occlusion_queries; i++, query++) {
+		cgi.AddOcclusionQuery(cgi.view, query);
 	}
 
-	const r_bsp_light_t *l = mod->bsp->lights;
-	for (int32_t i = 0; i < mod->bsp->num_lights; i++, l++) {
+	// and light queries
+	r_bsp_light_t *light = mod->bsp->lights;
+	for (int32_t i = 0; i < mod->bsp->num_lights; i++, light++) {
 
-		switch (l->type) {
+		switch (light->type) {
 			case LIGHT_INVALID:
 			case LIGHT_AMBIENT:
 			case LIGHT_SUN:
@@ -316,22 +316,39 @@ static void Cg_AddOcclusionQueries(void) {
 				break;
 		}
 
-		if (l->shadow == 0.f) {
+		if (light->shadow == 0.f) {
 			continue;
 		}
 
-		if (Box3_Radius(l->bounds) < 64.f) {
+		if (Box3_Radius(light->bounds) < 64.f) {
 			continue;
 		}
 
-		cgi.AddOcclusionQuery(cgi.view, Box3_Expand(l->bounds, 1.f));
+		cgi.AddOcclusionQuery(cgi.view, &light->query);
 	}
 
+	// and server side entity queries
+//	for (int32_t i = 0; i < frame->num_entities; i++) {
+//
+//		const uint32_t snum = (frame->entity_state + i) & ENTITY_STATE_MASK;
+//		const entity_state_t *s = &cgi.client->entity_states[snum];
+//
+//		cl_entity_t *ent = &cgi.client->entities[s->number];
+//
+//		if (ent->current.model1) {
+//			if (ent->query.name == 0) {
+//				ent->query = cgi.CreateOcclusionQuery(ent->abs_bounds);
+//			}
+//			cgi.AddOcclusionQuery(cgi.view, &ent->query);
+//		}
+//	}
+
+	// and client side queries too
 	cg_entity_t *e = (cg_entity_t *) cg_entities->data;
 	for (guint i = 0; i < cg_entities->len; i++, e++) {
 
-		if (Box3_Distance(e->bounds) > 0.f) {
-			cgi.AddOcclusionQuery(cgi.view, Box3_Expand(e->bounds, 1.f));
+		if (e->query.name) {
+			cgi.AddOcclusionQuery(cgi.view, &e->query);
 		}
 	}
 }
@@ -369,7 +386,7 @@ void Cg_PrepareView(const cl_frame_t *frame) {
 
 	Cg_UpdateBob(ps1);
 
-	Cg_AddOcclusionQueries();
+	Cg_AddOcclusionQueries(frame);
 
 	cgi.view->contents = cgi.PointContents(cgi.view->origin);
 

--- a/src/client/cl_cgame.c
+++ b/src/client/cl_cgame.c
@@ -259,6 +259,8 @@ void Cl_InitCgame(void) {
 	import.WorldModel = R_WorldModel;
 
 	import.InitView = R_InitView;
+	import.CreateOcclusionQuery = R_CreateOcclusionQuery;
+	import.DestroyOcclusionQuery = R_DestroyOcclusionQuery;
 	import.AddOcclusionQuery = R_AddOcclusionQuery;
 	import.CulludeBox = R_CulludeBox;
 	import.CulludeSphere = R_CulludeSphere;

--- a/src/client/cl_cgame.c
+++ b/src/client/cl_cgame.c
@@ -259,9 +259,6 @@ void Cl_InitCgame(void) {
 	import.WorldModel = R_WorldModel;
 
 	import.InitView = R_InitView;
-	import.CreateOcclusionQuery = R_CreateOcclusionQuery;
-	import.DestroyOcclusionQuery = R_DestroyOcclusionQuery;
-	import.AddOcclusionQuery = R_AddOcclusionQuery;
 	import.CulludeBox = R_CulludeBox;
 	import.CulludeSphere = R_CulludeSphere;
 	import.AddEntity = R_AddEntity;

--- a/src/client/cl_types.h
+++ b/src/client/cl_types.h
@@ -94,6 +94,8 @@ typedef struct {
 
 	mat4_t matrix; // snapped transform matrix, for traces
 	mat4_t inverse_matrix; // inverse transform, for point contents
+
+	r_occlusion_query_t query; // the occlusion query
 } cl_entity_t;
 
 /**

--- a/src/client/cl_types.h
+++ b/src/client/cl_types.h
@@ -94,8 +94,6 @@ typedef struct {
 
 	mat4_t matrix; // snapped transform matrix, for traces
 	mat4_t inverse_matrix; // inverse transform, for point contents
-
-	r_occlusion_query_t query; // the occlusion query
 } cl_entity_t;
 
 /**

--- a/src/client/renderer/r_bsp.c
+++ b/src/client/renderer/r_bsp.c
@@ -73,7 +73,7 @@ static void R_UpdateBspInlineModelBlendDepth_r(const r_view_t *view,
 		return;
 	}
 
-	box3_t bounds = node->bounds;
+	box3_t bounds = node->visible_bounds;
 
 	if (e) {
 		bounds = Mat4_TransformBounds(e->matrix, bounds);
@@ -112,7 +112,7 @@ static void R_UpdateBspInlineModelBlendDepth_r(const r_view_t *view,
 			continue;
 		}
 		
-		if (!Box3_Intersects(draw->bounds, node->bounds)) {
+		if (!Box3_Intersects(draw->bounds, node->visible_bounds)) {
 			continue;
 		}
 

--- a/src/client/renderer/r_bsp_model.c
+++ b/src/client/renderer/r_bsp_model.c
@@ -250,6 +250,7 @@ static void R_LoadBspLeafs(r_bsp_model_t *bsp) {
 
 		out->contents = in->contents;
 		out->bounds = in->bounds;
+		out->visible_bounds = in->visible_bounds;
 	}
 }
 
@@ -267,8 +268,8 @@ static void R_LoadBspNodes(r_bsp_model_t *bsp) {
 	for (int32_t i = 0; i < bsp->num_nodes; i++, in++, out++) {
 
 		out->contents = CONTENTS_NODE; // differentiate from leafs
-
 		out->bounds = in->bounds;
+		out->visible_bounds = in->visible_bounds;
 
 		out->plane = bsp->planes + in->plane;
 
@@ -344,23 +345,11 @@ static void R_LoadBspInlineModels(r_bsp_model_t *bsp) {
 static _Bool R_LoadBspOcclusionQueries(const r_bsp_model_t *bsp, r_bsp_node_t *node) {
 
 	if (node->contents != CONTENTS_NODE) {
-
-		node->visible_bounds = Box3_Null();
-
-		const r_bsp_face_t *face = bsp->faces;
-		for (int32_t i = 0; i < bsp->num_faces; i++, face++) {
-			if (Box3_Intersects(node->bounds, face->bounds)) {
-				node->visible_bounds = Box3_Union(node->visible_bounds, face->bounds);
-			}
-		}
-
 		return false;
 	}
 
 	const _Bool a = R_LoadBspOcclusionQueries(bsp, node->children[0]);
 	const _Bool b = R_LoadBspOcclusionQueries(bsp, node->children[1]);
-
-	node->visible_bounds = Box3_Union(node->children[0]->visible_bounds, node->children[1]->visible_bounds);
 
 	if (!a || !b) {
 

--- a/src/client/renderer/r_bsp_model.c
+++ b/src/client/renderer/r_bsp_model.c
@@ -336,7 +336,7 @@ static _Bool R_SetupBspNode(r_bsp_inline_model_t *model, r_bsp_node_t *parent, r
 			if (b) {
 				R_DestroyNodeOcclusionQueries(node->children[1]);
 			}
-			node->query = R_CreateOcclusionQuery(node->visible_bounds);
+			node->query = R_CreateOcclusionQuery(Box3_Expand(node->visible_bounds, 1.f));
 			return true;
 		}
 	}

--- a/src/client/renderer/r_bsp_model.c
+++ b/src/client/renderer/r_bsp_model.c
@@ -364,7 +364,7 @@ static _Bool R_LoadBspOcclusionQueries(const r_bsp_model_t *bsp, r_bsp_node_t *n
 
 	if (!a || !b) {
 
-		const float size = 256.f;
+		const float size = 384.f;
 		if (Box3_Volume(node->visible_bounds) > size * size * size) {
 			if (a) {
 				R_DestroyOcclusionQuery(&node->children[0]->query);

--- a/src/client/renderer/r_bsp_model.c
+++ b/src/client/renderer/r_bsp_model.c
@@ -309,7 +309,7 @@ static _Bool R_SetupBspNode(r_bsp_inline_model_t *model, r_bsp_node_t *parent, r
 
 	if (!a || !b) {
 
-		const float size = 512.f;
+		const float size = r_occlusion_query_size->value;
 		if (Box3_Volume(node->visible_bounds) > size * size * size) {
 			if (a) {
 				R_DestroyOcclusionQuery(&node->children[0]->query);

--- a/src/client/renderer/r_main.c
+++ b/src/client/renderer/r_main.c
@@ -42,6 +42,7 @@ cvar_t *r_get_error;
 cvar_t *r_error_level;
 cvar_t *r_max_errors;
 cvar_t *r_occlude;
+cvar_t *r_occlusion_query_size;
 
 int32_t r_error_count;
 
@@ -391,6 +392,7 @@ static void R_InitLocal(void) {
 	r_error_level = Cvar_Add("r_error_level", "2", CVAR_DEVELOPER, "Error level for more fine-tuned control over KHR_debug reporting. 0 will report all, up to 3 which will only report errors. (developer tool)");
 	r_max_errors = Cvar_Add("r_max_errors", "8", CVAR_DEVELOPER, "The max number of errors before skipping error handlers (developer tool)");
 	r_occlude = Cvar_Add("r_occlude", "1", CVAR_DEVELOPER, "Controls the rendering of occlusion queries (developer tool)");
+	r_occlusion_query_size = Cvar_Add("r_occlusion_query_size", "256", CVAR_DEVELOPER, "Controls the occlusion query size (developer tool)");
 
 	// settings and preferences
 	r_allow_high_dpi = Cvar_Add("r_allow_high_dpi", "1", CVAR_ARCHIVE | CVAR_R_CONTEXT, "Enables or disables support for High-DPI (Retina, 4K) display modes");

--- a/src/client/renderer/r_main.c
+++ b/src/client/renderer/r_main.c
@@ -245,7 +245,6 @@ void R_InitView(r_view_t *view) {
 	view->num_sprites = 0;
 	view->num_sprite_instances = 0;
 	view->num_stains = 0;
-	view->num_occlusion_queries = 0;
 
 	memset(view->frustum, 0, sizeof(view->frustum));
 }

--- a/src/client/renderer/r_main.h
+++ b/src/client/renderer/r_main.h
@@ -266,6 +266,7 @@ extern cvar_t *r_get_error;
 extern cvar_t *r_error_level;
 extern cvar_t *r_max_errors;
 extern cvar_t *r_occlude;
+extern cvar_t *r_occlusion_query_size;
 
 /**
  * @brief Keeps track of how many errors we've run into, so we can

--- a/src/client/renderer/r_occlude.c
+++ b/src/client/renderer/r_occlude.c
@@ -47,31 +47,32 @@ static struct {
 static _Bool R_OccludeBox_r(const r_view_t *view, const box3_t bounds, const r_bsp_node_t *node) {
 
 	if (node->contents != CONTENTS_NODE) {
-		return false;
+		return true;
 	}
 
 	const int32_t side = Cm_BoxOnPlaneSide(bounds, node->plane->cm);
+
 	if (side & SIDE_FRONT) {
-		if (R_OccludeBox_r(view, bounds, node->children[0])) {
-			return true;
+		if (R_OccludeBox_r(view, bounds, node->children[0]) == false) {
+			return false;
 		}
 	}
 
 	if (side & SIDE_BACK) {
-		if (R_OccludeBox_r(view, bounds, node->children[1])) {
-			return true;
+		if (R_OccludeBox_r(view, bounds, node->children[1]) == false) {
+			return false;
 		}
 	}
 
 	if (node->query.name) {
-		if (Box3_Contains(node->query.bounds, bounds)) {
-			if (node->query.result == 0) {
-				return true;
+		if (Box3_Intersects(node->query.bounds, bounds)) {
+			if (node->query.result == 1) {
+				return false;
 			}
 		}
 	}
 
-	return false;
+	return true;
 }
 
 /**

--- a/src/client/renderer/r_occlude.h
+++ b/src/client/renderer/r_occlude.h
@@ -28,7 +28,9 @@ _Bool R_CulludeSphere(const r_view_t *view, const vec3_t point, const float radi
 _Bool R_OccludeBox(const r_view_t *view, const box3_t bounds);
 _Bool R_OccludeSphere(const r_view_t *view, const vec3_t origin, float radius);
 
-void R_AddOcclusionQuery(r_view_t *view, const box3_t bounds);
+r_occlusion_query_t R_CreateOcclusionQuery(const box3_t bounds);
+void R_DestroyOcclusionQuery(r_occlusion_query_t *query);
+void R_AddOcclusionQuery(r_view_t *view, r_occlusion_query_t *query);
 
 #ifdef __R_LOCAL_H__
 

--- a/src/client/renderer/r_stain.c
+++ b/src/client/renderer/r_stain.c
@@ -105,28 +105,25 @@ static void R_StainNode(const r_stain_t *stain, const r_bsp_node_t *node) {
 		return;
 	}
 
-	if (node->contents & CONTENTS_MASK_SOLID) {
+	// project the stain onto the node's plane
+	const r_stain_t projected = {
+		.origin = Vec3_Fmaf(stain->origin, -dist, plane->normal),
+		.radius = stain->radius - fabsf(dist),
+		.color = stain->color
+	};
 
-		// project the stain onto the node's plane
-		const r_stain_t s = {
-			.origin = Vec3_Fmaf(stain->origin, -dist, plane->normal),
-			.radius = stain->radius - fabsf(dist),
-			.color = stain->color
-		};
+	r_bsp_face_t *face = node->faces;
+	for (int32_t i = 0; i < node->num_faces; i++, face++) {
 
-		r_bsp_face_t *face = node->faces;
-		for (int32_t i = 0; i < node->num_faces; i++, face++) {
-
-			if (!(face->brush_side->contents & CONTENTS_MASK_SOLID)) {
-				continue;
-			}
-
-			if (face->brush_side->surface & SURF_MASK_NO_LIGHTMAP) {
-				continue;
-			}
-
-			R_StainFace(&s, face);
+		if (!(face->brush_side->contents & CONTENTS_MASK_SOLID)) {
+			continue;
 		}
+
+		if (face->brush_side->surface & SURF_MASK_NO_LIGHTMAP) {
+			continue;
+		}
+
+		R_StainFace(&projected, face);
 	}
 
 	// recurse down both sides

--- a/src/client/renderer/r_types.h
+++ b/src/client/renderer/r_types.h
@@ -28,6 +28,34 @@
 
 #include "r_gl_types.h"
 
+
+#define MAX_OCCLUSION_QUERIES MAX_ENTITIES
+
+/**
+ * @brief OpenGL occlusion queries.
+ */
+typedef struct {
+	/**
+	 * @brief The query name.
+	 */
+	GLuint name;
+
+	/**
+	 * @brief The query bounds.
+	 */
+	box3_t bounds;
+
+	/**
+	 * @brief Non-zero if the query is available.
+	 */
+	GLint available;
+
+	/**
+	 * @brief Non-zero of the query produced visible fragments.
+	 */
+	GLint result;
+} r_occlusion_query_t;
+
 /**
  * @brief Media types.
  */
@@ -383,13 +411,6 @@ typedef struct {
 } r_bsp_face_t;
 
 /**
- * @brief Light sources per scene.
- * @remarks Lights that are frustum culled or occluded are discarded.
- * @see `MAX_LIGHT_UNIFORMS`
- */
-#define MAX_LIGHTS 1024
-
-/**
  * @brief BSP draw elements, which include all opaque faces of a given material
  * within a particular inline model.
  */
@@ -548,6 +569,11 @@ typedef struct {
 	 * @brief The light bounds, for frustum and occlusion culling.
 	 */
 	box3_t bounds;
+
+	/**
+	 * @brief The light occlusion query.
+	 */
+	r_occlusion_query_t query;
 } r_bsp_light_t;
 
 /**
@@ -621,6 +647,9 @@ typedef struct {
 
 	int32_t num_inline_models;
 	r_bsp_inline_model_t *inline_models;
+
+	int32_t num_occlusion_queries;
+	r_occlusion_query_t *occlusion_queries;
 
 	int32_t num_lights;
 	r_bsp_light_t *lights;
@@ -1147,6 +1176,13 @@ typedef struct r_entity_s {
 	int32_t blend_depth;
 } r_entity_t;
 
+/**
+ * @brief Light sources per scene.
+ * @remarks Lights that are frustum culled or occluded are discarded.
+ * @see `MAX_LIGHT_UNIFORMS`
+ */
+#define MAX_LIGHTS 1024
+
 #define MAX_LIGHT_ENTITIES 32
 
 /**
@@ -1224,38 +1260,6 @@ typedef struct {
 	 */
 	GLint index;
 } r_light_t;
-
-#define MAX_OCCLUSION_QUERIES MAX_ENTITIES
-
-/**
- * @brief OpenGL occlusion queries.
- */
-typedef struct {
-	/**
-	 * @brief The query name.
-	 */
-	GLuint name;
-
-	/**
-	 * @brief The query index.
-	 */
-	int32_t index;
-
-	/**
-	 * @brief The query bounds.
-	 */
-	box3_t bounds;
-
-	/**
-	 * @brief
-	 */
-	GLint available;
-
-	/**
-	 * @brief
-	 */
-	GLint result;
-} r_occlusion_query_t;
 
 /**
  * @brief Framebuffer attachments bitmask.

--- a/src/collision/cm_bsp.c
+++ b/src/collision/cm_bsp.c
@@ -215,6 +215,7 @@ static void Bsp_SwapNodes(void *lump, const int32_t num) {
 		node->children[1] = LittleLong(node->children[1]);
 
 		node->bounds = LittleBounds(node->bounds);
+		node->visible_bounds = LittleBounds(node->visible_bounds);
 
 		node->first_face = LittleLong(node->first_face);
 		node->num_faces = LittleLong(node->num_faces);
@@ -260,7 +261,8 @@ static void Bsp_SwapLeafs(void *lump, const int32_t num) {
 		leaf->cluster = LittleLong(leaf->cluster);
 
 		leaf->bounds = LittleBounds(leaf->bounds);
-
+		leaf->visible_bounds = LittleBounds(leaf->visible_bounds);
+		
 		leaf->first_leaf_brush = LittleLong(leaf->first_leaf_brush);
 		leaf->num_leaf_brushes = LittleLong(leaf->num_leaf_brushes);
 

--- a/src/collision/cm_bsp.h
+++ b/src/collision/cm_bsp.h
@@ -286,7 +286,8 @@ typedef struct {
 	int32_t plane;
 	int32_t children[2]; // negative numbers are -(leafs + 1), not nodes
 
-	box3_t bounds; // for frustum culling
+	box3_t bounds; // for collision
+	box3_t visible_bounds; // for frustum culling
 
 	int32_t first_face;
 	int32_t num_faces; // counting both sides
@@ -296,7 +297,8 @@ typedef struct {
 	int32_t contents; // OR of all brushes
 	int32_t cluster;
 
-	box3_t bounds; // for frustum culling
+	box3_t bounds; // for collision
+	box3_t visible_bounds; // for frustum culling
 
 	int32_t first_leaf_face;
 	int32_t num_leaf_faces;

--- a/src/shared/box.h
+++ b/src/shared/box.h
@@ -145,7 +145,15 @@ static inline void Box3_ToPoints(const box3_t bounds, vec3_t *points) {
 */
 static inline _Bool __attribute__ ((warn_unused_result)) Box3_Intersects(const box3_t a, const box3_t b) {
 
-	return Vec3_BoxIntersect(a.mins, a.maxs, b.mins, b.maxs);
+	if (a.mins.x >= b.maxs.x || a.mins.y >= b.maxs.y || a.mins.z >= b.maxs.z) {
+		return false;
+	}
+
+	if (a.maxs.x <= b.mins.x || a.maxs.y <= b.mins.y || a.maxs.z <= b.mins.z) {
+		return false;
+	}
+
+	return true;
 }
 
 /**
@@ -153,7 +161,15 @@ static inline _Bool __attribute__ ((warn_unused_result)) Box3_Intersects(const b
 */
 static inline _Bool __attribute__ ((warn_unused_result)) Box3_ContainsPoint(const box3_t a, const vec3_t b) {
 
-	return Vec3_BoxIntersect(b, b, a.mins, a.maxs);
+	if (a.mins.x > b.x || a.mins.y > b.y || a.mins.z > b.z) {
+		return false;
+	}
+
+	if (a.maxs.x < b.x || a.maxs.y < b.y || a.maxs.z < b.z) {
+		return false;
+	}
+
+	return true;
 }
 
 /**
@@ -322,4 +338,12 @@ static inline box3_t __attribute__ ((warn_unused_result)) Box3_Scale(const box3_
 		Vec3_Scale(bounds.mins, scale),
 		Vec3_Scale(bounds.maxs, scale)
 	);
+}
+
+/**
+ * @return The volume of `b`.
+ */
+static inline float __attribute__ ((warn_unused_result)) Box3_Volume(const box3_t b) {
+	const vec3_t size =  Box3_Size(b);
+	return size.x * size.y * size.z;
 }

--- a/src/shared/vector.h
+++ b/src/shared/vector.h
@@ -653,22 +653,6 @@ static inline vec3_t __attribute__ ((warn_unused_result)) Vec3_Subtract(const ve
 }
 
 /**
- * @return True if the specified boxes intersect, false otherwise.
- */
-static inline _Bool __attribute__ ((warn_unused_result)) Vec3_BoxIntersect(const vec3_t amins, const vec3_t amaxs, const vec3_t bmins, const vec3_t bmaxs) {
-
-	if (amins.x >= bmaxs.x || amins.y >= bmaxs.y || amins.z >= bmaxs.z) {
-		return false;
-	}
-
-	if (amaxs.x <= bmins.x || amaxs.y <= bmins.y || amaxs.z <= bmins.z) {
-		return false;
-	}
-
-	return true;
-}
-
-/**
  * @return The vector `v` cast to `vec3d_t`.
  */
 static inline vec3d_t __attribute__ ((warn_unused_result)) Vec3_CastVec3d(const vec3_t v) {

--- a/src/tools/quemap/light.c
+++ b/src/tools/quemap/light.c
@@ -397,6 +397,7 @@ static light_t *LightForPatch(const patch_t *patch) {
 	light->size = sqrtf(Cm_WindingArea(patch->winding));
 	light->origin = Vec3_Fmaf(Cm_WindingCenter(patch->winding), 1.f, plane->normal);
 	light->face = patch->face;
+	light->brush_side = brush_side;
 	light->plane = plane;
 	light->normal = plane->normal;
 	light->theta = Radians(material->cm->light.cone);
@@ -597,6 +598,7 @@ static light_t *LightForLightmappedPatch(const lightmap_t *lm, const patch_t *pa
 	light->size = sqrtf(Cm_WindingArea(patch->winding));
 	light->origin = Vec3_Fmaf(Cm_WindingCenter(patch->winding), 1.f, lm->plane->normal);
 	light->face = patch->face;
+	light->brush_side = patch->brush_side;
 	light->plane = lm->plane;
 	light->normal = lm->plane->normal;
 	light->theta = Radians(DEFAULT_LIGHT_CONE);

--- a/src/tools/quemap/light.c
+++ b/src/tools/quemap/light.c
@@ -495,21 +495,6 @@ static GPtrArray *BoxLights(light_type_t type, const box3_t bounds) {
 }
 
 /**
- * @brief
- */
-static box3_t NodeBounds(const bsp_node_t *node) {
-
-	box3_t bounds = Box3_Null();
-
-	const bsp_face_t *face = bsp_file.faces + node->first_face;
-	for (int32_t i = 0; i < node->num_faces; i++, face++) {
-		bounds = Box3_Union(bounds, face->bounds);
-	}
-
-	return Box3_Expand(bounds, BSP_LIGHTGRID_LUXEL_SIZE);
-}
-
-/**
  * @brief Hashes light sources of the specified type(s) into bins by node and leaf.
  */
 static void HashLights(light_type_t type) {
@@ -527,7 +512,7 @@ static void HashLights(light_type_t type) {
 			g_ptr_array_free(node_lights[i], true);
 		}
 
-		node_lights[i] = BoxLights(type, NodeBounds(node));
+		node_lights[i] = BoxLights(type, Box3_Expand(node->visible_bounds, BSP_LIGHTMAP_LUXEL_SIZE));
 	}
 
 	const bsp_leaf_t *leaf = bsp_file.leafs;
@@ -541,7 +526,7 @@ static void HashLights(light_type_t type) {
 			g_ptr_array_free(leaf_lights[i], true);
 		}
 
-		leaf_lights[i] = BoxLights(type, leaf->bounds);
+		leaf_lights[i] = BoxLights(type, Box3_Expand(leaf->visible_bounds, BSP_LIGHTMAP_LUXEL_SIZE));
 	}
 }
 

--- a/src/tools/quemap/light.h
+++ b/src/tools/quemap/light.h
@@ -111,6 +111,11 @@ typedef struct light_s {
 	const bsp_face_t *face;
 
 	/**
+	 * @brief The light source brush side for patch and indirect lights.
+	 */
+	const bsp_brush_side_t *brush_side;
+
+	/**
 	 * @brief The light source plane for patch and indirect lights.
 	 */
 	const bsp_plane_t *plane;

--- a/src/tools/quemap/patch.c
+++ b/src/tools/quemap/patch.c
@@ -30,7 +30,7 @@ patch_t *patches;
  */
 static patch_t *BuildPatch(const bsp_model_t *model,
 						   const bsp_face_t *face,
-						   const bsp_brush_side_t *side,
+						   const bsp_brush_side_t *brush_side,
 						   const vec3_t origin,
 						   cm_winding_t *w) {
 
@@ -38,7 +38,7 @@ static patch_t *BuildPatch(const bsp_model_t *model,
 
 	patch->model = model;
 	patch->face = face;
-	patch->side = side;
+	patch->brush_side = brush_side;
 	patch->origin = origin;
 	patch->winding = w;
 
@@ -111,7 +111,7 @@ static void SubdividePatch_r(patch_t *patch) {
 
 	vec3_t normal = Vec3_Zero();
 
-	const float size = materials[patch->side->material].cm->patch_size ?: patch_size;
+	const float size = materials[patch->brush_side->material].cm->patch_size ?: patch_size;
 
 	int32_t i;
 	for (i = 0; i < 3; i++) {
@@ -138,7 +138,7 @@ static void SubdividePatch_r(patch_t *patch) {
 	patch_t *p = (patch_t *) Mem_TagMalloc(sizeof(*p), MEM_TAG_PATCH);
 	p->model = patch->model;
 	p->face = patch->face;
-	p->side = patch->side;
+	p->brush_side = patch->brush_side;
 	p->origin = patch->origin;
 
 	patch->winding = front;
@@ -158,7 +158,7 @@ void SubdividePatch(int32_t patch_num) {
 
 	patch_t *patch = &patches[patch_num];
 
-	if (patch->side->surface & SURF_MASK_NO_LIGHTMAP) {
+	if (patch->brush_side->surface & SURF_MASK_NO_LIGHTMAP) {
 		return;
 	}
 

--- a/src/tools/quemap/patch.h
+++ b/src/tools/quemap/patch.h
@@ -27,6 +27,7 @@
 typedef struct patch_s {
 	const bsp_model_t *model;
 	const bsp_face_t *face;
+	const bsp_brush_side_t *side;
 	vec3_t origin;
 	cm_winding_t *winding;
 	struct patch_s *next;  // next in face

--- a/src/tools/quemap/patch.h
+++ b/src/tools/quemap/patch.h
@@ -27,7 +27,7 @@
 typedef struct patch_s {
 	const bsp_model_t *model;
 	const bsp_face_t *face;
-	const bsp_brush_side_t *side;
+	const bsp_brush_side_t *brush_side;
 	vec3_t origin;
 	cm_winding_t *winding;
 	struct patch_s *next;  // next in face

--- a/src/tools/quemap/tree.h
+++ b/src/tools/quemap/tree.h
@@ -32,6 +32,7 @@ typedef struct node_s {
 	struct node_s *parent;
 	int32_t plane; // -1 = leaf node
 	box3_t bounds; // valid after portalization
+	box3_t visible_bounds;
 	csg_brush_t *volume; // one for each leaf/node
 
 	// nodes only

--- a/src/tools/quemap/writebsp.c
+++ b/src/tools/quemap/writebsp.c
@@ -94,8 +94,8 @@ static int32_t EmitLeaf(node_t *node) {
 
 	out->contents = node->contents;
 	out->cluster = node->cluster;
-
 	out->bounds = node->bounds;
+	out->visible_bounds = node->visible_bounds;
 
 	// write the leaf_brushes
 	out->first_leaf_brush = bsp_file.num_leaf_brushes;
@@ -194,9 +194,9 @@ static int32_t EmitNode(const node_t *node) {
 	bsp_node_t *out = &bsp_file.nodes[bsp_file.num_nodes];
 	bsp_file.num_nodes++;
 
-	out->bounds = node->bounds;
-
 	out->plane = node->plane;
+	out->bounds = node->bounds;
+	out->visible_bounds = node->visible_bounds;
 
 	if (node->faces) {
 		out->first_face = bsp_file.num_faces;


### PR DESCRIPTION
The goal of this PR is to completely remove the burden of placing occlusion queries from the mapper, while also improving performance. This approach is inspired by this article: https://developer.nvidia.com/gpugems/gpugems2/part-i-geometric-complexity/chapter-6-hardware-occlusion-queries-made-useful

The general idea is to select nodes from the BSP that satisfy a heuristic (some general size threshold, configurable by cvar), and create queries spanning the visible bounds of those nodes. Since the selection produces a completely contiguous graph, where every valid point in the map is covered by exactly one query, the actual occlusion check changes from:

    find a query that fully contains the box in question, and if that query is occluded, we can skip the object

To:

    find all queries that intersect the box in question, and if all of those queries are occluded, we can skip the object

This is actually a significant improvement for things like dynamic lights and even large sprites which often exceed the solid world bounds (where the mapper had likely not placed an occlusion query).

Lastly, because the occlusion queries are derived from the BSP tree, we can make some optimizations when we receive a query result: a positive result (visible) should propagate up the tree, and a negative result (occluded) should propagate down. This reduces the latency of query results by a frame or two, and allows us to skip certain queries entirely for certain frames. There's still more work to be done to improve this optimization.

Assuming we stick with this approach, I'll update the code and editor configurations to remove all occurrences of `CONTENTS_OCCLUSION_QUERY` since it will no longer be required / supported. This will require stripping these brushes from our maps, too.

This change itself is a BSP format update, because I extended the BSP node struct to include visible bounds (which is often a subset of collision bounds).