### PR TITLE
macos: move Fs_DataDir outside the .app bundle

### DIFF
--- a/src/common/filesystem.c
+++ b/src/common/filesystem.c
@@ -523,7 +523,7 @@ void Fs_AddToSearchPath(const char *path) {
 }
 
 /**
- * @brief Variadic arguments version of Fs_AddToSearchPath.
+ * @brief Variadic arguments version of `Fs_AddToSearchPath`.
  */
 void Fs_AddToSearchPathv(const char *dir, ...) {
   char path[MAX_OS_PATH] = "";
@@ -546,7 +546,7 @@ void Fs_AddToSearchPathv(const char *dir, ...) {
 }
 
 /**
- * @brief Enumeration helper for Fs_AddToSearchPath. Adds all archive files for
+ * @brief Enumeration helper for `Fs_AddToSearchPath`. Adds all archive files for
  * the newly added filesystem mount point.
  */
 static void Fs_AddToSearchPath_enumerate(const char *path, void *data) {
@@ -733,9 +733,26 @@ void Fs_Init(const uint32_t flags) {
           "Please move Quetoo.app to your Applications folder and try again.\n");
       }
 
+      /*
+       * The macOS paths for game data are a little funky. The .app bundle ships with a copy of
+       * `quetoo-data` so that users don't have to sit through a lengthy download the first time
+       * they launch the game. But this copy is immutable, signed, and must never be updated by the
+       * in-game installer, or Gatekeeper would hassle the user when they relaunch the game.
+       *
+       * So, we set `data_dir` to `Sys_UserDir()/share`. This writes updated official game content to
+       * the user's home, without conflating it with true user-owned data like screenshots, configs,
+       * custom maps etc. Then, we append `Contents/Resources` to the search path, allowing the
+       * game to fall back on the read-only copy of quetoo-data that it originally came with.
+       */
+
       g_snprintf(fs_state.bin_dir, MAX_OS_PATH, "%s/Contents/MacOS", fs_state.base_dir);
       g_snprintf(fs_state.lib_dir, MAX_OS_PATH, "%s/Contents/MacOS/lib/quetoo", fs_state.base_dir);
-      g_snprintf(fs_state.data_dir, MAX_OS_PATH, "%s/Contents/Resources", fs_state.base_dir);
+      g_snprintf(fs_state.data_dir, MAX_OS_PATH, "%s/share", Sys_UserDir());
+
+      char resources[MAX_OS_PATH];
+      g_snprintf(resources, MAX_OS_PATH, "%s/Contents/Resources", fs_state.base_dir);
+      Fs_AddToSearchPathv(resources, NULL);
+      Fs_AddToSearchPathv(resources, DEFAULT_GAME, NULL);
     }
 #elif defined(__linux__)
     if ((c = strstr(path, "/bin/"))) {

--- a/src/common/sys.c
+++ b/src/common/sys.c
@@ -104,8 +104,8 @@ const char *Sys_Username(void) {
  * @details Uses `SDL_GetPrefPath`, which yields a platform-conventional
  * per-user, per-app directory:
  *   - Windows: `%APPDATA%\WickedOldGames\Quetoo`
- *   - macOS:   `~/Library/Application Support/Quetoo`
- *   - Linux:   `$XDG_DATA_HOME/Quetoo` (or `~/.local/share/Quetoo`)
+ *   - macOS:   `~/Library/Application Support/WickedOldGames/Quetoo`
+ *   - Linux:   `$XDG_DATA_HOME/WickedOldGames/Quetoo` (or `~/.local/share/WickedOldGames/Quetoo`)
  */
 const char *Sys_UserDir(void) {
   static char user_dir[MAX_OS_PATH];


### PR DESCRIPTION
## Problem

On macOS, `Fs_DataDir()` currently points to `Quetoo.app/Contents/Resources/`. This means:

1. **Drag-replacing** `Quetoo.app` in Finder (the standard macOS upgrade UX) **wipes all downloaded game data** — the installer writes into the bundle, which gets replaced entirely.
2. The bundle **cannot be code-signed or notarized** while the installer is writing into it, since any modification after signing invalidates the signature.

## Solution

Move `Fs_DataDir()` to `~/Library/Application Support/WickedOldGames/Quetoo/share/`, outside the bundle entirely.

- The bundle becomes **immutable** — it contains only binaries and libraries, never game data.
- Drag-replacing the `.app` is safe; downloaded data survives in Application Support.
- The path is now signable and notarizable.

## Bundle seed layer

To preserve the "immediately playable" property of fat `.app` bundles (which ship with game data pre-populated in `Contents/Resources/`), the bundle's `Contents/Resources/` directory is mounted as a **read-only seed layer at the lowest PhysFS search path priority**.

Once the installer downloads files to `data_dir`, those files shadow the bundle seed automatically. No installer code changes required.

**PhysFS priority order (highest → lowest):**
```
~/...Quetoo/default          ← Fs_WriteDir: user configs, screenshots
~/...Quetoo/share/default    ← Fs_DataDir: installer-managed official data
.app/Contents/MacOS/lib/...  ← game modules
~/...Quetoo/share            ← installer data root
.app/Contents/Resources/...  ← bundle seed (read-only, lowest priority)
```

## Changes

- `src/common/filesystem.c`: macOS `data_dir` → `Sys_UserDir()/share`; add bundle seed mount block before standard search paths

No changes needed to the installer, CI packaging, or the fat `.app` assembly step (which already puts data into `Contents/Resources/default/`).
