### PR TITLE
Introduce manifest file for comprehensive in-game downloading / pk3 authoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ src/tests/*.trs
 src/tests/check_atlas
 src/tests/check_box
 src/tests/check_cm_entity
+src/tests/check_cm_manifest
 src/tests/check_cm_polylib
 src/tests/check_cm_test
 src/tests/check_cmd

--- a/Quetoo.vs15/libs/libcmodel.vcxproj
+++ b/Quetoo.vs15/libs/libcmodel.vcxproj
@@ -22,6 +22,7 @@
     <ClInclude Include="..\..\src\collision\cm_bsp.h" />
     <ClInclude Include="..\..\src\collision\cm_entity.h" />
     <ClInclude Include="..\..\src\collision\cm_local.h" />
+    <ClInclude Include="..\..\src\collision\cm_manifest.h" />
     <ClInclude Include="..\..\src\collision\cm_material.h" />
     <ClInclude Include="..\..\src\collision\cm_model.h" />
     <ClInclude Include="..\..\src\collision\cm_polylib.h" />
@@ -32,6 +33,7 @@
   <ItemGroup>
     <ClCompile Include="..\..\src\collision\cm_bsp.c" />
     <ClCompile Include="..\..\src\collision\cm_entity.c" />
+    <ClCompile Include="..\..\src\collision\cm_manifest.c" />
     <ClCompile Include="..\..\src\collision\cm_material.c" />
     <ClCompile Include="..\..\src\collision\cm_model.c" />
     <ClCompile Include="..\..\src\collision\cm_polylib.c" />

--- a/Quetoo.vs15/quemap.vcxproj
+++ b/Quetoo.vs15/quemap.vcxproj
@@ -28,6 +28,7 @@
     <ClCompile Include="..\src\tools\quemap\leakfile.c" />
     <ClCompile Include="..\src\tools\quemap\light.c" />
     <ClCompile Include="..\src\tools\quemap\main.c" />
+    <ClCompile Include="..\src\tools\quemap\manifest.c" />
     <ClCompile Include="..\src\tools\quemap\map.c" />
     <ClCompile Include="..\src\tools\quemap\material.c" />
     <ClCompile Include="..\src\tools\quemap\patch.c" />
@@ -63,6 +64,7 @@
     <ClInclude Include="..\src\tools\quemap\qbsp.h" />
     <ClInclude Include="..\src\tools\quemap\qlight.h" />
     <ClInclude Include="..\src\tools\quemap\quemap.h" />
+    <ClInclude Include="..\src\tools\quemap\manifest.h" />
     <ClInclude Include="..\src\tools\quemap\qzip.h" />
     <ClInclude Include="..\src\tools\quemap\simplex.h" />
     <ClInclude Include="..\src\tools\quemap\texture.h" />

--- a/Quetoo.xcodeproj/project.pbxproj
+++ b/Quetoo.xcodeproj/project.pbxproj
@@ -51,6 +51,8 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
+		522B158EA7384E83CD005789 /* cm_manifest.c in Sources */ = {isa = PBXBuildFile; fileRef = D126FFD46C343DDC86C13E17 /* cm_manifest.c */; };
+		997E573805B0DCF96FB8C299 /* manifest.c in Sources */ = {isa = PBXBuildFile; fileRef = 57941D4E858E897A2E3083ED /* manifest.c */; };
 		CE04015D25D32C4D00C31433 /* libsndfile.1.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = CE04015C25D32C4D00C31433 /* libsndfile.1.dylib */; };
 		CE0401EF25D34C1100C31433 /* libObjectively.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = CE27BE561D9167C700F87B2C /* libObjectively.dylib */; };
 		CE04F03E25CADF4900C31433 /* atlas.c in Sources */ = {isa = PBXBuildFile; fileRef = CE354EDA220738BF008AE0C2 /* atlas.c */; };
@@ -600,6 +602,15 @@
 		CEAD8FA02F8D76830087A850 /* check_http.c in Sources */ = {isa = PBXBuildFile; fileRef = CEAD8F8C2F8D76260087A850 /* check_http.c */; };
 		CEAD8FA12F8D76E60087A850 /* libnet.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CE80FE661C5E431000A21A51 /* libnet.a */; };
 		CEAD8FA22F8D76FC0087A850 /* libObjectively.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = CE27BE561D9167C700F87B2C /* libObjectively.dylib */; };
+		CEAD8FA82F8D8DE30087A850 /* tests.c in Sources */ = {isa = PBXBuildFile; fileRef = CE12D6DC1C5C58C300CD0B13 /* tests.c */; };
+		CEAD8FAB2F8D8DE30087A850 /* libcommon.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CE80FDE31C5E3E1100A21A51 /* libcommon.a */; };
+		CEAD8FAC2F8D8DE30087A850 /* libshared.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CE80FDD51C5E3D4E00A21A51 /* libshared.a */; };
+		CEAD8FAD2F8D8DE30087A850 /* libglib-2.0.0.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = CE12D8231C5C69A800CD0B13 /* libglib-2.0.0.dylib */; };
+		CEAD8FAE2F8D8DE30087A850 /* libphysfs.3.2.0.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = CE56BD542AAE349700A8AB5E /* libphysfs.3.2.0.dylib */; };
+		CEAD8FAF2F8D8DE30087A850 /* libSDL3.0.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = CE5A6AB02EC600E4005F3C92 /* libSDL3.0.dylib */; };
+		CEAD8FB02F8D8DE30087A850 /* libcheck.0.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = CE9A66FB2D246A1D0068D720 /* libcheck.0.dylib */; };
+		CEAD8FB52F8D8DF70087A850 /* check_cm_manifest.c in Sources */ = {isa = PBXBuildFile; fileRef = CEAD8FA32F8D8DB70087A850 /* check_cm_manifest.c */; };
+		CEAD8FB62F8D8E060087A850 /* libcollision.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CE80FE381C5E421900A21A51 /* libcollision.a */; };
 		CEADA4A2278237D800E19745 /* libObjectively.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = CE27BE561D9167C700F87B2C /* libObjectively.dylib */; };
 		CEADA4A3278237D800E19745 /* libObjectivelyMVC.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = CEDB4BB01D404D9D009921B6 /* libObjectivelyMVC.dylib */; };
 		CEADCE2725DB415C006E34A6 /* DialogViewController.css in CopyFiles */ = {isa = PBXBuildFile; fileRef = CE7D2C2A2030F269004BC58E /* DialogViewController.css */; };
@@ -702,6 +713,7 @@
 		CEFF1379277FB763001E1500 /* TeamPlayerView.c in Sources */ = {isa = PBXBuildFile; fileRef = CEFF1376277FB721001E1500 /* TeamPlayerView.c */; };
 		CEFF13BE277FB7AC001E1500 /* TeamPlayerView.h in Headers */ = {isa = PBXBuildFile; fileRef = CEFF1378277FB721001E1500 /* TeamPlayerView.h */; };
 		CEFF1426277FB7C8001E1500 /* TeamPlayerView.json in CopyFiles */ = {isa = PBXBuildFile; fileRef = CEFF1377277FB721001E1500 /* TeamPlayerView.json */; };
+		F53787C291008C7507AE5FF4 /* cm_manifest.h in Headers */ = {isa = PBXBuildFile; fileRef = 9BEEC6DF7149D25DE326F0A7 /* cm_manifest.h */; };
 		F57902A224843EA10023101D /* soften_fs.glsl in CopyFiles */ = {isa = PBXBuildFile; fileRef = F57902A124843E730023101D /* soften_fs.glsl */; };
 /* End PBXBuildFile section */
 
@@ -901,6 +913,13 @@
 			proxyType = 1;
 			remoteGlobalIDString = CE80FE431C5E431000A21A51;
 			remoteInfo = net;
+		};
+		CEAD8FA62F8D8DE30087A850 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = CE12D4A11C5C579D00CD0B13 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = CE80FDD91C5E3E1100A21A51;
+			remoteInfo = common;
 		};
 		CEB384F129A3D24D006DEA13 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -1116,6 +1135,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		57941D4E858E897A2E3083ED /* manifest.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = manifest.c; sourceTree = "<group>"; };
+		9BEEC6DF7149D25DE326F0A7 /* cm_manifest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = cm_manifest.h; sourceTree = "<group>"; };
 		CE04015C25D32C4D00C31433 /* libsndfile.1.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libsndfile.1.dylib; path = ../../../../usr/local/lib/libsndfile.1.dylib; sourceTree = "<group>"; };
 		CE04EF9325CA0EE400C31433 /* Makefile.am */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = Makefile.am; sourceTree = "<group>"; };
 		CE04EFC125CA0F7D00C31433 /* Makefile.am */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = Makefile.am; sourceTree = "<group>"; };
