### PR TITLE
Fixing rapidjson compilation error in newer compilers

### DIFF
--- a/deps/rapidjson/rapidjson/document.h
+++ b/deps/rapidjson/rapidjson/document.h
@@ -316,8 +316,6 @@ struct GenericStringRef {
 
     GenericStringRef(const GenericStringRef& rhs) : s(rhs.s), length(rhs.length) {}
 
-    GenericStringRef& operator=(const GenericStringRef& rhs) { s = rhs.s; length = rhs.length; }
-
     //! implicit conversion to plain CharType pointer
     operator const Ch *() const { return s; }
 
@@ -328,6 +326,8 @@ private:
     //! Disallow construction from non-const array
     template<SizeType N>
     GenericStringRef(CharType (&str)[N]) /* = delete */;
+    //! Copy assignment operator not permitted - immutable type
+    GenericStringRef& operator=(const GenericStringRef& rhs) /* = delete */;
 };
 
 //! Mark a character pointer as constant string


### PR DESCRIPTION
--- ORIGINAL PATCH ---
From 3b2441b87f99ab65f37b141a7b548ebadb607b96 Mon Sep 17 00:00:00 2001
From: Janusz Chorko <janusz.chorko@apdu.pl>
Date: Fri, 26 Aug 2016 21:17:38 +0200
Subject: [PATCH 1/2] Removed non-compiling assignment operator. Fixed #718
--- END OF PATCH HEADER ---

Original Patch: https://github.com/Tencent/rapidjson/pull/719.patch