### PR TITLE
ci: build universal macOS binary (arm64 + x86_64)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - runner: macos-14
+          - runner: macos-15
             arch: arm64
             build: arm64-apple-darwin
           - runner: macos-15-large
@@ -148,7 +148,7 @@ jobs:
 
   lipo-macos:
     needs: build-macos
-    runs-on: macos-14
+    runs-on: macos-15
 
     steps:
     - name: Download arm64 artifact

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,9 @@ jobs:
           - runner: macos-14
             arch: arm64
             build: arm64-apple-darwin
+          - runner: macos-13
+            arch: x86_64
+            build: x86_64-apple-darwin
 
     runs-on: ${{ matrix.runner }}
 
@@ -142,6 +145,45 @@ jobs:
       with:
         name: quetoo-${{ matrix.build }}
         path: quetoo/quetoo-${{ matrix.build }}.zip
+
+  lipo-macos:
+    needs: build-macos
+    runs-on: macos-14
+
+    steps:
+    - name: Download arm64 artifact
+      uses: actions/download-artifact@v6
+      with:
+        name: quetoo-arm64-apple-darwin
+
+    - name: Download x86_64 artifact
+      uses: actions/download-artifact@v6
+      with:
+        name: quetoo-x86_64-apple-darwin
+
+    - name: Create universal binary
+      run: |
+        mkdir arm64 x86_64
+        unzip quetoo-arm64-apple-darwin.zip -d arm64
+        unzip quetoo-x86_64-apple-darwin.zip -d x86_64
+
+        find arm64/Quetoo.app -type f | while read f; do
+          if ! file "$f" | grep -q "Mach-O"; then
+            continue
+          fi
+          x86="x86_64/${f#arm64/}"
+          if [ -f "$x86" ]; then
+            lipo -create "$f" "$x86" -output "$f"
+          fi
+        done
+
+        cd arm64 && zip -r ../quetoo-universal-apple-darwin.zip Quetoo.app
+
+    - name: Upload universal artifact
+      uses: actions/upload-artifact@v6
+      with:
+        name: quetoo-universal-apple-darwin
+        path: quetoo-universal-apple-darwin.zip
 
   build-linux:
     needs: resolve-deps
@@ -389,7 +431,7 @@ jobs:
         path: quetoo/quetoo-x86_64-pc-windows.zip
 
   release:
-    needs: [build-macos, build-linux, build-windows]
+    needs: [lipo-macos, build-linux, build-windows]
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
 
@@ -427,11 +469,11 @@ jobs:
 
         | Platform | Download |
         |----------|----------|
-        | macOS (Apple Silicon) | quetoo-arm64-apple-darwin.zip |
+        | macOS (Universal) | quetoo-universal-apple-darwin.zip |
         | Linux (x86_64) | quetoo-x86_64-pc-linux.tar.gz |
         | Windows (x86_64) | quetoo-x86_64-pc-windows.zip |" \
           --prerelease \
-          quetoo-arm64-apple-darwin/quetoo-arm64-apple-darwin.zip \
+          quetoo-universal-apple-darwin/quetoo-universal-apple-darwin.zip \
           quetoo-x86_64-pc-linux-archive/quetoo-x86_64-pc-linux.tar.gz \
           quetoo-x86_64-pc-windows/quetoo-x86_64-pc-windows.zip
       env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
           - runner: macos-14
             arch: arm64
             build: arm64-apple-darwin
-          - runner: macos-13
+          - runner: macos-15-large
             arch: x86_64
             build: x86_64-apple-darwin
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - runner: macos-14
+          - runner: macos-15
             arch: arm64
             build: arm64-apple-darwin
           - runner: macos-15-large
@@ -146,7 +146,7 @@ jobs:
 
   lipo-macos:
     needs: build-macos
-    runs-on: macos-14
+    runs-on: macos-15
 
     steps:
     - name: Download arm64 artifact

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,9 @@ jobs:
           - runner: macos-14
             arch: arm64
             build: arm64-apple-darwin
+          - runner: macos-13
+            arch: x86_64
+            build: x86_64-apple-darwin
 
     runs-on: ${{ matrix.runner }}
 
@@ -140,6 +143,45 @@ jobs:
       with:
         name: quetoo-${{ matrix.build }}
         path: quetoo/quetoo-${{ matrix.build }}.zip
+
+  lipo-macos:
+    needs: build-macos
+    runs-on: macos-14
+
+    steps:
+    - name: Download arm64 artifact
+      uses: actions/download-artifact@v6
+      with:
+        name: quetoo-arm64-apple-darwin
+
+    - name: Download x86_64 artifact
+      uses: actions/download-artifact@v6
+      with:
+        name: quetoo-x86_64-apple-darwin
+
+    - name: Create universal binary
+      run: |
+        mkdir arm64 x86_64
+        unzip quetoo-arm64-apple-darwin.zip -d arm64
+        unzip quetoo-x86_64-apple-darwin.zip -d x86_64
+
+        find arm64/Quetoo.app -type f | while read f; do
+          if ! file "$f" | grep -q "Mach-O"; then
+            continue
+          fi
+          x86="x86_64/${f#arm64/}"
+          if [ -f "$x86" ]; then
+            lipo -create "$f" "$x86" -output "$f"
+          fi
+        done
+
+        cd arm64 && zip -r ../quetoo-universal-apple-darwin.zip Quetoo.app
+
+    - name: Upload universal artifact
+      uses: actions/upload-artifact@v6
+      with:
+        name: quetoo-universal-apple-darwin
+        path: quetoo-universal-apple-darwin.zip
 
   build-linux:
     needs: resolve-deps