@@ -1760,6 +1781,8 @@
 		CEAD8F872F8690B90087A850 /* libSDL3_image.0.4.2.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libSDL3_image.0.4.2.dylib; path = ../../../../opt/homebrew/Cellar/sdl3_image/3.4.2/lib/libSDL3_image.0.4.2.dylib; sourceTree = "<group>"; };
 		CEAD8F8C2F8D76260087A850 /* check_http.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = check_http.c; sourceTree = "<group>"; };
 		CEAD8F9D2F8D765F0087A850 /* check_http */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = check_http; sourceTree = BUILT_PRODUCTS_DIR; };
+		CEAD8FA32F8D8DB70087A850 /* check_cm_manifest.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = check_cm_manifest.c; sourceTree = "<group>"; };
+		CEAD8FB42F8D8DE30087A850 /* check_cm_manifest */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = check_cm_manifest; sourceTree = BUILT_PRODUCTS_DIR; };
 		CEB112AE22544B3800CE65F6 /* voxel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = voxel.h; sourceTree = "<group>"; };
 		CEB112AF22544B3900CE65F6 /* voxel.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = voxel.c; sourceTree = "<group>"; };
 		CEB3038D2247A59F000FCB07 /* points.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = points.h; sourceTree = "<group>"; };
@@ -1827,6 +1850,8 @@
 		CEFF1376277FB721001E1500 /* TeamPlayerView.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = TeamPlayerView.c; sourceTree = "<group>"; };
 		CEFF1377277FB721001E1500 /* TeamPlayerView.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = TeamPlayerView.json; sourceTree = "<group>"; };
 		CEFF1378277FB721001E1500 /* TeamPlayerView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TeamPlayerView.h; sourceTree = "<group>"; };
+		D126FFD46C343DDC86C13E17 /* cm_manifest.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = cm_manifest.c; sourceTree = "<group>"; };
+		DF0B9374573E39DECA0D8E4C /* manifest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = manifest.h; sourceTree = "<group>"; };
 		F57902A124843E730023101D /* soften_fs.glsl */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = soften_fs.glsl; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -2182,6 +2207,20 @@
 				CEAD8F972F8D765F0087A850 /* libphysfs.3.2.0.dylib in Frameworks */,
 				CEAD8F982F8D765F0087A850 /* libSDL3.0.dylib in Frameworks */,
 				CEAD8F992F8D765F0087A850 /* libcheck.0.dylib in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CEAD8FAA2F8D8DE30087A850 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				CEAD8FAC2F8D8DE30087A850 /* libshared.a in Frameworks */,
+				CEAD8FAB2F8D8DE30087A850 /* libcommon.a in Frameworks */,
+				CEAD8FB62F8D8E060087A850 /* libcollision.a in Frameworks */,
+				CEAD8FAD2F8D8DE30087A850 /* libglib-2.0.0.dylib in Frameworks */,
+				CEAD8FAE2F8D8DE30087A850 /* libphysfs.3.2.0.dylib in Frameworks */,
+				CEAD8FAF2F8D8DE30087A850 /* libSDL3.0.dylib in Frameworks */,
+				CEAD8FB02F8D8DE30087A850 /* libcheck.0.dylib in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2775,6 +2814,8 @@
 				CE12D6291C5C58C300CD0B13 /* cm_local.h */,
 				CEA3B4851E057569004A6CF3 /* cm_material.c */,
 				CEA3B4861E057569004A6CF3 /* cm_material.h */,
+				D126FFD46C343DDC86C13E17 /* cm_manifest.c */,
+				9BEEC6DF7149D25DE326F0A7 /* cm_manifest.h */,
 				CE12D62A1C5C58C300CD0B13 /* cm_model.c */,
 				CE12D62B1C5C58C300CD0B13 /* cm_model.h */,
 				CE3C529321E4DF2500FEDBED /* cm_polylib.c */,
@@ -2936,6 +2977,7 @@
 				CE354EEE22075054008AE0C2 /* check_atlas.c */,
 				CE9A67092D2588B20068D720 /* check_box.c */,
 				CEA509062EA5D21F00F27205 /* check_cm_entity.c */,
+				CEAD8FA32F8D8DB70087A850 /* check_cm_manifest.c */,
 				CEE3A0EF21EE2A5E0070FD3E /* check_cm_polylib.c */,
 				CE4DCFFA256F0DF500FECAFC /* check_cm_test.c */,
 				CE12D6CB1C5C58C300CD0B13 /* check_cmd.c */,
@@ -3002,6 +3044,8 @@
 				CE92B3A91D2FF72200E9153A /* quemap-icon.rc */,
 				CE12D6FF1C5C58C300CD0B13 /* quemap.h */,
 				CE92B3AA1D2FF77800E9153A /* quemap.ico */,
+				57941D4E858E897A2E3083ED /* manifest.c */,
+				DF0B9374573E39DECA0D8E4C /* manifest.h */,
 				CE12D7021C5C58C300CD0B13 /* qzip.c */,
 				CE6FF29C1E9E6FBA00F3C160 /* qzip.h */,
 				CEEC202F25B3265700E49614 /* simplex.c */,
@@ -3080,6 +3124,7 @@
 				CE9A67152D2589020068D720 /* check_box */,
 				CEA509052EA5D20A00F27205 /* check_cm_polylib */,
 				CEAD8F9D2F8D765F0087A850 /* check_http */,
+				CEAD8FB42F8D8DE30087A850 /* check_cm_manifest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -3658,6 +3703,7 @@
 				CE3C529421E4DF2500FEDBED /* cm_polylib.h in Headers */,
 				CE80FE721C5E437F00A21A51 /* cm_local.h in Headers */,
 				CEA3B48E1E0576E7004A6CF3 /* cm_material.h in Headers */,
+				F53787C291008C7507AE5FF4 /* cm_manifest.h in Headers */,
 				CE80FE731C5E437F00A21A51 /* cm_model.h in Headers */,
 				CE80FE741C5E437F00A21A51 /* cm_test.h in Headers */,
 				CE80FE751C5E437F00A21A51 /* cm_trace.h in Headers */,
@@ -4335,6 +4381,23 @@
 			productReference = CEAD8F9D2F8D765F0087A850 /* check_http */;
 			productType = "com.apple.product-type.tool";
 		};
+		CEAD8FA42F8D8DE30087A850 /* check_cm_manifest */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CEAD8FB12F8D8DE30087A850 /* Build configuration list for PBXNativeTarget "check_cm_manifest" */;
+			buildPhases = (
+				CEAD8FA72F8D8DE30087A850 /* Sources */,
+				CEAD8FAA2F8D8DE30087A850 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				CEAD8FA52F8D8DE30087A850 /* PBXTargetDependency */,
+			);
+			name = check_cm_manifest;
+			productName = "test-r_media";
+			productReference = CEAD8FB42F8D8DE30087A850 /* check_cm_manifest */;
+			productType = "com.apple.product-type.tool";
+		};
 		CEB384DE29A3A73B006DEA13 /* check_color */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = CEB384E929A3A73B006DEA13 /* Build configuration list for PBXNativeTarget "check_color" */;
@@ -4495,6 +4558,7 @@
 				CE9A670B2D2589020068D720 /* check_box */,
 				CE51FB9D21481DD300ABE14F /* check_cmd */,
 				CEE3A0F021EE2B3F0070FD3E /* check_cm_entity */,
+				CEAD8FA42F8D8DE30087A850 /* check_cm_manifest */,
 				CEA508F52EA5D20A00F27205 /* check_cm_polylib */,
 				CE4DCF8C256F0DAD00FECAFC /* check_cm_test */,
 				CEB384DE29A3A73B006DEA13 /* check_color */,
@@ -4777,6 +4841,7 @@
 				CE80FFF21C5E4D1800A21A51 /* qbsp.c in Sources */,
 				CE80FFF31C5E4D1800A21A51 /* qlight.c in Sources */,
 				CE80FFF61C5E4D1800A21A51 /* qzip.c in Sources */,
+				997E573805B0DCF96FB8C299 /* manifest.c in Sources */,
 				CE80FFF81C5E4D1800A21A51 /* texture.c in Sources */,
 				CE91924D2055731E007AC8FF /* tjunction.c in Sources */,
 				CE80FFFA1C5E4D1800A21A51 /* tree.c in Sources */,
@@ -4823,6 +4888,7 @@
 				CE6C2D111E24902900F55B0A /* cm_bsp.c in Sources */,
 				CEBDB0CA214A037900A7AC3D /* cm_entity.c in Sources */,
 				CEA3B48D1E0576E3004A6CF3 /* cm_material.c in Sources */,
+				522B158EA7384E83CD005789 /* cm_manifest.c in Sources */,
 				CE80FE3B1C5E424300A21A51 /* cm_model.c in Sources */,
 				CE80FE3C1C5E424300A21A51 /* cm_test.c in Sources */,
 				CE80FE3D1C5E424300A21A51 /* cm_trace.c in Sources */,
