### PR TITLE
Fix `BadMatch (invalid parameter attributes)` SDL error

### DIFF
--- a/src/client/renderer/r_context.c
+++ b/src/client/renderer/r_context.c
@@ -122,10 +122,6 @@ void R_InitContext(void) {
   }
 
   Com_Print("  Trying %dx%d..\n", w, h);
-
-  if ((r_context.window = SDL_CreateWindow(PACKAGE_STRING, w, h, window_flags)) == NULL) {
-    Com_Error(ERROR_FATAL, "Failed to set video mode: %s\n", SDL_GetError());
-  }
   
   R_SetWindowIcon();
 
@@ -142,6 +138,10 @@ void R_InitContext(void) {
   SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 4);
   SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 1);
   SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);
+
+  if ((r_context.window = SDL_CreateWindow(PACKAGE_STRING, w, h, window_flags)) == NULL) {
+    Com_Error(ERROR_FATAL, "Failed to set video mode: %s\n", SDL_GetError());
+  }
 
   SDL_GLContextFlag context_flags = SDL_GL_CONTEXT_FORWARD_COMPATIBLE_FLAG;
 


### PR DESCRIPTION
Nvidia's linux drivers seem to require all the attributes being set before creating the window or context creation will fail. This hasn't been tested with other platforms/drivers. It might not be the "proper" fix but it worked for me.

## Summary

<!-- Briefly describe what this PR does and why. -->

Fixes #<!-- issue number -->

## Changes

<!-- List the key changes in this PR. -->

- 

## Testing

<!-- Describe how you tested this change. -->

- [x] Builds without warnings (`make -j$(nproc)`)
- [x] Tests pass (`make check`)
- [x] Tested in-game on <!-- platform(s) -->

## Notes

<!-- Anything else reviewers should know? -->
