### PR TITLE
linux: replace AppImage with tarball packaging

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -254,13 +254,13 @@ jobs:
       working-directory: quetoo/linux
       run: |
         export PKG_CONFIG_PATH="/usr/local/lib/pkgconfig:${PKG_CONFIG_PATH}"
-        make appimage deb rpm
+        make archive deb rpm
 
-    - name: Upload AppImage artifact
+    - name: Upload archive artifact
       uses: actions/upload-artifact@v6
       with:
-        name: quetoo-x86_64-pc-linux-appimage
-        path: quetoo/linux/target/quetoo-x86_64-pc-linux.AppImage
+        name: quetoo-x86_64-pc-linux-archive
+        path: quetoo/linux/target/quetoo-x86_64-pc-linux.tar.gz
 
     - name: Upload .deb artifact
       uses: actions/upload-artifact@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,10 +149,8 @@ jobs:
         include:
           - runner: ubuntu-22.04
             build: x86_64-pc-linux
-            appimage: true
           - runner: ubuntu-22.04-arm
             build: aarch64-pc-linux
-            appimage: false
 
     runs-on: ${{ matrix.runner }}
 
@@ -263,18 +261,13 @@ jobs:
       working-directory: quetoo/linux
       run: |
         export PKG_CONFIG_PATH="/usr/local/lib/pkgconfig:${PKG_CONFIG_PATH}"