@@ -4940,6 +5006,15 @@
 			files = (
 				CEAD8F912F8D765F0087A850 /* tests.c in Sources */,
 				CEAD8FA02F8D76830087A850 /* check_http.c in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CEAD8FA72F8D8DE30087A850 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				CEAD8FA82F8D8DE30087A850 /* tests.c in Sources */,
+				CEAD8FB52F8D8DF70087A850 /* check_cm_manifest.c in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -5159,6 +5234,11 @@
 			isa = PBXTargetDependency;
 			target = CE80FE431C5E431000A21A51 /* net */;
 			targetProxy = CEAD8F9E2F8D76790087A850 /* PBXContainerItemProxy */;
+		};
+		CEAD8FA52F8D8DE30087A850 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = CE80FDD91C5E3E1100A21A51 /* common */;
+			targetProxy = CEAD8FA62F8D8DE30087A850 /* PBXContainerItemProxy */;
 		};
 		CEB384F229A3D24D006DEA13 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -5842,6 +5922,20 @@
 			};
 			name = Release;
 		};
+		CEAD8FB22F8D8DE30087A850 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		CEAD8FB32F8D8DE30087A850 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
 		CEB384EA29A3A73B006DEA13 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -6223,6 +6317,15 @@
 			buildConfigurations = (
 				CEAD8F9B2F8D765F0087A850 /* Debug */,
 				CEAD8F9C2F8D765F0087A850 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		CEAD8FB12F8D8DE30087A850 /* Build configuration list for PBXNativeTarget "check_cm_manifest" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				CEAD8FB22F8D8DE30087A850 /* Debug */,
+				CEAD8FB32F8D8DE30087A850 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Quetoo.xcodeproj/project.pbxproj
+++ b/Quetoo.xcodeproj/project.pbxproj
@@ -918,8 +918,8 @@
 			isa = PBXContainerItemProxy;
 			containerPortal = CE12D4A11C5C579D00CD0B13 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = CE80FDD91C5E3E1100A21A51;
-			remoteInfo = common;
+			remoteGlobalIDString = CE80FE0E1C5E421900A21A51;
+			remoteInfo = collision;
 		};
 		CEB384F129A3D24D006DEA13 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -5237,7 +5237,7 @@
 		};
 		CEAD8FA52F8D8DE30087A850 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = CE80FDD91C5E3E1100A21A51 /* common */;