@@ -396,7 +438,7 @@ jobs:
         path: quetoo/quetoo-x86_64-pc-windows.zip
 
   release:
-    needs: [build-macos, build-linux, build-windows]
+    needs: [lipo-macos, build-linux, build-windows]
     runs-on: ubuntu-latest
 
     steps:
@@ -429,10 +471,10 @@ jobs:
       run: |
         # macOS bundle: data into Quetoo.app/Contents/Resources/default/
         mkdir bundle-macos && cd bundle-macos
-        unzip ../quetoo-arm64-apple-darwin/quetoo-arm64-apple-darwin.zip
+        unzip ../quetoo-universal-apple-darwin/quetoo-universal-apple-darwin.zip
         mkdir -p Quetoo.app/Contents/Resources/default
         cp -r ../quetoo-data/target/default/. Quetoo.app/Contents/Resources/default/
-        zip -r ../quetoo-bundle-arm64-apple-darwin.zip Quetoo.app
+        zip -r ../quetoo-bundle-universal-apple-darwin.zip Quetoo.app
         cd ..
 
         # Linux bundle: extract archive, inject data into quetoo/share/quetoo/default/, repack
@@ -469,7 +511,7 @@ jobs:
         ### Bundles (binaries + game data, ready to play)
         | Platform | Download |
         |----------|----------|
-        | macOS (Apple Silicon) | quetoo-bundle-arm64-apple-darwin.zip |
+        | macOS (Universal) | quetoo-bundle-universal-apple-darwin.zip |
         | Linux (x86_64 archive) | quetoo-bundle-x86_64-pc-linux.tar.gz |
         | Linux (arm64 archive) | quetoo-bundle-aarch64-pc-linux.tar.gz |
         | Windows (x86_64) | quetoo-bundle-x86_64-pc-windows.zip |
@@ -477,7 +519,7 @@ jobs:
         ### Binaries only (for updates)
         | Platform | Download |
         |----------|----------|
-        | macOS (Apple Silicon) | quetoo-arm64-apple-darwin.zip |
+        | macOS (Universal) | quetoo-universal-apple-darwin.zip |
         | Linux (x86_64 archive) | quetoo-x86_64-pc-linux.tar.gz |
         | Linux (x86_64 .deb) | quetoo-x86_64-pc-linux.deb |
         | Linux (x86_64 .rpm) | quetoo-x86_64-pc-linux.rpm |
@@ -487,11 +529,11 @@ jobs:
         | Windows (x86_64) | quetoo-x86_64-pc-windows.zip |
 
         For Linux package-managed installs, also install the matching [quetoo-data ${{ github.ref_name }}](https://github.com/jdolan/quetoo-data/releases/tag/${{ github.ref_name }}) release." \
-          quetoo-bundle-arm64-apple-darwin.zip \
+          quetoo-bundle-universal-apple-darwin.zip \
           quetoo-bundle-x86_64-pc-linux.tar.gz \
           quetoo-bundle-aarch64-pc-linux.tar.gz \
           quetoo-bundle-x86_64-pc-windows.zip \
-          quetoo-arm64-apple-darwin/quetoo-arm64-apple-darwin.zip \
+          quetoo-universal-apple-darwin/quetoo-universal-apple-darwin.zip \
           quetoo-x86_64-pc-linux-archive/quetoo-x86_64-pc-linux.tar.gz \
           quetoo-x86_64-pc-linux-deb/quetoo-x86_64-pc-linux.deb \
           quetoo-x86_64-pc-linux-rpm/quetoo-x86_64-pc-linux.rpm \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
           - runner: macos-14
             arch: arm64
             build: arm64-apple-darwin
-          - runner: macos-13
+          - runner: macos-15-large
             arch: x86_64
             build: x86_64-apple-darwin
 


### PR DESCRIPTION
Adds x86_64 (Intel) to the macOS CI matrix and introduces a `lipo-macos` job that merges both arch builds into a single universal `.app`.

## What changes

- **`build-macos` matrix**: adds `macos-13` / `x86_64-apple-darwin` alongside the existing `macos-14` / arm64 job. The `HOMEBREW_PREFIX` conditional already handled this.
- **New `lipo-macos` job**: downloads both arch artifacts, walks every file in the `.app`, detects Mach-O binaries with `file`, and `lipo -create`s them into fat binaries. Produces `quetoo-universal-apple-darwin.zip`.
- **`release` job**: now depends on `lipo-macos` instead of `build-macos`, and uses the universal artifact.
- **Snapshot + versioned release notes**: updated to say "macOS (Universal)".

Both `build.yml` (snapshot) and `release.yml` (versioned releases) are updated identically.

## Result

One `.app` that runs natively on Apple Silicon and Intel Macs. Users don't have to know which they have.