-        if [ "${{ matrix.appimage }}" = "true" ]; then
-          make appimage deb rpm VERSION=${GITHUB_REF_NAME#v}
-        else
-          make deb rpm VERSION=${GITHUB_REF_NAME#v}
-        fi
+        make archive deb rpm VERSION=${GITHUB_REF_NAME#v}
 
-    - name: Upload AppImage artifact
-      if: matrix.appimage
+    - name: Upload archive artifact
       uses: actions/upload-artifact@v6
       with:
-        name: quetoo-${{ matrix.build }}-appimage
-        path: quetoo/linux/target/quetoo-${{ matrix.build }}.AppImage
+        name: quetoo-${{ matrix.build }}-archive
+        path: quetoo/linux/target/quetoo-${{ matrix.build }}.tar.gz
 
     - name: Upload .deb artifact
       uses: actions/upload-artifact@v6
@@ -442,16 +435,18 @@ jobs:
         zip -r ../quetoo-bundle-arm64-apple-darwin.zip Quetoo.app
         cd ..
 
-        # Linux bundle: extract AppImage, inject data into usr/share/default/, repack
-        chmod +x quetoo-x86_64-pc-linux-appimage/quetoo-x86_64-pc-linux.AppImage
-        ./quetoo-x86_64-pc-linux-appimage/quetoo-x86_64-pc-linux.AppImage --appimage-extract
-        mkdir -p squashfs-root/usr/share/default
-        cp -r quetoo-data/target/default/. squashfs-root/usr/share/default/
-        curl -fsSL -o appimagetool \
-          https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage
-        chmod +x appimagetool
-        ARCH=x86_64 ./appimagetool --appimage-extract-and-run \
-          squashfs-root quetoo-bundle-x86_64-pc-linux.AppImage
+        # Linux bundle: extract archive, inject data into quetoo/share/quetoo/default/, repack
+        mkdir -p quetoo-bundle-linux-x86_64
+        tar xzf quetoo-x86_64-pc-linux-archive/quetoo-x86_64-pc-linux.tar.gz -C quetoo-bundle-linux-x86_64
+        mkdir -p quetoo-bundle-linux-x86_64/quetoo/share/quetoo/default
+        cp -r quetoo-data/target/default/. quetoo-bundle-linux-x86_64/quetoo/share/quetoo/default/
+        tar czf quetoo-bundle-x86_64-pc-linux.tar.gz -C quetoo-bundle-linux-x86_64 quetoo/
+
+        mkdir -p quetoo-bundle-linux-aarch64
+        tar xzf quetoo-aarch64-pc-linux-archive/quetoo-aarch64-pc-linux.tar.gz -C quetoo-bundle-linux-aarch64
+        mkdir -p quetoo-bundle-linux-aarch64/quetoo/share/quetoo/default
+        cp -r quetoo-data/target/default/. quetoo-bundle-linux-aarch64/quetoo/share/quetoo/default/
+        tar czf quetoo-bundle-aarch64-pc-linux.tar.gz -C quetoo-bundle-linux-aarch64 quetoo/
 
         # Windows bundle: data as share/default/ alongside bin/ and lib/
         mkdir bundle-windows && cd bundle-windows
@@ -475,28 +470,32 @@ jobs:
         | Platform | Download |
         |----------|----------|
         | macOS (Apple Silicon) | quetoo-bundle-arm64-apple-darwin.zip |
-        | Linux (x86_64 AppImage) | quetoo-bundle-x86_64-pc-linux.AppImage |
+        | Linux (x86_64 archive) | quetoo-bundle-x86_64-pc-linux.tar.gz |
+        | Linux (arm64 archive) | quetoo-bundle-aarch64-pc-linux.tar.gz |
         | Windows (x86_64) | quetoo-bundle-x86_64-pc-windows.zip |
 
         ### Binaries only (for updates)
         | Platform | Download |
         |----------|----------|
         | macOS (Apple Silicon) | quetoo-arm64-apple-darwin.zip |
-        | Linux (x86_64 AppImage) | quetoo-x86_64-pc-linux.AppImage |
+        | Linux (x86_64 archive) | quetoo-x86_64-pc-linux.tar.gz |
         | Linux (x86_64 .deb) | quetoo-x86_64-pc-linux.deb |
         | Linux (x86_64 .rpm) | quetoo-x86_64-pc-linux.rpm |
+        | Linux (arm64 archive) | quetoo-aarch64-pc-linux.tar.gz |
         | Linux (arm64 .deb) | quetoo-aarch64-pc-linux.deb |
         | Linux (arm64 .rpm) | quetoo-aarch64-pc-linux.rpm |
         | Windows (x86_64) | quetoo-x86_64-pc-windows.zip |
 
         For Linux package-managed installs, also install the matching [quetoo-data ${{ github.ref_name }}](https://github.com/jdolan/quetoo-data/releases/tag/${{ github.ref_name }}) release." \
           quetoo-bundle-arm64-apple-darwin.zip \
-          quetoo-bundle-x86_64-pc-linux.AppImage \
+          quetoo-bundle-x86_64-pc-linux.tar.gz \
+          quetoo-bundle-aarch64-pc-linux.tar.gz \
           quetoo-bundle-x86_64-pc-windows.zip \
           quetoo-arm64-apple-darwin/quetoo-arm64-apple-darwin.zip \
-          quetoo-x86_64-pc-linux-appimage/quetoo-x86_64-pc-linux.AppImage \
+          quetoo-x86_64-pc-linux-archive/quetoo-x86_64-pc-linux.tar.gz \
           quetoo-x86_64-pc-linux-deb/quetoo-x86_64-pc-linux.deb \
           quetoo-x86_64-pc-linux-rpm/quetoo-x86_64-pc-linux.rpm \
+          quetoo-aarch64-pc-linux-archive/quetoo-aarch64-pc-linux.tar.gz \
           quetoo-aarch64-pc-linux-deb/quetoo-aarch64-pc-linux.deb \
           quetoo-aarch64-pc-linux-rpm/quetoo-aarch64-pc-linux.rpm \
           quetoo-x86_64-pc-windows/quetoo-x86_64-pc-windows.zip

--- a/linux/AppRun
+++ b/linux/AppRun
@@ -1,3 +1,0 @@
-#!/bin/sh
-HERE="$(dirname "$(readlink -f "$0")")"
-exec "${HERE}/usr/bin/quetoo" "${@}"

--- a/linux/Makefile
+++ b/linux/Makefile
@@ -26,14 +26,13 @@ MODULES = \
 	$(STAGING)/lib/default/cgame.so \
 	$(STAGING)/lib/default/game.so
 
-APPIMAGE = $(TARGET)/quetoo-$(BUILD).AppImage
+ARCHIVE  = $(TARGET)/quetoo-$(BUILD).tar.gz
 DEB      = $(TARGET)/quetoo_$(VERSION)_$(DEB_ARCH).deb
 RPM      = $(TARGET)/quetoo-$(VERSION)-1.$(ARCH).rpm
 
 LINUXDEPLOY     = $(TARGET)/linuxdeploy-$(ARCH).AppImage
-APPIMAGETOOL    = $(TARGET)/appimagetool-$(ARCH).AppImage
 
-all: appimage deb rpm
+all: archive deb rpm
 
 configure:
 	cd .. && autoreconf -i && ./configure \
@@ -53,11 +52,6 @@ $(STAGING): compile
 $(LINUXDEPLOY):
 	curl -fsSL -o $@ \
 		https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-$(ARCH).AppImage
-	chmod +x $@
-
-$(APPIMAGETOOL):
-	curl -fsSL -o $@ \
-		https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-$(ARCH).AppImage
 	chmod +x $@
 
 # ---------------------------------------------------------------------------
@@ -80,18 +74,15 @@ $(APPDIR): $(STAGING) $(LINUXDEPLOY)
 		--desktop-file quetoo/Quetoo.desktop \
 		--icon-file $(APPDIR)/quetoo.png
 
-	# Install our custom AppRun.  Remove any symlink linuxdeploy created first,
-	# because cp(1) follows symlinks and would otherwise overwrite the binary it
-	# points to instead of replacing the symlink itself.
-	rm -f $(APPDIR)/AppRun
-	install -m755 AppRun $(APPDIR)/AppRun
+	# Install the icon at its XDG path so Sys_RegisterDesktopEntry can reference it.
+	install -Dm644 $(APPDIR)/quetoo.png \
+		$(APPDIR)/usr/share/icons/hicolor/256x256/apps/quetoo.png
 
 # ---------------------------------------------------------------------------
-# AppImage
+# Archive
 
-appimage: $(APPDIR) $(APPIMAGETOOL)
-	ARCH=$(ARCH) $(APPIMAGETOOL) --appimage-extract-and-run \
-		$(APPDIR) $(APPIMAGE)
+archive: $(APPDIR)
+	tar czf $(ARCHIVE) -C $(APPDIR) --transform 's|^usr|quetoo|' usr/
 
 # ---------------------------------------------------------------------------
 # .deb / .rpm — reuse the linuxdeploy-bundled AppDir content so we don't
@@ -189,9 +180,9 @@ release: all
 	aws s3 sync --delete $(STAGING) $(QUETOO_S3_BUCKET)/$(BUILD)
 	git rev-list --count HEAD > $(TARGET)/version
 	aws s3 cp $(TARGET)/version $(QUETOO_S3_BUCKET)/versions/$(BUILD)
-	aws s3 cp $(APPIMAGE) $(QUETOO_S3_BUCKET)/snapshots/
-	aws s3 cp $(DEB)      $(QUETOO_S3_BUCKET)/snapshots/
-	aws s3 cp $(RPM)      $(QUETOO_S3_BUCKET)/snapshots/
+	aws s3 cp $(ARCHIVE) $(QUETOO_S3_BUCKET)/snapshots/
+	aws s3 cp $(DEB)     $(QUETOO_S3_BUCKET)/snapshots/
+	aws s3 cp $(RPM)     $(QUETOO_S3_BUCKET)/snapshots/
 
 install-data:
 	aws s3 sync $(QUETOO_DATA_S3_BUCKET)/ $(STAGING)/share
@@ -199,4 +190,4 @@ install-data:
 clean:
 	rm -rf $(TARGET)
 
-.PHONY: all configure compile appimage deb rpm release install-data clean
+.PHONY: all configure compile archive deb rpm release install-data clean

--- a/src/common/filesystem.c
+++ b/src/common/filesystem.c
@@ -738,12 +738,7 @@ void Fs_Init(const uint32_t flags) {
       g_snprintf(fs_state.data_dir, MAX_OS_PATH, "%s/Contents/Resources", fs_state.base_dir);
     }
 #elif defined(__linux__)
-    const char *appdir = getenv("APPDIR");
-    if (appdir) {
-      g_snprintf(fs_state.bin_dir, MAX_OS_PATH, "%s/usr/bin", appdir);
-      g_snprintf(fs_state.lib_dir, MAX_OS_PATH, "%s/usr/lib/quetoo", appdir);
-      g_snprintf(fs_state.data_dir, MAX_OS_PATH, "%s/usr/share/quetoo", appdir);
-    } else if ((c = strstr(path, "/bin/"))) {
+    if ((c = strstr(path, "/bin/"))) {
       *c = '\0';
       g_strlcpy(fs_state.base_dir, path, sizeof(fs_state.base_dir));
 

--- a/src/common/sys.c
+++ b/src/common/sys.c
@@ -23,8 +23,13 @@
 #include "sys.h"
 #include "filesystem.h"
 
+#include <errno.h>
 #include <signal.h>
 #include <glib/gstdio.h>
+
+#if !defined(_WIN32)
+  #include <unistd.h>
+#endif
 
 #if defined(_WIN32)
   #include <windows.h>
@@ -177,6 +182,138 @@ void *Sys_LoadLibrary(void *handle, const char *entry_point, void *params) {
 
   return EntryPoint(params);
 }
+
+/**
+ * @brief On Linux archive installs, writes a .desktop file to
+ * ~/.local/share/applications/ so the game appears in the system launcher.
+ * No-op for system-managed installs (deb/rpm under /usr/).
+ */
+#if defined(__linux__)
+void Sys_InstallDesktopEntry(void) {
+
+  const char *exe = Sys_ExecutablePath();
+  if (!exe) {
+    return;
+  }
+
+  // Skip system-managed installs; the package manager owns desktop integration.
+  if (g_str_has_prefix(exe, "/usr/")) {
+    return;
+  }
+
+  // Derive install prefix by stripping /bin/<name>.
+  char prefix[MAX_OS_PATH];
+  g_strlcpy(prefix, exe, sizeof(prefix));
+  char *bin = strstr(prefix, "/bin/");
+  if (!bin) {
+    return;
+  }
+  *bin = '\0';
+
+  char icon_path[MAX_OS_PATH];
+  g_snprintf(icon_path, sizeof(icon_path),
+    "%s/share/icons/hicolor/256x256/apps/quetoo.png", prefix);
+
+  // Destination: ~/.local/share/applications/quetoo.desktop
+  char desktop_dest[MAX_OS_PATH];
+  g_snprintf(desktop_dest, sizeof(desktop_dest),
+    "%s/applications/quetoo.desktop", g_get_user_data_dir());
+
+  // Skip writing if Exec= already points at this binary (no change needed).
+  char expected_exec[MAX_OS_PATH];
+  g_snprintf(expected_exec, sizeof(expected_exec), "Exec=%s", exe);
+  if (g_file_test(desktop_dest, G_FILE_TEST_EXISTS)) {
+    gchar *contents = NULL;
+    if (g_file_get_contents(desktop_dest, &contents, NULL, NULL)) {
+      const bool up_to_date = strstr(contents, expected_exec) != NULL;
+      g_free(contents);
+      if (up_to_date) {
+        return;
+      }
+    }
+  }
+
+  gchar *dir = g_path_get_dirname(desktop_dest);
+  g_mkdir_with_parents(dir, 0755);
+  g_free(dir);
+
+  gchar *content = g_strdup_printf(
+    "[Desktop Entry]\n"
+    "Name=Quetoo\n"
+    "Comment=Free, open-source arena first-person shooter\n"
+    "Exec=%s %%U\n"
+    "Icon=%s\n"
+    "Terminal=false\n"
+    "Type=Application\n"
+    "Categories=Game;ActionGame;\n"
+    "StartupNotify=true\n",
+    exe, icon_path);
+
+  GError *error = NULL;
+  if (!g_file_set_contents(desktop_dest, content, -1, &error)) {
+    Com_Warn("Failed to install desktop entry: %s\n", error->message);
+    g_error_free(error);
+  }
+
+  g_free(content);
+}
+
+/**
+ * @brief On Linux archive installs, creates symlinks in ~/.local/bin pointing
+ * to the game's executables, making them available on the user's $PATH.
+ * No-op for system-managed installs (deb/rpm under /usr/).
+ */
+void Sys_InstallLocalBin(void) {
+
+  static const char *names[] = { "quetoo", "quemap", "quetoo-dedicated", NULL };
+
+  const char *exe = Sys_ExecutablePath();
+  if (!exe || g_str_has_prefix(exe, "/usr/")) {
+    return;
+  }
+
+  char prefix[MAX_OS_PATH];
+  g_strlcpy(prefix, exe, sizeof(prefix));
+  char *bin = strstr(prefix, "/bin/");
+  if (!bin) {
+    return;
+  }
+  *bin = '\0';
+
+  gchar *local_bin = g_build_filename(g_get_home_dir(), ".local", "bin", NULL);
+  g_mkdir_with_parents(local_bin, 0755);
+
+  for (const char * const *name = names; *name; name++) {
+    char src[MAX_OS_PATH];
+    g_snprintf(src, sizeof(src), "%s/bin/%s", prefix, *name);
+
+    if (!g_file_test(src, G_FILE_TEST_EXISTS)) {
+      continue;
+    }
+
+    gchar *dest = g_build_filename(local_bin, *name, NULL);
+
+    char current[MAX_OS_PATH] = { 0 };
+    const ssize_t len = readlink(dest, current, sizeof(current) - 1);
+    if (len > 0) {
+      current[len] = '\0';
+      if (g_strcmp0(current, src) == 0) {
+        g_free(dest);
+        continue;
+      }
+      g_unlink(dest);
+    }
+
+    if (symlink(src, dest) != 0) {
+      Com_Warn("Failed to install %s to %s: %s\n", src, dest, strerror(errno));
+    }
+
+    g_free(dest);
+  }
+
+  g_free(local_bin);
+}
+#endif
 
 /**
  * @brief On platforms supporting it, capture a backtrace. Returns

--- a/src/common/sys.h
+++ b/src/common/sys.h
@@ -33,6 +33,11 @@ void *Sys_OpenLibrary(const char *name, bool global);
 void *Sys_LoadLibrary(void *handle, const char *entry_point, void *params);
 void Sys_CloseLibrary(void *handle);
 
+#if defined(__linux__)
+void Sys_InstallDesktopEntry(void);
+void Sys_InstallLocalBin(void);
+#endif
+
 GString *Sys_Backtrace(uint32_t start, uint32_t max_count);
 void Sys_Raise(const char *msg);
 void Sys_Signal(int32_t s);

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -452,6 +452,11 @@ int32_t main(int32_t argc, char *argv[]) {
 
   Com_Init(argc, argv); // let's get it started in here
 
+#if defined(__linux__)
+  Sys_InstallDesktopEntry();
+  Sys_InstallLocalBin();
+#endif
+
   jmp_set = true;
 
   while (true) { // this is our main loop


### PR DESCRIPTION
Replaces the AppImage Linux distribution format with a plain `.tar.gz` archive.

## Motivation

AppImage uses a read-only squashfs mount (`$APPDIR`). Quetoo's in-game installer must write game data to `Fs_DataDir()`, which is irreconcilable with AppImage's immutability without significant workarounds. A tarball with a flat directory structure lets the installer update files in-place, identical to how Windows works.

## Changes

- **`linux/Makefile`** — replaced `appimage`/`appimagetool` targets with `archive`; packs `AppDir/usr/` as `quetoo/` via `tar --transform`
- **`linux/AppRun`** — deleted (AppImage-only)
- **`src/common/filesystem.c`** — removed `$APPDIR`/`$APPIMAGE` env-var detection; standard `/bin/` path stripping handles the tarball layout naturally
- **`src/common/sys.c`** — added `Sys_InstallDesktopEntry()` and `Sys_InstallLocalBin()` (Linux only): on first run, writes `~/.local/share/applications/quetoo.desktop` with correct absolute paths, and creates symlinks in `~/.local/bin` for `quetoo`, `quemap`, and `quetoo-dedicated`; both skip for system installs (`/usr/` prefix) and are no-ops when already up to date
- **`src/common/sys.h`** / **`src/main/main.c`** — declarations and call sites
- **`.github/workflows/build.yml`** — `make archive deb rpm`, artifact renamed
- **`.github/workflows/release.yml`** — archive bundle for both x86_64 and arm64; removed `appimage` matrix variable; updated release notes and asset list

## Archive layout

After extraction, the directory tree is:
```
quetoo/
  bin/quetoo
  bin/quemap
  bin/quetoo-dedicated
  lib/quetoo/default/game.so
  lib/quetoo/default/cgame.so
  share/quetoo/default/   ← installer writes here
  share/icons/hicolor/256x256/apps/quetoo.png
```

The engine's `/bin/` path detection sets `base_dir`, `lib_dir`, and `data_dir` correctly with no special-casing required. The `g_strcmp0` guard prevents the override from firing on system installs (`/usr/bin/`, `/usr/local/bin/`, etc.).

## Desktop integration

No CD-autorun equivalent exists on Linux. Instead, on first run the binary self-registers:
- `~/.local/share/applications/quetoo.desktop` — with absolute `Exec=` and `Icon=` paths
- `~/.local/bin/quetoo` etc. — symlinks into the install's `bin/`

Both are idempotent (skip if symlink/file already points to the correct path) and skipped entirely for deb/rpm installs where the package manager owns desktop integration.

Closes #762