+			target = CE80FE0E1C5E421900A21A51 /* collision */;
 			targetProxy = CEAD8FA62F8D8DE30087A850 /* PBXContainerItemProxy */;
 		};
 		CEB384F229A3D24D006DEA13 /* PBXTargetDependency */ = {

--- a/Quetoo.xcodeproj/xcshareddata/xcschemes/check_cm_manifest.xcscheme
+++ b/Quetoo.xcodeproj/xcshareddata/xcschemes/check_cm_manifest.xcscheme
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "2620"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "CEAD8FA42F8D8DE30087A850"
+               BuildableName = "check_cm_manifest"
+               BlueprintName = "check_cm_manifest"
+               ReferencedContainer = "container:Quetoo.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES"
+      viewDebuggingEnabled = "No">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "CEAD8FA42F8D8DE30087A850"
+            BuildableName = "check_cm_manifest"
+            BlueprintName = "check_cm_manifest"
+            ReferencedContainer = "container:Quetoo.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "CK_FORK"
+            value = "no"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "CEAD8FA42F8D8DE30087A850"
+            BuildableName = "check_cm_manifest"
+            BlueprintName = "check_cm_manifest"
+            ReferencedContainer = "container:Quetoo.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/src/client/cl_media.c
+++ b/src/client/cl_media.c
@@ -23,9 +23,9 @@
 
 /**
  * @brief Entry point for file downloads, or "precache" from server. Attempt to
- * download .pk3 and .bsp from server. Archive is preferred. Once all precache
- * checks are completed, we load media and ask the server to begin sending
- * us frames.
+ * download the .pk3 archive, then the .mf manifest and all assets it references.
+ * Once all precache checks are completed, we load media and ask the server to
+ * begin sending us frames.
  */
 void Cl_RequestNextDownload(void) {
 
@@ -33,22 +33,40 @@ void Cl_RequestNextDownload(void) {
     return;
   }
 
-  // check zip
+  // check pk3 archive (may contain everything including manifest and bsp)
   if (cl.precache_check == CS_PK3) {
-    cl.precache_check = CS_BSP;
+    cl.precache_check = CS_MANIFEST;
 
     if (*cl.config_strings[CS_PK3] != '\0') {
       Cl_CheckOrDownloadFile(cl.config_strings[CS_PK3]);
     }
   }
 
-  // check .bsp via models
-  if (cl.precache_check == CS_BSP) { // the map is the only model we care about
+  // download the manifest and all assets it references (including the bsp)
+  if (cl.precache_check == CS_MANIFEST) {
     cl.precache_check++;
 
-    if (*cl.config_strings[CS_BSP] != '\0') {
-      Cl_CheckOrDownloadFile(cl.config_strings[CS_BSP]);
+    Cl_CheckOrDownloadFile(cl.config_strings[CS_MANIFEST]);
+
+    GList *manifest = Cm_ReadManifest(cl.config_strings[CS_MANIFEST]);
+    if (!manifest) {
+      Com_Error(ERROR_DROP, "Failed to read %s\n", cl.config_strings[CS_MANIFEST]);
     }
+
+    for (GList *e = manifest; e; e = e->next) {
+      const cm_manifest_entry_t *entry = (const cm_manifest_entry_t *) e->data;
+
+      if (Fs_Exists(entry->path)) {
+        if (!Cm_CheckManifestEntry(entry)) {
+          Com_Warn("%s differs from server (expected %s)\n",
+                   entry->path, entry->hash);
+        }
+      } else {
+        Cl_CheckOrDownloadFile(entry->path);
+      }
+    }
+
+    Cm_FreeManifest(manifest);
   }
 
   // we're good to go, lock and load (literally)

--- a/src/client/cl_media.c
+++ b/src/client/cl_media.c
@@ -46,27 +46,29 @@ void Cl_RequestNextDownload(void) {
   if (cl.precache_check == CS_MANIFEST) {
     cl.precache_check++;
 
-    Cl_CheckOrDownloadFile(cl.config_strings[CS_MANIFEST]);
+    if (*cl.config_strings[CS_MANIFEST] != '\0') {
+      Cl_CheckOrDownloadFile(cl.config_strings[CS_MANIFEST]);
 
-    GList *manifest = Cm_ReadManifest(cl.config_strings[CS_MANIFEST]);
-    if (!manifest) {
-      Com_Error(ERROR_DROP, "Failed to read %s\n", cl.config_strings[CS_MANIFEST]);
-    }
-
-    for (GList *e = manifest; e; e = e->next) {
-      const cm_manifest_entry_t *entry = (const cm_manifest_entry_t *) e->data;
-
-      if (Fs_Exists(entry->path)) {
-        if (!Cm_CheckManifestEntry(entry)) {
-          Com_Warn("%s differs from server (expected %s)\n",
-                   entry->path, entry->hash);
-        }
-      } else {
-        Cl_CheckOrDownloadFile(entry->path);
+      GList *manifest = Cm_ReadManifest(cl.config_strings[CS_MANIFEST]);
+      if (!manifest) {
+        Com_Error(ERROR_DROP, "Failed to read %s\n", cl.config_strings[CS_MANIFEST]);
       }
-    }
 
-    Cm_FreeManifest(manifest);
+      for (GList *e = manifest; e; e = e->next) {
+        const cm_manifest_entry_t *entry = (const cm_manifest_entry_t *) e->data;
+
+        if (Fs_Exists(entry->path)) {
+          if (!Cm_CheckManifestEntry(entry)) {
+            Com_Warn("%s differs from server (expected %s)\n",
+                     entry->path, entry->hash);
+          }
+        } else {
+          Cl_CheckOrDownloadFile(entry->path);
+        }
+      }
+
+      Cm_FreeManifest(manifest);
+    }
   }
 
   // we're good to go, lock and load (literally)

--- a/src/collision/Makefile.am
+++ b/src/collision/Makefile.am
@@ -2,6 +2,7 @@ noinst_HEADERS = \
 	cm_bsp.h \
 	cm_entity.h \
 	cm_local.h \
+	cm_manifest.h \
 	cm_material.h \
 	cm_model.h \
 	cm_polylib.h \
@@ -21,6 +22,7 @@ libcollision_la_CFLAGS = \
 libcollision_la_SOURCES = \
 	cm_bsp.c \
 	cm_entity.c \
+	cm_manifest.c \
 	cm_material.c \
 	cm_model.c \
 	cm_polylib.c \

--- a/src/collision/cm_manifest.c
+++ b/src/collision/cm_manifest.c
@@ -112,6 +112,8 @@ GList *Cm_ReadManifest(const char *path) {
 	Fs_Free(data);
 
 	for (gchar **line = lines; *line; line++) {
+		g_strstrip(*line);
+
 		if (**line == '\0') {
 			continue;
 		}

--- a/src/collision/cm_manifest.c
+++ b/src/collision/cm_manifest.c
@@ -1,0 +1,144 @@
+/*
+ * Copyright(c) 1997-2001 id Software, Inc.
+ * Copyright(c) 2002 The Quakeforge Project.
+ * Copyright(c) 2006 Quetoo.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+#include "cm_manifest.h"
+
+/**
+ * @brief Computes the MD5 hex digest of the given data.
+ */
+static void Cm_Md5Hex(const void *data, size_t len, char *hex, size_t hex_size) {
+
+	GChecksum *md5 = g_checksum_new(G_CHECKSUM_MD5);
+	g_checksum_update(md5, (const guchar *) data, len);
+	g_strlcpy(hex, g_checksum_get_string(md5), hex_size);
+	g_checksum_free(md5);
+}
+
+/**
+ * @brief Appends an entry to a manifest list, computing the MD5 checksum of the given data.
+ */
+void Cm_AddManifestEntry(GList **manifest, const char *path, const void *data, size_t len) {
+
+	assert(manifest);
+	assert(path);
+	assert(data);
+	assert(len > 0);
+
+	cm_manifest_entry_t *entry = Mem_Malloc(sizeof(*entry));
+	g_strlcpy(entry->path, path, sizeof(entry->path));
+	Cm_Md5Hex(data, len, entry->hash, sizeof(entry->hash));
+
+	*manifest = g_list_append(*manifest, entry);
+}
+
+/**
+ * @brief Verifies a manifest entry against the local file on disk.
+ */
+bool Cm_CheckManifestEntry(const cm_manifest_entry_t *entry) {
+
+	assert(entry);
+
+	void *data = NULL;
+	const int64_t len = Fs_Load(entry->path, &data);
+	if (len <= 0 || !data) {
+		if (data) {
+			Fs_Free(data);
+		}
+		return false;
+	}
+
+	char hash[sizeof(entry->hash)];
+	Cm_Md5Hex(data, len, hash, sizeof(hash));
+	Fs_Free(data);
+
+	return !g_strcmp0(entry->hash, hash);
+}
+
+/**
+ * @brief Writes a manifest list to a file.
+ */
+int32_t Cm_WriteManifest(const char *path, GList *manifest) {
+
+	file_t *file = Fs_OpenWrite(path);
+	if (!file) {
+		Com_Warn("Failed to open %s for writing\n", path);
+		return -1;
+	}
+
+	int32_t count = 0;
+	for (GList *e = manifest; e; e = e->next) {
+		const cm_manifest_entry_t *entry = (const cm_manifest_entry_t *) e->data;
+		Fs_Print(file, "%s %s\n", entry->hash, entry->path);
+		count++;
+	}
+
+	Fs_Close(file);
+
+	return count;
+}
+
+/**
+ * @brief Reads a manifest file and returns a GList of cm_manifest_entry_t.
+ */
+GList *Cm_ReadManifest(const char *path) {
+
+	void *data = NULL;
+	const int64_t len = Fs_Load(path, &data);
+	if (len <= 0 || !data) {
+		return NULL;
+	}
+
+	GList *manifest = NULL;
+
+	gchar **lines = g_strsplit((const char *) data, "\n", -1);
+	Fs_Free(data);
+
+	for (gchar **line = lines; *line; line++) {
+		if (**line == '\0') {
+			continue;
+		}
+
+		char *space = strchr(*line, ' ');
+		if (!space) {
+			Com_Warn("Malformed manifest line: %s\n", *line);
+			continue;
+		}
+
+		*space = '\0';
+
+		cm_manifest_entry_t *entry = Mem_Malloc(sizeof(*entry));
+		g_strlcpy(entry->path, space + 1, sizeof(entry->path));
+		g_strlcpy(entry->hash, *line, sizeof(entry->hash));
+
+		manifest = g_list_append(manifest, entry);
+	}
+
+	g_strfreev(lines);
+
+	return manifest;
+}
+
+/**
+ * @brief Frees a manifest list.
+ */
+void Cm_FreeManifest(GList *manifest) {
+	g_list_free_full(manifest, Mem_Free);
+}

--- a/src/collision/cm_manifest.h
+++ b/src/collision/cm_manifest.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright(c) 1997-2001 id Software, Inc.
+ * Copyright(c) 2002 The Quakeforge Project.
+ * Copyright(c) 2006 Quetoo.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+#pragma once
+
+#include "common/common.h"
+
+/**
+ * @brief A single entry in a map manifest.
+ */
+typedef struct {
+	char path[MAX_QPATH];
+	char hash[33]; // 32 hex chars + NUL (MD5)
+} cm_manifest_entry_t;
+
+/**
+ * @brief Appends an entry to a manifest list, computing the MD5 checksum of the given data.
+ * @param manifest Pointer to the manifest GList (may point to NULL for empty list).
+ * @param path The asset path.
+ * @param data The file data to checksum.
+ * @param len The length of the data in bytes.
+ */
+void Cm_AddManifestEntry(GList **manifest, const char *path, const void *data, size_t len);
+
+/**
+ * @brief Verifies a manifest entry against the local file on disk.
+ * @param entry The manifest entry to check.
+ * @return true if the local file exists and its MD5 matches the entry's hash.
+ */
+bool Cm_CheckManifestEntry(const cm_manifest_entry_t *entry);
+
+/**
+ * @brief Writes a manifest list to a file.
+ * @param path The output file path (e.g. "maps/edge.mf").
+ * @param manifest The manifest list to write.
+ * @return The number of entries written, or -1 on failure.
+ */
+int32_t Cm_WriteManifest(const char *path, GList *manifest);
+
+/**
+ * @brief Reads a manifest file and returns a GList of cm_manifest_entry_t.
+ * Each entry is allocated with Mem_Malloc and should be freed with
+ * Cm_FreeManifest.
+ * @param path The manifest file path (e.g. "maps/edge.mf").
+ * @return A GList of cm_manifest_entry_t, or NULL on failure.
+ */
+GList *Cm_ReadManifest(const char *path);
+
+/**
+ * @brief Frees a manifest list.
+ */
+void Cm_FreeManifest(GList *manifest);

--- a/src/game/default/g_types.h
+++ b/src/game/default/g_types.h
@@ -28,7 +28,7 @@
  * @brief Game protocol version (protocol minor version). To be incremented
  * whenever the game protocol changes.
  */
-#define PROTOCOL_MINOR 1020
+#define PROTOCOL_MINOR 1021
 
 /**
  * @brief Game-specific server protocol commands. These are parsed directly by

--- a/src/net/net_sock.c
+++ b/src/net/net_sock.c
@@ -22,9 +22,6 @@
 #include <errno.h>
 
 #if defined(_WIN32)
-  #include <winsock2.h>
-  #include <ws2tcpip.h>
-
   #define ioctl ioctlsocket
 
   #include <Objectively/URLSession.h>

--- a/src/net/net_types.h
+++ b/src/net/net_types.h
@@ -22,6 +22,8 @@
 #pragma once
 
 #if defined(_WIN32)
+  #include <winsock2.h>
+  #include <ws2tcpip.h>
   #include <inttypes.h>
 
   typedef uint32_t in_addr_t;

--- a/src/net/net_udp.c
+++ b/src/net/net_udp.c
@@ -19,10 +19,7 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
  */
 
-#if defined(_WIN32)
-  #include <winsock2.h>
-  #include <ws2tcpip.h>
-#elif !defined(_MSC_VER)
+#if !defined(_WIN32) && !defined(_MSC_VER)
   #include <sys/time.h>
 #endif
 

--- a/src/server/sv_http.c
+++ b/src/server/sv_http.c
@@ -29,7 +29,9 @@ static int32_t sv_http_socket = -1;
  */
 static const char *sv_http_allowed_patterns[] = {
 	"*.pk3",
+	"docs/*",
 	"maps/*",
+	"mapshots/*",
 	"models/*",
 	"sounds/*",
 	"sky/*",

--- a/src/server/sv_init.c
+++ b/src/server/sv_init.c
@@ -275,6 +275,8 @@ static void Sv_LoadMedia(const char *server, sv_state_t state) {
       sv.config_strings[CS_PK3][0] = '\0';
     }
 
+    g_snprintf(sv.config_strings[CS_MANIFEST], MAX_STRING_CHARS, "maps/%s.mf", sv.name);
+
     for (int32_t i = 0; i < Cm_NumModels(); i++) {
 
       if (i == MAX_MODELS) {

--- a/src/shared/shared.h
+++ b/src/shared/shared.h
@@ -35,9 +35,10 @@
  */
 #define CS_NAME     0 // the server name
 #define CS_PK3      1 // pk3 name
-#define CS_BSP      2 // bsp name
-#define CS_BSP_SIZE 3 // for catching incompatible bsps
-#define CS_MODELS   4 // bsp inline models and mesh models
+#define CS_MANIFEST 2 // map manifest
+#define CS_BSP      3 // bsp name
+#define CS_BSP_SIZE 4 // for catching incompatible bsps
+#define CS_MODELS   5 // bsp inline models and mesh models
 #define CS_SOUNDS   (CS_MODELS + MAX_MODELS)
 #define CS_MUSICS   (CS_SOUNDS + MAX_SOUNDS)
 #define CS_IMAGES   (CS_MUSICS + MAX_MUSICS)

--- a/src/tests/Makefile.am
+++ b/src/tests/Makefile.am
@@ -33,6 +33,7 @@ TESTS = \
 	check_atlas \
 	check_box \
 	check_cm_entity \
+	check_cm_manifest \
 	check_cm_polylib \
 	check_cm_test \
 	check_cmd \
@@ -76,6 +77,14 @@ check_cm_entity_SOURCES = \
 check_cm_entity_CFLAGS = \
 	$(TESTS_CFLAGS)
 check_cm_entity_LDADD = \
+	$(TESTS_LIBS) \
+	$(top_builddir)/src/collision/libcollision.la
+
+check_cm_manifest_SOURCES = \
+	check_cm_manifest.c
+check_cm_manifest_CFLAGS = \
+	$(TESTS_CFLAGS)
+check_cm_manifest_LDADD = \
 	$(TESTS_LIBS) \
 	$(top_builddir)/src/collision/libcollision.la
 

--- a/src/tests/check_cm_manifest.c
+++ b/src/tests/check_cm_manifest.c
@@ -1,0 +1,235 @@
+/*
+ * Copyright(c) 1997-2001 id Software, Inc.
+ * Copyright(c) 2002 The Quakeforge Project.
+ * Copyright(c) 2006 Quetoo.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+#include "tests.h"
+#include "collision/cm_manifest.h"
+
+quetoo_t quetoo;
+
+/**
+ * @brief Setup fixture.
+ */
+void setup(void) {
+	Mem_Init();
+	Fs_Init(FS_NONE);
+}
+
+/**
+ * @brief Teardown fixture.
+ */
+void teardown(void) {
+	Fs_Shutdown();
+	Mem_Shutdown();
+}
+
+/**
+ * @brief Helper to write raw text to a file.
+ */
+static void write_file(const char *path, const char *content) {
+	file_t *file = Fs_OpenWrite(path);
+	ck_assert_msg(file != NULL, "Failed to open %s for writing", path);
+	Fs_Print(file, "%s", content);
+	Fs_Close(file);
+}
+
+START_TEST(check_Cm_ReadManifest) {
+
+	write_file("test.mf",
+		"d41d8cd98f00b204e9800998ecf8427e textures/edge/floor01_d.tga\n"
+		"a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6 sounds/weapons/rg_fire.ogg\n"
+	);
+
+	GList *manifest = Cm_ReadManifest("test.mf");
+	ck_assert_msg(manifest != NULL, "Cm_ReadManifest returned NULL");
+	ck_assert_int_eq(g_list_length(manifest), 2);
+
+	const cm_manifest_entry_t *e0 = (const cm_manifest_entry_t *) manifest->data;
+	ck_assert_str_eq(e0->path, "textures/edge/floor01_d.tga");
+	ck_assert_str_eq(e0->hash, "d41d8cd98f00b204e9800998ecf8427e");
+
+	const cm_manifest_entry_t *e1 = (const cm_manifest_entry_t *) manifest->next->data;
+	ck_assert_str_eq(e1->path, "sounds/weapons/rg_fire.ogg");
+	ck_assert_str_eq(e1->hash, "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6");
+
+	Cm_FreeManifest(manifest);
+
+} END_TEST
+
+START_TEST(check_Cm_ReadManifest_empty_lines) {
+
+	write_file("test_empty.mf",
+		"\n"
+		"d41d8cd98f00b204e9800998ecf8427e textures/foo.tga\n"
+		"\n"
+		"\n"
+		"a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6 sounds/bar.ogg\n"
+		"\n"
+	);
+
+	GList *manifest = Cm_ReadManifest("test_empty.mf");
+	ck_assert_msg(manifest != NULL, "Cm_ReadManifest returned NULL");
+	ck_assert_int_eq(g_list_length(manifest), 2);
+
+	Cm_FreeManifest(manifest);
+
+} END_TEST
+
+START_TEST(check_Cm_ReadManifest_missing_file) {
+
+	GList *manifest = Cm_ReadManifest("nonexistent.mf");
+	ck_assert_msg(manifest == NULL, "Expected NULL for missing manifest");
+
+} END_TEST
+
+START_TEST(check_Cm_WriteManifest) {
+
+	const char *content1 = "hello";
+	const char *content2 = "world";
+
+	GList *manifest = NULL;
+	Cm_AddManifestEntry(&manifest, "textures/edge/floor01_d.tga", content1, strlen(content1));
+	Cm_AddManifestEntry(&manifest, "sounds/weapons/rg_fire.ogg", content2, strlen(content2));
+
+	const int32_t count = Cm_WriteManifest("test_write.mf", manifest);
+	ck_assert_int_eq(count, 2);
+
+	Cm_FreeManifest(manifest);
+
+	// verify the file was written correctly (MD5 of "hello" and "world")
+	void *data = NULL;
+	const int64_t len = Fs_Load("test_write.mf", &data);
+	ck_assert_msg(len > 0, "Failed to load written manifest");
+	ck_assert_msg(strstr((const char *) data, "5d41402abc4b2a76b9719d911017c592 textures/edge/floor01_d.tga") != NULL,
+		"Missing first entry in written manifest");
+	ck_assert_msg(strstr((const char *) data, "7d793037a0760186574b0282f2f435e7 sounds/weapons/rg_fire.ogg") != NULL,
+		"Missing second entry in written manifest");
+	Fs_Free(data);
+
+} END_TEST
+
+START_TEST(check_Cm_Manifest_roundtrip) {
+
+	const char *content1 = "file1data";
+	const char *content2 = "file2data";
+	const char *content3 = "file3data";
+
+	GList *manifest = NULL;
+	Cm_AddManifestEntry(&manifest, "textures/edge/floor01_d.tga", content1, strlen(content1));
+	Cm_AddManifestEntry(&manifest, "sounds/weapons/rg_fire.ogg", content2, strlen(content2));
+	Cm_AddManifestEntry(&manifest, "maps/edge.nav", content3, strlen(content3));
+
+	// save original hashes for comparison
+	cm_manifest_entry_t orig[3];
+	GList *e = manifest;
+	for (int32_t i = 0; i < 3; i++, e = e->next) {
+		orig[i] = *(const cm_manifest_entry_t *) e->data;
+	}
+
+	Cm_WriteManifest("test_roundtrip.mf", manifest);
+	Cm_FreeManifest(manifest);
+
+	GList *loaded = Cm_ReadManifest("test_roundtrip.mf");
+	ck_assert_msg(loaded != NULL, "Cm_ReadManifest returned NULL after write");
+	ck_assert_int_eq(g_list_length(loaded), 3);
+
+	e = loaded;
+	for (int32_t i = 0; i < 3; i++, e = e->next) {
+		const cm_manifest_entry_t *entry = (const cm_manifest_entry_t *) e->data;
+		ck_assert_str_eq(entry->path, orig[i].path);
+		ck_assert_str_eq(entry->hash, orig[i].hash);
+	}
+
+	Cm_FreeManifest(loaded);
+
+} END_TEST
+
+START_TEST(check_Cm_CheckManifestEntry) {
+
+	// write a file and build a manifest entry from the same content
+	const char *content = "test file content";
+	write_file("test_asset.tga", content);
+
+	GList *manifest = NULL;
+	Cm_AddManifestEntry(&manifest, "test_asset.tga", content, strlen(content));
+
+	const cm_manifest_entry_t *entry = (const cm_manifest_entry_t *) manifest->data;
+
+	// local file matches — should return true
+	ck_assert(Cm_CheckManifestEntry(entry));
+
+	// overwrite the file with different content
+	write_file("test_asset.tga", "different content");
+
+	// now should return false
+	ck_assert(!Cm_CheckManifestEntry(entry));
+
+	Cm_FreeManifest(manifest);
+
+} END_TEST
+
+/**
+ * @brief Test entry point.
+ */
+int32_t main(int32_t argc, char **argv) {
+
+	Test_Init(argc, argv);
+
+	Suite *suite = suite_create("check_cm_manifest");
+
+	{
+		TCase *tcase = tcase_create("Cm_ReadManifest");
+		tcase_add_checked_fixture(tcase, setup, teardown);
+		tcase_add_test(tcase, check_Cm_ReadManifest);
+		tcase_add_test(tcase, check_Cm_ReadManifest_empty_lines);
+		tcase_add_test(tcase, check_Cm_ReadManifest_missing_file);
+
+		suite_add_tcase(suite, tcase);
+	}
+
+	{
+		TCase *tcase = tcase_create("Cm_WriteManifest");
+		tcase_add_checked_fixture(tcase, setup, teardown);
+		tcase_add_test(tcase, check_Cm_WriteManifest);
+
+		suite_add_tcase(suite, tcase);
+	}
+
+	{
+		TCase *tcase = tcase_create("Cm_Manifest_roundtrip");
+		tcase_add_checked_fixture(tcase, setup, teardown);
+		tcase_add_test(tcase, check_Cm_Manifest_roundtrip);
+
+		suite_add_tcase(suite, tcase);
+	}
+
+	{
+		TCase *tcase = tcase_create("Cm_CheckManifestEntry");
+		tcase_add_checked_fixture(tcase, setup, teardown);
+		tcase_add_test(tcase, check_Cm_CheckManifestEntry);
+
+		suite_add_tcase(suite, tcase);
+	}
+
+	int32_t failed = Test_Run(suite);
+
+	Test_Shutdown();
+	return failed;
+}

--- a/src/tools/quemap/Makefile.am
+++ b/src/tools/quemap/Makefile.am
@@ -9,6 +9,7 @@ noinst_HEADERS = \
 	face.h \
 	leakfile.h \
 	light.h \
+	manifest.h \
 	material.h \
 	patch.h \
 	points.h \
@@ -35,6 +36,7 @@ quemap_SOURCES = \
 	leakfile.c \
 	light.c \
 	main.c \
+	manifest.c \
 	map.c \
 	material.c \
 	patch.c \

--- a/src/tools/quemap/main.c
+++ b/src/tools/quemap/main.c
@@ -19,6 +19,7 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
  */
 
+#include "manifest.h"
 #include "qbsp.h"
 #include "qlight.h"
 #include "qzip.h"
@@ -380,6 +381,9 @@ int32_t main(int32_t argc, char **argv) {
 
     FreeMaterials();
   }
+
+  // always write the manifest after compilation (or before -zip)
+  WriteManifest();
 
   if (do_zip) {
     ZIP_Main();

--- a/src/tools/quemap/manifest.c
+++ b/src/tools/quemap/manifest.c
@@ -45,6 +45,16 @@ static bool Add(const char *name) {
 		return false;
 	}
 
+	if (*name == '/') {
+		Com_Warn("Rejecting absolute path: %s\n", name);
+		return false;
+	}
+
+	if (strchr(name, ' ')) {
+		Com_Warn("Rejecting path with spaces: %s\n", name);
+		return false;
+	}
+
 	if (strstr(name, "..")) {
 		Com_Warn("Rejecting path with '..': %s\n", name);
 		return false;
@@ -79,10 +89,7 @@ static bool AddFirstWithExtensions(const char *name, const char **extensions) {
 	const char **ext = extensions;
 	while (*ext) {
 		const char *path = va("%s.%s", base, *ext);
-		if (Fs_Exists(path)) {
-			if (!g_hash_table_contains(paths, path)) {
-				g_hash_table_insert(paths, g_strdup(path), g_strdup(path));
-			}
+		if (Add(path)) {
 			return true;
 		}
 		ext++;

--- a/src/tools/quemap/manifest.c
+++ b/src/tools/quemap/manifest.c
@@ -299,6 +299,7 @@ int32_t WriteManifest(void) {
 
 		void *data = NULL;
 		const int64_t len = Fs_Load(path, &data);
+		// zero-length assets are intentionally skipped (no valid game assets are empty)
 		if (len > 0 && data) {
 			Cm_AddManifestEntry(&manifest, path, data, len);
 			Com_Verbose("  %s\n", path);

--- a/src/tools/quemap/manifest.c
+++ b/src/tools/quemap/manifest.c
@@ -276,6 +276,10 @@ int32_t WriteManifest(void) {
 	AddDocumentation();
 	AddMapshots();
 
+	// add the bsp itself to the manifest
+	const char *bsp_path = va("maps/%s.bsp", map_base);
+	Add(bsp_path);
+
 	// sort the asset paths
 	GList *asset_paths = g_hash_table_get_values(paths);
 	asset_paths = g_list_sort(asset_paths, (GCompareFunc) g_strcmp0);

--- a/src/tools/quemap/manifest.c
+++ b/src/tools/quemap/manifest.c
@@ -1,0 +1,319 @@
+/*
+ * Copyright(c) 1997-2001 id Software, Inc.
+ * Copyright(c) 2002 The Quakeforge Project.
+ * Copyright(c) 2006 Quetoo.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+#include "bsp.h"
+#include "manifest.h"
+#include "material.h"
+
+#include "collision/cm_manifest.h"
+
+static GHashTable *paths;
+
+/**
+ * @brief Forbidden extensions that must never appear in a manifest.
+ * A malicious map could reference server.cfg to expose rcon_password, etc.
+ */
+static const char *forbidden_extensions[] = { ".cfg", ".rc", NULL };
+
+/**
+ * @brief Adds the specified resource path if it exists.
+ */
+static bool Add(const char *name) {
+
+	assert(name);
+
+	if (!strlen(name)) {
+		Com_Verbose("Failed to add empty path\n");
+		return false;
+	}
+
+	if (strstr(name, "..")) {
+		Com_Warn("Rejecting path with '..': %s\n", name);
+		return false;
+	}
+
+	for (const char **ext = forbidden_extensions; *ext; ext++) {
+		if (g_str_has_suffix(name, *ext)) {
+			Com_Warn("Rejecting forbidden file type: %s\n", name);
+			return false;
+		}
+	}
+
+	if (Fs_Exists(name)) {
+		if (!g_hash_table_contains(paths, name)) {
+			g_hash_table_insert(paths, g_strdup(name), g_strdup(name));
+		}
+		return true;
+	} else {
+		Com_Verbose("Failed to add %s\n", name);
+		return false;
+	}
+}
+
+/**
+ * @brief Adds the first resource found by name, trying the specified file extensions in order.
+ */
+static bool AddFirstWithExtensions(const char *name, const char **extensions) {
+	char base[MAX_QPATH];
+
+	StripExtension(name, base);
+
+	const char **ext = extensions;
+	while (*ext) {
+		const char *path = va("%s.%s", base, *ext);
+		if (Fs_Exists(path)) {
+			if (!g_hash_table_contains(paths, path)) {
+				g_hash_table_insert(paths, g_strdup(path), g_strdup(path));
+			}
+			return true;
+		}
+		ext++;
+	}
+
+	return false;
+}
+
+/**
+ * @brief Attempts to add the specified sound in any available format.
+ */
+static void AddSound(const char *sound) {
+	const char *sound_extensions[] = { "ogg", "wav", NULL };
+
+	if (!AddFirstWithExtensions(va("sounds/%s", sound), sound_extensions)) {
+		Com_Warn("Failed to add %s\n", sound);
+	}
+}
+
+/**
+ * @brief Attempts to add the specified image in any available format.
+ */
+static void AddImage(const char *image) {
+	const char *image_extensions[] = { "tga", "png", "jpg", NULL };
+
+	if (!AddFirstWithExtensions(image, image_extensions)) {
+		Com_Warn("Failed to add %s\n", image);
+	}
+}
+
+/**
+ * @brief Adds the sky environment map.
+ */
+static void AddSky(const char *sky) {
+
+	Com_Debug(DEBUG_ALL, "Adding sky %s\n", sky);
+
+	AddImage(va("sky/%s", sky));
+}
+
+/**
+ * @brief Adds the material's assets to the assets list.
+ */
+static void AddMaterial(const cm_material_t *material) {
+
+	if (Add(material->diffusemap.path)) {
+		Add(material->path);
+		Add(material->normalmap.path);
+		Add(material->heightmap.path);
+		Add(material->specularmap.path);
+		Add(material->tintmap.path);
+
+		for (const cm_stage_t *stage = material->stages; stage; stage = stage->next) {
+			Add(stage->asset.path);
+			for (int32_t i = 0; i < stage->animation.num_frames; i++) {
+				Add(stage->animation.frames[i].path);
+			}
+		}
+	} else {
+		Com_Warn("Failed to add %s\n", material->name);
+	}
+}
+
+/**
+ * @brief Adds all world materials to the assets list.
+ */
+static void AddBspMaterials(void) {
+
+	for (int32_t i = 0; i < bsp_file.num_materials; i++) {
+		const char *name = bsp_file.materials[i].name;
+
+		cm_material_t *material = Cm_LoadMaterial(name, ASSET_CONTEXT_TEXTURES);
+
+		AddMaterial(material);
+
+		Cm_FreeMaterial(material);
+	}
+}
+
+/**
+ * @brief Fs_Enumerate callback that adds all files in a model directory.
+ */
+static void AddModel_enumerate(const char *path, void *data) {
+	Add(path);
+}
+
+/**
+ * @brief Adds the specified model and all assets in its directory.
+ */
+static void AddModel(const char *model) {
+	const char *model_formats[] = { "md3", "obj", NULL };
+	char path[MAX_QPATH];
+
+	if (model[0] == '*') { // inline bsp model
+		return;
+	}
+
+	if (!AddFirstWithExtensions(model, model_formats)) {
+		Com_Warn("Failed to resolve %s\n", model);
+		return;
+	}
+
+	Dirname(model, path);
+
+	Fs_Enumerate(va("%s*", path), AddModel_enumerate, NULL);
+}
+
+/**
+ * @brief Adds all entity-referenced assets (sounds, models, sky).
+ */
+static void AddEntities(void) {
+
+	GList *entities = Cm_LoadEntities(bsp_file.entity_string);
+
+	for (GList *entity = entities; entity; entity = entity->next) {
+		const cm_entity_t *e = entity->data;
+		while (e) {
+
+			if (!g_strcmp0(e->key, "sound")) {
+				AddSound(e->string);
+			} else if (!g_strcmp0(e->key, "model")) {
+				AddModel(e->string);
+			} else if (!g_strcmp0(e->key, "sky")) {
+				AddSky(e->string);
+			}
+
+			e = e->next;
+		}
+	}
+
+	g_list_free_full(entities, Mem_Free);
+}
+
+/**
+ * @brief Adds the navigation file.
+ */
+static void AddNavigation(void) {
+	Add(va("maps/%s.nav", map_base));
+}
+
+/**
+ * @brief Adds the location file.
+ */
+static void AddLocation(void) {
+	Add(va("maps/%s.loc", map_base));
+}
+
+/**
+ * @brief Adds documentation.
+ */
+static void AddDocumentation(void) {
+	Add(va("docs/map-%s.txt", map_base));
+}
+
+/**
+ * @brief Fs_Enumerate callback for mapshots.
+ */
+static void AddMapshots_enumerate(const char *path, void *data) {
+
+	if (g_str_has_suffix(path, ".jpg") ||
+		g_str_has_suffix(path, ".png") ||
+		g_str_has_suffix(path, ".tga")) {
+		Add(path);
+	}
+}
+
+/**
+ * @brief Adds mapshot images.
+ */
+static void AddMapshots(void) {
+	Fs_Enumerate(va("mapshots/%s/*", map_base), AddMapshots_enumerate, NULL);
+}
+
+/**
+ * @brief Discovers all assets referenced by the BSP and writes a manifest
+ * file (maps/<name>.mf) containing one asset per line as "md5 path", sorted.
+ */
+int32_t WriteManifest(void) {
+
+	Com_Print("\n------------------------------------------\n");
+	Com_Print("\nWriting manifest for %s\n\n", bsp_name);
+
+	paths = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, g_free);
+
+	LoadBSPFile(bsp_name, (1 << BSP_LUMP_MATERIALS) | (1 << BSP_LUMP_ENTITIES));
+
+	AddBspMaterials();
+	AddEntities();
+	AddNavigation();
+	AddLocation();
+	AddDocumentation();
+	AddMapshots();
+
+	// sort the asset paths
+	GList *asset_paths = g_hash_table_get_values(paths);
+	asset_paths = g_list_sort(asset_paths, (GCompareFunc) g_strcmp0);
+
+	// build the manifest entries with checksums
+	GList *manifest = NULL;
+
+	for (GList *a = asset_paths; a; a = a->next) {
+		const char *path = (const char *) a->data;
+
+		void *data = NULL;
+		const int64_t len = Fs_Load(path, &data);
+		if (len > 0 && data) {
+			Cm_AddManifestEntry(&manifest, path, data, len);
+			Com_Verbose("  %s\n", path);
+		} else {
+			Com_Warn("Failed to load %s\n", path);
+		}
+		if (data) {
+			Fs_Free(data);
+		}
+	}
+
+	g_list_free(asset_paths);
+	g_hash_table_destroy(paths);
+
+	// write the manifest
+	char mf_path[MAX_OS_PATH];
+	g_snprintf(mf_path, sizeof(mf_path), "maps/%s.mf", map_base);
+
+	const int32_t count = Cm_WriteManifest(mf_path, manifest);
+	if (count < 0) {
+		Com_Error(ERROR_FATAL, "Failed to write %s\n", mf_path);
+	}
+
+	Cm_FreeManifest(manifest);
+
+	Com_Print("Wrote %s (%d assets)\n", mf_path, count);
+
+	return 0;
+}

--- a/src/tools/quemap/manifest.h
+++ b/src/tools/quemap/manifest.h
@@ -21,14 +21,6 @@
 
 #pragma once
 
-#include "common/common.h"
+#include "quemap.h"
 
-#include "cm_bsp.h"
-#include "cm_entity.h"
-#include "cm_manifest.h"
-#include "cm_material.h"
-#include "cm_model.h"
-#include "cm_polylib.h"
-#include "cm_test.h"
-#include "cm_trace.h"
-#include "cm_types.h"
+int32_t WriteManifest(void);

--- a/src/tools/quemap/qzip.c
+++ b/src/tools/quemap/qzip.c
@@ -22,230 +22,14 @@
 #include "deps/minizip/miniz.h"
 
 #include "bsp.h"
-#include "material.h"
 #include "qzip.h"
 
 bool include_shared = false;
 bool update_zip = false;
 
-#define MISSING "__missing__"
-
-static GHashTable *paths;
-
 /**
- * @brief Adds the specified resource path if it exists.
- */
-static bool Add(const char *name) {
-
-  assert(name);
-
-  if (strlen(name) && Fs_Exists(name)) {
-    if (!g_hash_table_contains(paths, name)) {
-      g_hash_table_insert(paths, g_strdup(name), g_strdup(name));
-    }
-    return true;
-  } else {
-    Com_Verbose("Failed to add %s\n", name);
-    return false;
-  }
-}
-
-/**
- * @brief Adds the first resource found by name, trying the specified file extensions in order.
- */
-static bool AddFirstWithExtensions(const char *name, const char **extensions) {
-  char base[MAX_QPATH];
-
-  StripExtension(name, base);
-
-  if (g_hash_table_contains(paths, base)) {
-    return true;
-  }
-
-  const char **ext = extensions;
-  while (*ext) {
-    const char *path = va("%s.%s", base, *ext);
-    if (Fs_Exists(path)) {
-      g_hash_table_insert(paths, g_strdup(base), g_strdup(path));
-      return true;
-    }
-    ext++;
-  }
-
-  g_hash_table_insert(paths, g_strdup(base), g_strdup(MISSING));
-  return false;
-}
-
-/**
- * @brief Attempts to add the specified sound in any available format.
- */
-static void AddSound(const char *sound) {
-  const char *sound_extensions[] = { "ogg", "wav", NULL };
-
-  if (!AddFirstWithExtensions(va("sounds/%s", sound), sound_extensions)) {
-    Com_Warn("Failed to add %s\n", sound);
-  }
-}
-
-/**
- * @brief Attempts to add the specified image in any available format. If required,
- * a warning will be issued should we fail to resolve the specified image.
- */
-static void AddImage(const char *image) {
-  const char *image_extensions[] = { "tga", "png", "jpg", NULL };
-
-  if (!AddFirstWithExtensions(image, image_extensions)) {
-    Com_Warn("Failed to add %s\n", image);
-  }
-}
-
-/**
- * @brief Adds the sky environment map.
- */
-static void AddSky(const char *sky) {
-
-  Com_Debug(DEBUG_ALL, "Adding sky %s\n", sky);
-
-  AddImage(va("sky/%s", sky));
-}
-
-/**
- * @Adds the material's assets to the assets list.
- */
-static void AddMaterial(const cm_material_t *material) {
-
-  if (Add(material->diffusemap.path)) {
-    Add(material->path);
-    Add(material->normalmap.path);
-    Add(material->heightmap.path);
-    Add(material->specularmap.path);
-    Add(material->tintmap.path);
-
-    for (const cm_stage_t *stage = material->stages; stage; stage = stage->next) {
-      Add(stage->asset.path);
-      for (int32_t i = 0; i < stage->animation.num_frames; i++) {
-        Add(stage->animation.frames[i].path);
-      }
-    }
-  } else {
-    Com_Warn("Failed to add %s\n", material->name);
-  }
-}
-
-/**
- * @brief Adds all world materials to the assets list.
- */
-static void AddBspMaterials(void) {
-
-  for (int32_t i = 0; i < bsp_file.num_materials; i++) {
-    const char *name = bsp_file.materials[i].name;
-
-    cm_material_t *material = Cm_LoadMaterial(name, ASSET_CONTEXT_TEXTURES);
-
-    AddMaterial(material);
-
-    Cm_FreeMaterial(material);
-  }
-}
-
-/**
- * @brief Fs_Enumerate callback that adds all files in a model directory.
- */
-static void AddModel_enumerate(const char *path, void *data) {
-  Add(path);
-}
-
-/**
- * @brief Adds the specified model and all assets in its directory.
- */
-static void AddModel(const char *model) {
-  const char *model_formats[] = { "md3", "obj", NULL };
-  char path[MAX_QPATH];
-
-  if (model[0] == '*') { // inline bsp model
-    return;
-  }
-
-  if (!AddFirstWithExtensions(model, model_formats)) {
-    Com_Warn("Failed to resolve %s\n", model);
-    return;
-  }
-
-  Dirname(model, path);
-
-  Fs_Enumerate(va("%s*", path), AddModel_enumerate, NULL);
-}
-
-/**
- * @brief
- */
-static void AddEntities(void) {
-
-  GList *entities = Cm_LoadEntities(bsp_file.entity_string);
-
-  for (GList *entity = entities; entity; entity = entity->next) {
-    const cm_entity_t *e = entity->data;
-    while (e) {
-
-      if (!g_strcmp0(e->key, "sound")) {
-        AddSound(e->string);
-      } else if (!g_strcmp0(e->key, "model")) {
-        AddModel(e->string);
-      } else if (!g_strcmp0(e->key, "sky")) {
-        AddSky(e->string);
-      }
-
-      e = e->next;
-    }
-  }
-
-  g_list_free_full(entities, Mem_Free);
-}
-
-/**
- * @brief
- */
-static void AddNavigation(void) {
-  Add(va("maps/%s.nav", map_base));
-}
-
-/**
- * @brief
- */
-static void AddLocation(void) {
-  Add(va("maps/%s.loc", map_base));
-}
-
-/**
- * @brief
- */
-static void AddDocumentation(void) {
-  Add(va("docs/map-%s.txt", map_base));
-}
-
-/**
- * @brief
- */
-static void AddMapshots_enumerate(const char *path, void *data) {
-
-  if (g_str_has_suffix(path, ".jpg") ||
-    g_str_has_suffix(path, ".png") ||
-    g_str_has_suffix(path, ".tga")) {
-    Add(path);
-  }
-}
-
-/**
- * @brief
- */
-static void AddMapshots(void) {
-  Fs_Enumerate(va("mapshots/%s/*", map_base), AddMapshots_enumerate, NULL);
-}
-
-/**
- * @brief Loads the specified BSP file, resolves all resources referenced by it,
- * and generates a new zip archive for the project. This is a very inefficient
- * but straightforward implementation.
+ * @brief Reads the manifest file and generates a pk3 archive containing
+ * all referenced assets.
  */
 int32_t ZIP_Main(void) {
   char path[MAX_OS_PATH];
@@ -255,33 +39,25 @@ int32_t ZIP_Main(void) {
 
   const uint32_t start = (uint32_t) SDL_GetTicks();
 
-  paths = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, g_free);
+  // read the manifest
+  char mf_path[MAX_OS_PATH];
+  g_snprintf(mf_path, sizeof(mf_path), "maps/%s.mf", map_base);
 
-  LoadBSPFile(bsp_name, (1 << BSP_LUMP_MATERIALS) | (1 << BSP_LUMP_ENTITIES));
-
-  // add the materials
-  AddBspMaterials();
-
-  // add the sounds, models, sky, ..
-  AddEntities();
-
-  // add navigation, location, docs and mapshots
-  AddNavigation();
-  AddLocation();
-  AddDocumentation();
-  AddMapshots();
-
-  // and of course the bsp and map
-  if (!Add(va("maps/%s.bsp", map_base))) {
-    Com_Warn("Failed to add maps/%s.bsp\n", map_base);
+  GList *manifest = Cm_ReadManifest(mf_path);
+  if (!manifest) {
+    Com_Error(ERROR_FATAL, "Failed to load %s. Run -bsp first to generate the manifest.\n", mf_path);
   }
-  if (!Add(va("maps/%s.map", map_base))) {
-    Com_Warn("Failed to add maps/%s.map\n", map_base);
-  };
 
-  // sort the assets for output readability
-  GList *assets = g_hash_table_get_values(paths);
-  assets = g_list_sort(assets, (GCompareFunc) g_strcmp0);
+  // always include the bsp itself
+  GList *assets = NULL;
+  assets = g_list_append(assets, g_strdup(va("maps/%s.bsp", map_base)));
+
+  for (GList *e = manifest; e; e = e->next) {
+    const cm_manifest_entry_t *entry = (const cm_manifest_entry_t *) e->data;
+    assets = g_list_append(assets, g_strdup(entry->path));
+  }
+
+  Cm_FreeManifest(manifest);
 
   mz_zip_archive zip;
   memset(&zip, 0, sizeof(zip));
@@ -295,47 +71,51 @@ int32_t ZIP_Main(void) {
     GList *a = assets;
     while (a) {
       const char *filename = (char *) a->data;
-      if (g_strcmp0(filename, MISSING)) {
 
-        if (include_shared == false) {
-          const char *dir = Fs_RealDir(filename);
+      if (!Fs_Exists(filename)) {
+        Com_Warn("Missing %s\n", filename);
+        a = a->next;
+        continue;
+      }
 
-          if (GlobMatch("sky-*.pk3", dir, GLOB_CASE_INSENSITIVE) ||
-            GlobMatch("sounds-*.pk3", dir, GLOB_CASE_INSENSITIVE) ||
-            GlobMatch("textures-*.pk3", dir, GLOB_CASE_INSENSITIVE) ||
-            GlobMatch("*/common/*", filename, GLOB_CASE_INSENSITIVE) ||
+      if (include_shared == false) {
+        const char *dir = Fs_RealDir(filename);
 
-            // If the file comes from the official game data, and is not in a pk3,
-            // skip it. This allows us to rebuild our official maps easily, but without
-            // pulling in flares, envmaps, etc.
+        if (GlobMatch("sky-*.pk3", dir, GLOB_CASE_INSENSITIVE) ||
+          GlobMatch("sounds-*.pk3", dir, GLOB_CASE_INSENSITIVE) ||
+          GlobMatch("textures-*.pk3", dir, GLOB_CASE_INSENSITIVE) ||
+          GlobMatch("*/common/*", filename, GLOB_CASE_INSENSITIVE) ||
 
-            (g_str_has_prefix(dir, PKGDATADIR) && !g_str_has_suffix(dir, ".pk3"))) {
+          // If the file comes from the official game data, and is not in a pk3,
+          // skip it. This allows us to rebuild our official maps easily, but without
+          // pulling in flares, envmaps, etc.
+
+          (g_str_has_prefix(dir, PKGDATADIR) && !g_str_has_suffix(dir, ".pk3"))) {
 
             Com_Print("[S] %s (%s)\n", filename, dir);
             a = a->next;
             continue;
-          }
         }
-
-        void *buffer;
-        const int64_t len = Fs_Load(filename, &buffer);
-        if (len == -1) {
-          Com_Warn("Failed to read %s\n", filename);
-          a = a->next;
-          continue;
-        }
-
-        if (!mz_zip_writer_add_mem(&zip, filename, buffer, len, MZ_DEFAULT_COMPRESSION)) {
-          Com_Error(ERROR_FATAL, "Failed to add %s to %s: %s\n",
-                filename,
-                path,
-                mz_zip_get_error_string(mz_zip_get_last_error(&zip)));
-        }
-
-        Com_Print("[A] %s\n", filename);
-
-        Fs_Free(buffer);
       }
+
+      void *buffer;
+      const int64_t len = Fs_Load(filename, &buffer);
+      if (len == -1) {
+        Com_Warn("Failed to read %s\n", filename);
+        a = a->next;
+        continue;
+      }
+
+      if (!mz_zip_writer_add_mem(&zip, filename, buffer, len, MZ_DEFAULT_COMPRESSION)) {
+        Com_Error(ERROR_FATAL, "Failed to add %s to %s: %s\n",
+              filename,
+              path,
+              mz_zip_get_error_string(mz_zip_get_last_error(&zip)));
+      }
+
+      Com_Print("[A] %s\n", filename);
+
+      Fs_Free(buffer);
       a = a->next;
     }
 
@@ -350,8 +130,7 @@ int32_t ZIP_Main(void) {
           mz_zip_get_error_string(mz_zip_get_last_error(&zip)));
   }
 
-  g_list_free(assets);
-  g_hash_table_destroy(paths);
+  g_list_free_full(assets, g_free);
 
   const uint32_t end = (uint32_t) SDL_GetTicks();
   Com_Print("\nWrote %s in %d ms\n", path, end - start);

--- a/src/tools/quemap/qzip.c
+++ b/src/tools/quemap/qzip.c
@@ -48,9 +48,11 @@ int32_t ZIP_Main(void) {
     Com_Error(ERROR_FATAL, "Failed to load %s. Run -bsp first to generate the manifest.\n", mf_path);
   }
 
-  // always include the bsp itself
+  // the manifest includes the bsp and all referenced assets
   GList *assets = NULL;
-  assets = g_list_append(assets, g_strdup(va("maps/%s.bsp", map_base)));
+
+  // include the manifest itself so the pk3 is self-contained
+  assets = g_list_append(assets, g_strdup(mf_path));
 
   for (GList *e = manifest; e; e = e->next) {
     const cm_manifest_entry_t *entry = (const cm_manifest_entry_t *) e->data;


### PR DESCRIPTION
This PR introduces a `map/${map}.mf` manifest file to provide a simple but robust in-game download support. All materials, sounds, textures, models, .. anything referenced by the .bsp file is included in the manifest. The client parses the manifest and checks for not only local file existence, but also md5 checksum match (warning if mismatch is found). The client then requests in order any locally missing files.