### PR TITLE
Add per-match frag stats submission (quetoo-stats)

### DIFF
--- a/Quetoo.xcodeproj/xcshareddata/xcschemes/quetoo-all.xcscheme
+++ b/Quetoo.xcodeproj/xcshareddata/xcschemes/quetoo-all.xcscheme
@@ -148,7 +148,7 @@
             isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
-            argument = "+map edge"
+            argument = "+map darkzone"
             isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument

--- a/src/client/cl_main.c
+++ b/src/client/cl_main.c
@@ -36,6 +36,7 @@ cvar_t *cl_no_lerp;
 cvar_t *cl_team_chat_sound;
 cvar_t *cl_timeout;
 
+cvar_t *guid;
 cvar_t *name;
 cvar_t *active;
 cvar_t *message_level;
@@ -528,18 +529,18 @@ static void Cl_InitLocal(void) {
 
   // user info
 
+  guid = Cvar_Add("guid", "", CVAR_USER_INFO | CVAR_ARCHIVE | CVAR_NO_SET, NULL);
+  if (strlen(guid->string) == 0) {
+    char *uuid = g_uuid_string_random();
+    Cvar_ForceSetString("guid", uuid);
+    g_free(uuid);
+  }
+
   name = Cvar_Add("name", Cl_Username(), CVAR_USER_INFO | CVAR_ARCHIVE, "Your player name");
   active = Cvar_Add("active", "0", CVAR_USER_INFO | CVAR_NO_SET, NULL);
   message_level = Cvar_Add("message_level", "0", CVAR_USER_INFO | CVAR_ARCHIVE, "The lowest message level you'll receive");
   password = Cvar_Add("password", "", CVAR_USER_INFO, "Password to the server you want to connect to");
   rate = Cvar_Add("rate", "0", CVAR_USER_INFO | CVAR_ARCHIVE, "Your bandwidth throttle, or 0 for none");
-
-  cvar_t *cl_guid = Cvar_Add("guid", "", CVAR_USER_INFO | CVAR_ARCHIVE | CVAR_NO_SET, "Per-install anonymous stats identifier");
-  if (!cl_guid->string[0]) {
-    char *uuid = g_uuid_string_random();
-    Cvar_ForceSetString("guid", uuid);
-    g_free(uuid);
-  }
 
   qport = Cvar_Add("qport", va("%u", Randomu() & 0xff), 0, NULL);
 

--- a/src/client/cl_main.c
+++ b/src/client/cl_main.c
@@ -534,6 +534,13 @@ static void Cl_InitLocal(void) {
   password = Cvar_Add("password", "", CVAR_USER_INFO, "Password to the server you want to connect to");
   rate = Cvar_Add("rate", "0", CVAR_USER_INFO | CVAR_ARCHIVE, "Your bandwidth throttle, or 0 for none");
 
+  cvar_t *cl_guid = Cvar_Add("guid", "", CVAR_USER_INFO | CVAR_ARCHIVE | CVAR_NO_SET, "Per-install anonymous stats identifier");
+  if (!cl_guid->string[0]) {
+    char *uuid = g_uuid_string_random();
+    Cvar_ForceSetString("guid", uuid);
+    g_free(uuid);
+  }
+
   qport = Cvar_Add("qport", va("%u", Randomu() & 0xff), 0, NULL);
 
   cl_draw_net_messages = Cvar_Add("cl_draw_net_messages", "0", CVAR_DEVELOPER, NULL);

--- a/src/client/cl_main.h
+++ b/src/client/cl_main.h
@@ -33,6 +33,7 @@ extern cvar_t *cl_no_lerp;
 extern cvar_t *cl_team_chat_sound;
 extern cvar_t *cl_timeout;
 
+extern cvar_t *guid;
 extern cvar_t *name;
 extern cvar_t *active;
 extern cvar_t *message_level;

--- a/src/game/default/g_ai_info.c
+++ b/src/game/default/g_ai_info.c
@@ -28,19 +28,19 @@ static cvar_t *g_ai_name_prefix;
  * Each entry defines a unique bot with its own name, appearance, and personality.
  */
 static const g_ai_roster_t g_ai_roster[] = {
-  // name          skin                skill  aggr   aware
-  { "Stroggo",    "qforcer/default",   .50f,  .50f,  .50f },
-  { "Enforcer",   "guard/default",     .65f,  .60f,  .55f },
-  { "Berserker",  "gork/default",      .40f,  .85f,  .30f },
-  { "Gunner",     "guard/mgss",        .70f,  .45f,  .70f },
-  { "Gladiator",  "dragoon/default",   .55f,  .70f,  .45f },
-  { "Makron",     "dragoon/baron",     .85f,  .55f,  .80f },
-  { "Brain",      "gork/ctf",          .75f,  .25f,  .90f },
-  { "Widow",      "bunker/default",    .60f,  .40f,  .65f },
-  { "Tank",       "bunker/hax",        .35f,  .80f,  .35f },
-  { "Medic",      "guard/sggrd",       .45f,  .30f,  .75f },
-  { "Parasite",   "dragoon/bastard",   .80f,  .75f,  .60f },
-  { "Flyer",      "bunker/fidget",     .55f,  .65f,  .40f },
+  // name          skin                guid                                    skill  aggr   aware
+  { "Stroggo",    "qforcer/default",   "ccbb7ca1-03af-448d-b0ab-b9a496472d86", .50f,  .50f,  .50f },
+  { "Enforcer",   "guard/default",     "19d4d35d-e19c-43b7-9bbf-cd3ecbbf88d4", .65f,  .60f,  .55f },
+  { "Berserker",  "gork/default",      "9fa691aa-dc2d-49b4-a4b4-0c0fad4d755b", .40f,  .85f,  .30f },
+  { "Gunner",     "guard/mgss",        "42a7c448-4c4a-434a-9274-69f700b2f8b6", .70f,  .45f,  .70f },
+  { "Gladiator",  "dragoon/default",   "c4ad0a99-5251-42fc-bc63-2f705ce6f363", .55f,  .70f,  .45f },
+  { "Makron",     "dragoon/baron",     "1ba330d3-6ee3-473c-9d18-bd21d29ec262", .85f,  .55f,  .80f },
+  { "Brain",      "gork/ctf",          "82229474-3efc-4872-bd05-a5a997f9a3e6", .75f,  .25f,  .90f },
+  { "Widow",      "bunker/default",    "c83474c1-422c-44cd-a93b-918390435187", .60f,  .40f,  .65f },
+  { "Tank",       "bunker/hax",        "a66cc25d-e234-4f8d-98b5-7cc4d34ea067", .35f,  .80f,  .35f },
+  { "Medic",      "guard/sggrd",       "80baa7ff-2ea6-4d8e-b111-caaaf2147e8b", .45f,  .30f,  .75f },
+  { "Parasite",   "dragoon/bastard",   "cbb2fb55-72fc-4242-aa5b-ff9d5f056883", .80f,  .75f,  .60f },
+  { "Flyer",      "bunker/fidget",     "cbbe6216-801e-4c53-84bc-f2de6fcc3e1c", .55f,  .65f,  .40f },
 };
 
 static const uint32_t g_ai_roster_count = lengthof(g_ai_roster);
@@ -61,6 +61,7 @@ const g_ai_roster_t *G_Ai_GetUserInfo(const g_client_t *cl, char *info) {
   g_strlcpy(info, DEFAULT_BOT_INFO, MAX_INFO_STRING_STRING);
 
   InfoString_Set(info, "skin", entry->skin);
+  InfoString_Set(info, "guid", entry->guid);
   InfoString_Set(info, "color", va("%u", RandomRangeu(0, 360)));
   InfoString_Set(info, "hand", va("%u", RandomRangeu(0, 3)));
   InfoString_Set(info, "head", va("%02x%02x%02x", RandomRangeu(0, 256), RandomRangeu(0, 256), RandomRangeu(0, 256)));

--- a/src/game/default/g_ai_types.h
+++ b/src/game/default/g_ai_types.h
@@ -231,6 +231,11 @@ typedef struct {
   const char *skin;
 
   /**
+   * @brief Stable per-bot UUID for stats tracking.
+   */
+  const char *guid;
+
+  /**
    * @brief 0.0 (easy) to 1.0 (hard): aim, turn speed, reaction time.
    */
   float skill;

--- a/src/game/default/g_client.c
+++ b/src/game/default/g_client.c
@@ -1437,6 +1437,9 @@ void G_ClientUserInfoChanged(g_client_t *cl, const char *user_info) {
 
   // hook style
   G_SetClientHookStyle(cl);
+
+  // stats guid
+  g_strlcpy(cl->persistent.guid, InfoString_Get(user_info, "guid"), sizeof(cl->persistent.guid));
 }
 
 /**

--- a/src/game/default/g_combat.c
+++ b/src/game/default/g_combat.c
@@ -441,9 +441,6 @@ void G_Damage(const g_damage_t *dmg) {
         const bool target_ai = target->client->ai != NULL;
 
         if (!attacker_ai || !target_ai) { // drop ai-on-ai frags
-          if (!g_level.frags) {
-            g_level.frags = g_array_new(false, false, sizeof(g_frag_t));
-          }
           g_frag_t frag = {
             .mod = (int32_t) mod,
             .damage = damage_health,
@@ -457,7 +454,13 @@ void G_Damage(const g_damage_t *dmg) {
           g_strlcpy(frag.target, target->client->persistent.net_name, sizeof(frag.target));
           g_strlcpy(frag.target_guid, target->client->persistent.guid, sizeof(frag.target_guid));
           g_strlcpy(frag.weapon, G_WeaponNameForMod(mod), sizeof(frag.weapon));
-          g_array_append_val(g_level.frags, frag);
+
+          if (frag.attacker_guid[0] && frag.target_guid[0]) {
+            if (!g_level.frags) {
+              g_level.frags = g_array_new(false, false, sizeof(g_frag_t));
+            }
+            g_array_append_val(g_level.frags, frag);
+          }
         }
       }
 

--- a/src/game/default/g_combat.c
+++ b/src/game/default/g_combat.c
@@ -84,9 +84,9 @@ static const char *G_WeaponNameForMod(g_means_of_death mod) {
     case MOD_QUAKE_SUPER_SHOTGUN:
       return "Quake Super Shotgun";
     case MOD_QUAKE_NAILGUN:
-      return "Nailgun";
+      return "Quake Nailgun";
     case MOD_QUAKE_SUPER_NAILGUN:
-      return "Super Nailgun";
+      return "Quake Super Nailgun";
     case MOD_QUAKE_GRENADE:
     case MOD_QUAKE_GRENADE_SPLASH:
       return "Quake Grenade Launcher";

--- a/src/game/default/g_combat.c
+++ b/src/game/default/g_combat.c
@@ -436,7 +436,7 @@ void G_Damage(const g_damage_t *dmg) {
     if (target->health <= 0 && !G_Ai_InDeveloperMode()) {
       target->dead = true;
 
-      if (attacker->client && target->client && attacker != target) {
+      if (attacker->client && target->client) {
         const bool attacker_ai = attacker->client->ai != NULL;
         const bool target_ai = target->client->ai != NULL;
 

--- a/src/game/default/g_combat.c
+++ b/src/game/default/g_combat.c
@@ -44,9 +44,72 @@ bool G_OnSameTeam(const g_client_t *a, const g_client_t *b) {
 }
 
 /**
- * @brief Returns true if the inflictor can directly damage the target. Used for
- * explosions and melee attacks.
+ * @brief Returns a human-readable weapon name for a means of death, for stats recording.
  */
+static const char *G_WeaponNameForMod(g_means_of_death mod) {
+
+  switch (mod & ~MOD_FRIENDLY_FIRE) {
+    case MOD_BLASTER:
+      return "Blaster";
+    case MOD_SHOTGUN:
+      return "Shotgun";
+    case MOD_SUPER_SHOTGUN:
+      return "Super Shotgun";
+    case MOD_MACHINEGUN:
+      return "Machinegun";
+    case MOD_GRENADE:
+    case MOD_GRENADE_SPLASH:
+      return "Grenade Launcher";
+    case MOD_HANDGRENADE:
+    case MOD_HANDGRENADE_SPLASH:
+    case MOD_HANDGRENADE_KAMIKAZE:
+    case MOD_HANDGRENADE_SUICIDE:
+      return "Hand Grenade";
+    case MOD_ROCKET:
+    case MOD_ROCKET_SPLASH:
+      return "Rocket Launcher";
+    case MOD_HYPERBLASTER:
+    case MOD_HYPERBLASTER_CLIMB:
+      return "Hyperblaster";
+    case MOD_LIGHTNING:
+    case MOD_LIGHTNING_DISCHARGE:
+      return "Lightning";
+    case MOD_RAILGUN:
+      return "Railgun";
+    case MOD_BFG_LASER:
+    case MOD_BFG_BLAST:
+      return "BFG10K";
+    case MOD_QUAKE_SHOTGUN:
+      return "Quake Shotgun";
+    case MOD_QUAKE_SUPER_SHOTGUN:
+      return "Quake Super Shotgun";
+    case MOD_QUAKE_NAILGUN:
+      return "Nailgun";
+    case MOD_QUAKE_SUPER_NAILGUN:
+      return "Super Nailgun";
+    case MOD_QUAKE_GRENADE:
+    case MOD_QUAKE_GRENADE_SPLASH:
+      return "Quake Grenade Launcher";
+    case MOD_QUAKE_ROCKET:
+    case MOD_QUAKE_ROCKET_SPLASH:
+      return "Quake Rocket Launcher";
+    case MOD_QUAKE_THUNDERBOLT:
+    case MOD_QUAKE_THUNDERBOLT_DISCHARGE:
+      return "Thunderbolt";
+    case MOD_FIREBALL:
+      return "Fireball";
+    case MOD_HOOK:
+      return "Hook";
+    case MOD_TELEFRAG:
+      return "Telefrag";
+    case MOD_EXPLOSIVE:
+      return "Explosive";
+    default:
+      return "Unknown";
+  }
+}
+
+
 bool G_CanDamage(const g_entity_t *targ, const g_entity_t *inflictor) {
   vec3_t dest;
   cm_trace_t tr;
@@ -393,7 +456,7 @@ void G_Damage(const g_damage_t *dmg) {
           g_strlcpy(frag.attacker_guid, attacker->client->persistent.guid, sizeof(frag.attacker_guid));
           g_strlcpy(frag.target, target->client->persistent.net_name, sizeof(frag.target));
           g_strlcpy(frag.target_guid, target->client->persistent.guid, sizeof(frag.target_guid));
-          g_strlcpy(frag.weapon, inflictor->classname ?: "unknown", sizeof(frag.weapon));
+          g_strlcpy(frag.weapon, G_WeaponNameForMod(mod), sizeof(frag.weapon));
           g_array_append_val(g_level.frag_events, frag);
         }
       }

--- a/src/game/default/g_combat.c
+++ b/src/game/default/g_combat.c
@@ -441,8 +441,8 @@ void G_Damage(const g_damage_t *dmg) {
         const bool target_ai = target->client->ai != NULL;
 
         if (!attacker_ai || !target_ai) { // drop ai-on-ai frags
-          if (!g_level.frag_events) {
-            g_level.frag_events = g_array_new(false, false, sizeof(g_frag_t));
+          if (!g_level.frags) {
+            g_level.frags = g_array_new(false, false, sizeof(g_frag_t));
           }
           g_frag_t frag = {
             .mod = (int32_t) mod,
@@ -457,7 +457,7 @@ void G_Damage(const g_damage_t *dmg) {
           g_strlcpy(frag.target, target->client->persistent.net_name, sizeof(frag.target));
           g_strlcpy(frag.target_guid, target->client->persistent.guid, sizeof(frag.target_guid));
           g_strlcpy(frag.weapon, G_WeaponNameForMod(mod), sizeof(frag.weapon));
-          g_array_append_val(g_level.frag_events, frag);
+          g_array_append_val(g_level.frags, frag);
         }
       }
 

--- a/src/game/default/g_combat.c
+++ b/src/game/default/g_combat.c
@@ -373,15 +373,15 @@ void G_Damage(const g_damage_t *dmg) {
     if (target->health <= 0 && !G_Ai_InDeveloperMode()) {
       target->dead = true;
 
-      if (attacker->client && target->client && attacker != target && g_stats_url->string[0]) {
+      if (attacker->client && target->client && attacker != target) {
         const bool attacker_ai = attacker->client->ai != NULL;
         const bool target_ai = target->client->ai != NULL;
 
         if (!attacker_ai || !target_ai) { // drop ai-on-ai frags
           if (!g_level.frag_events) {
-            g_level.frag_events = g_array_new(false, false, sizeof(g_frag_event_t));
+            g_level.frag_events = g_array_new(false, false, sizeof(g_frag_t));
           }
-          g_frag_event_t frag = {
+          g_frag_t frag = {
             .mod = (int32_t) mod,
             .damage = damage_health,
             .time = (uint32_t) time(NULL),

--- a/src/game/default/g_combat.c
+++ b/src/game/default/g_combat.c
@@ -21,6 +21,7 @@
 
 #include "g_local.h"
 #include "bg_pmove.h"
+#include <time.h>
 
 /**
  * @brief Returns true if ent1 and ent2 are on the same team.
@@ -371,6 +372,31 @@ void G_Damage(const g_damage_t *dmg) {
     // kill target if he has *excessive blood loss*
     if (target->health <= 0 && !G_Ai_InDeveloperMode()) {
       target->dead = true;
+
+      if (attacker->client && target->client && attacker != target && g_stats_url->string[0]) {
+        const bool attacker_ai = attacker->client->ai != NULL;
+        const bool target_ai = target->client->ai != NULL;
+
+        if (!attacker_ai || !target_ai) { // drop ai-on-ai frags
+          if (!g_level.frag_events) {
+            g_level.frag_events = g_array_new(false, false, sizeof(g_frag_event_t));
+          }
+          g_frag_event_t frag = {
+            .mod = (int32_t) mod,
+            .damage = damage_health,
+            .time = (uint32_t) time(NULL),
+            .attacker_ai = attacker_ai,
+            .target_ai = target_ai,
+          };
+          g_strlcpy(frag.level, g_level.name, sizeof(frag.level));
+          g_strlcpy(frag.attacker, attacker->client->persistent.net_name, sizeof(frag.attacker));
+          g_strlcpy(frag.attacker_guid, attacker->client->persistent.guid, sizeof(frag.attacker_guid));
+          g_strlcpy(frag.target, target->client->persistent.net_name, sizeof(frag.target));
+          g_strlcpy(frag.target_guid, target->client->persistent.guid, sizeof(frag.target_guid));
+          g_strlcpy(frag.weapon, inflictor->classname ?: "unknown", sizeof(frag.weapon));
+          g_array_append_val(g_level.frag_events, frag);
+        }
+      }
 
       if (target->Die) {
         target->Die(target, attacker, mod);

--- a/src/game/default/g_combat.c
+++ b/src/game/default/g_combat.c
@@ -95,7 +95,7 @@ static const char *G_WeaponNameForMod(g_means_of_death mod) {
       return "Quake Rocket Launcher";
     case MOD_QUAKE_THUNDERBOLT:
     case MOD_QUAKE_THUNDERBOLT_DISCHARGE:
-      return "Thunderbolt";
+      return "Quake Thunderbolt";
     case MOD_FIREBALL:
       return "Fireball";
     case MOD_HOOK:

--- a/src/game/default/g_main.c
+++ b/src/game/default/g_main.c
@@ -446,9 +446,9 @@ void G_MuteClient(char *name, bool mute) {
 }
 
 /**
- * @brief Submits accumulated frag events to the server for stats processing.
+ * @brief Submits accumulated frags to the server for stats processing.
  */
-static void G_Stats_PostMatchSummary(void) {
+static void G_FragLog(void) {
 
   if (!g_level.frag_events || !g_level.frag_events->len) {
     return;
@@ -472,7 +472,7 @@ static void G_BeginIntermission(const char *map) {
 
   g_level.intermission_time = g_level.time;
 
-  G_Stats_PostMatchSummary();
+  G_FragLog();
 
   // respawn any dead clients
   G_ForEachClient(cl, {
@@ -506,7 +506,6 @@ static void G_BeginIntermission(const char *map) {
   // move all clients to the intermission point
   G_ForEachClient(cl, {
     G_ClientToIntermission(cl);
-
   });
 
   // play a dramatic sound effect

--- a/src/game/default/g_main.c
+++ b/src/game/default/g_main.c
@@ -163,10 +163,13 @@ cvar_t *g_time_limit;
 cvar_t *g_weapon_respawn_time;
 cvar_t *g_weapon_stay;
 
+cvar_t *g_stats_url;
+
 cvar_t *sv_min_clients;
 cvar_t *sv_max_clients;
 cvar_t *sv_max_entities;
 cvar_t *sv_hostname;
+cvar_t *sv_public;
 cvar_t *dedicated;
 cvar_t *editor;
 
@@ -446,6 +449,50 @@ void G_MuteClient(char *name, bool mute) {
 }
 
 /**
+ * @brief Serializes accumulated frag events to JSON and POSTs them asynchronously.
+ */
+static void G_Stats_PostMatchSummary(void) {
+
+  if (!g_level.frag_events || !g_level.frag_events->len) {
+    return;
+  }
+
+  GString *json = g_string_new("[");
+
+  for (guint i = 0; i < g_level.frag_events->len; i++) {
+    const g_frag_event_t *f = &g_array_index(g_level.frag_events, g_frag_event_t, i);
+
+    if (i > 0) {
+      g_string_append_c(json, ',');
+    }
+
+    g_string_append_printf(json,
+      "{\"level\":\"%s\","
+      "\"attacker\":\"%s\","
+      "\"attacker_guid\":\"%s\","
+      "\"attacker_ai\":%s,"
+      "\"target\":\"%s\","
+      "\"target_guid\":\"%s\","
+      "\"target_ai\":%s,"
+      "\"weapon\":\"%s\","
+      "\"mod\":%d,"
+      "\"damage\":%d,"
+      "\"time\":%u}",
+      f->level, f->attacker, f->attacker_guid, f->attacker_ai ? "true" : "false",
+      f->target, f->target_guid, f->target_ai ? "true" : "false",
+      f->weapon, f->mod, f->damage, f->time);
+  }
+
+  g_string_append_c(json, ']');
+
+  gi.HttpPostAsync(g_stats_url->string, json->str);
+
+  g_string_free(json, true);
+  g_array_free(g_level.frag_events, true);
+  g_level.frag_events = NULL;
+}
+
+/**
  * @brief Starts an intermission sequence, moving all clients to the intermission viewpoint
  * and selecting the next map.
  */
@@ -456,6 +503,10 @@ static void G_BeginIntermission(const char *map) {
   }
 
   g_level.intermission_time = g_level.time;
+
+  if (g_stats_url->string[0] && sv_public->integer > 0) {
+    G_Stats_PostMatchSummary();
+  }
 
   // respawn any dead clients
   G_ForEachClient(cl, {
@@ -1060,6 +1111,10 @@ void G_Init(void) {
   g_time_limit = gi.AddCvar("g_time_limit", "20", CVAR_SERVER_INFO, "The time limit per level in minutes.");
   g_weapon_respawn_time = gi.AddCvar("g_weapon_respawn_time", "5", CVAR_SERVER_INFO, "Weapon respawn interval in seconds.");
   g_weapon_stay = gi.AddCvar("g_weapon_stay", "0", CVAR_SERVER_INFO, "If enabled, weapons will remain when picked up rather than respawn with delay.");
+
+  g_stats_url = gi.AddCvar("g_stats_url", "https://giblets.quetoo.org/api/frags", 0, "URL to POST per-match frag stats to. Leave empty to disable.");
+
+  sv_public = gi.AddCvar("sv_public", "0", 0, NULL);
 
   G_Ai_Init(); // initialize the AI
 

--- a/src/game/default/g_main.c
+++ b/src/game/default/g_main.c
@@ -450,14 +450,14 @@ void G_MuteClient(char *name, bool mute) {
  */
 static void G_FragLog(void) {
 
-  if (!g_level.frag_events || !g_level.frag_events->len) {
+  if (!g_level.frags || !g_level.frags->len) {
     return;
   }
 
-  gi.FragLog((g_frag_t *) g_level.frag_events->data, g_level.frag_events->len);
+  gi.FragLog((g_frag_t *) g_level.frags->data, g_level.frags->len);
 
-  g_array_free(g_level.frag_events, true);
-  g_level.frag_events = NULL;
+  g_array_free(g_level.frags, true);
+  g_level.frags = NULL;
 }
 
 /**

--- a/src/game/default/g_main.c
+++ b/src/game/default/g_main.c
@@ -163,13 +163,10 @@ cvar_t *g_time_limit;
 cvar_t *g_weapon_respawn_time;
 cvar_t *g_weapon_stay;
 
-cvar_t *g_stats_url;
-
 cvar_t *sv_min_clients;
 cvar_t *sv_max_clients;
 cvar_t *sv_max_entities;
 cvar_t *sv_hostname;
-cvar_t *sv_public;
 cvar_t *dedicated;
 cvar_t *editor;
 
@@ -449,7 +446,7 @@ void G_MuteClient(char *name, bool mute) {
 }
 
 /**
- * @brief Serializes accumulated frag events to JSON and POSTs them asynchronously.
+ * @brief Submits accumulated frag events to the server for stats processing.
  */
 static void G_Stats_PostMatchSummary(void) {
 
@@ -457,37 +454,8 @@ static void G_Stats_PostMatchSummary(void) {
     return;
   }
 
-  GString *json = g_string_new("[");
+  gi.FragLog((g_frag_t *) g_level.frag_events->data, g_level.frag_events->len);
 
-  for (guint i = 0; i < g_level.frag_events->len; i++) {
-    const g_frag_event_t *f = &g_array_index(g_level.frag_events, g_frag_event_t, i);
-
-    if (i > 0) {
-      g_string_append_c(json, ',');
-    }
-
-    g_string_append_printf(json,
-      "{\"level\":\"%s\","
-      "\"attacker\":\"%s\","
-      "\"attacker_guid\":\"%s\","
-      "\"attacker_ai\":%s,"
-      "\"target\":\"%s\","
-      "\"target_guid\":\"%s\","
-      "\"target_ai\":%s,"
-      "\"weapon\":\"%s\","
-      "\"mod\":%d,"
-      "\"damage\":%d,"
-      "\"time\":%u}",
-      f->level, f->attacker, f->attacker_guid, f->attacker_ai ? "true" : "false",
-      f->target, f->target_guid, f->target_ai ? "true" : "false",
-      f->weapon, f->mod, f->damage, f->time);
-  }
-
-  g_string_append_c(json, ']');
-
-  gi.HttpPostAsync(g_stats_url->string, json->str);
-
-  g_string_free(json, true);
   g_array_free(g_level.frag_events, true);
   g_level.frag_events = NULL;
 }
@@ -504,9 +472,7 @@ static void G_BeginIntermission(const char *map) {
 
   g_level.intermission_time = g_level.time;
 
-  if (g_stats_url->string[0] && sv_public->integer > 0) {
-    G_Stats_PostMatchSummary();
-  }
+  G_Stats_PostMatchSummary();
 
   // respawn any dead clients
   G_ForEachClient(cl, {
@@ -1111,10 +1077,6 @@ void G_Init(void) {
   g_time_limit = gi.AddCvar("g_time_limit", "20", CVAR_SERVER_INFO, "The time limit per level in minutes.");
   g_weapon_respawn_time = gi.AddCvar("g_weapon_respawn_time", "5", CVAR_SERVER_INFO, "Weapon respawn interval in seconds.");
   g_weapon_stay = gi.AddCvar("g_weapon_stay", "0", CVAR_SERVER_INFO, "If enabled, weapons will remain when picked up rather than respawn with delay.");
-
-  g_stats_url = gi.AddCvar("g_stats_url", "https://giblets.quetoo.org/api/frags", 0, "URL to POST per-match frag stats to. Leave empty to disable.");
-
-  sv_public = gi.AddCvar("sv_public", "0", 0, NULL);
 
   G_Ai_Init(); // initialize the AI
 

--- a/src/game/default/g_main.h
+++ b/src/game/default/g_main.h
@@ -166,6 +166,9 @@ extern cvar_t *g_time_limit;
 extern cvar_t *g_weapon_respawn_time;
 extern cvar_t *g_weapon_stay;
 
+extern cvar_t *g_stats_url;
+extern cvar_t *sv_public;
+
 extern cvar_t *sv_max_clients;
 extern cvar_t *sv_max_entities;
 extern cvar_t *sv_min_clients;

--- a/src/game/default/g_main.h
+++ b/src/game/default/g_main.h
@@ -166,9 +166,6 @@ extern cvar_t *g_time_limit;
 extern cvar_t *g_weapon_respawn_time;
 extern cvar_t *g_weapon_stay;
 
-extern cvar_t *g_stats_url;
-extern cvar_t *sv_public;
-
 extern cvar_t *sv_max_clients;
 extern cvar_t *sv_max_entities;
 extern cvar_t *sv_min_clients;

--- a/src/game/default/g_types.h
+++ b/src/game/default/g_types.h
@@ -1239,7 +1239,7 @@ typedef struct {
   /**
    * @brief Per-install GUID sent via userinfo, used for stats reporting.
    */
-  char guid[37];
+  char guid[MAX_QPATH];
 } g_client_persistent_t;
 
 /**

--- a/src/game/default/g_types.h
+++ b/src/game/default/g_types.h
@@ -938,7 +938,7 @@ typedef struct {
   /**
    * @brief Accumulated frag events for this map, POSTed at intermission.
    */
-  GArray *frag_events;
+  GArray *frags;
 } g_level_t;
 
 /**

--- a/src/game/default/g_types.h
+++ b/src/game/default/g_types.h
@@ -934,6 +934,11 @@ typedef struct {
    * @brief Global spawn points (used in non-team modes).
    */
   g_spawn_points_t spawn_points;
+
+  /**
+   * @brief Accumulated frag events for this map, POSTed at intermission.
+   */
+  GArray *frag_events;
 } g_level_t;
 
 /**
@@ -1147,6 +1152,23 @@ typedef struct {
 #define MAX_NET_NAME_PRINTABLE 15
 
 /**
+ * @brief A single frag event, accumulated during a map and POSTed at intermission.
+ */
+typedef struct {
+  char level[MAX_QPATH];
+  char attacker[MAX_NET_NAME];
+  char attacker_guid[37];
+  char target[MAX_NET_NAME];
+  char target_guid[37];
+  char weapon[MAX_QPATH];
+  int32_t mod;
+  int32_t damage;
+  uint32_t time;
+  bool attacker_ai;
+  bool target_ai;
+} g_frag_event_t;
+
+/**
  * @brief This structure contains client data that persists over multiple spawns.
  */
 typedef struct {
@@ -1230,6 +1252,11 @@ typedef struct {
    * @brief True if the player is muted.
    */
   bool muted;
+
+  /**
+   * @brief Per-install GUID sent via userinfo, used for stats reporting.
+   */
+  char guid[37];
 } g_client_persistent_t;
 
 /**

--- a/src/game/default/g_types.h
+++ b/src/game/default/g_types.h
@@ -1152,23 +1152,6 @@ typedef struct {
 #define MAX_NET_NAME_PRINTABLE 15
 
 /**
- * @brief A single frag event, accumulated during a map and POSTed at intermission.
- */
-typedef struct {
-  char level[MAX_QPATH];
-  char attacker[MAX_NET_NAME];
-  char attacker_guid[37];
-  char target[MAX_NET_NAME];
-  char target_guid[37];
-  char weapon[MAX_QPATH];
-  int32_t mod;
-  int32_t damage;
-  uint32_t time;
-  bool attacker_ai;
-  bool target_ai;
-} g_frag_event_t;
-
-/**
  * @brief This structure contains client data that persists over multiple spawns.
  */
 typedef struct {

--- a/src/game/game.h
+++ b/src/game/game.h
@@ -24,7 +24,7 @@
 #include "shared/shared.h"
 #include "collision/cm_types.h"
 
-#define GAME_API_VERSION 26
+#define GAME_API_VERSION 27
 
 /**
  * @brief Server flags for `g_entity_t`.
@@ -610,6 +610,12 @@ typedef struct g_import_s {
    */
   void (*BroadcastPrint)(const int32_t level, const char *fmt, ...) __attribute__((format(printf, 2, 3)));
   void (*ClientPrint)(const g_client_t *cl, const int32_t level, const char *fmt, ...) __attribute__((format(printf, 3, 4)));
+
+  /**
+   * @brief Asynchronously `POST` a JSON payload to the given URL.
+   * @details Best-effort; failures are logged and silently discarded.
+   */
+  void (*HttpPostAsync)(const char *url, const char *json);
 
   /**
    * @}

--- a/src/game/game.h
+++ b/src/game/game.h
@@ -154,6 +154,23 @@ struct g_entity_s {
 #endif /* __GAME_LOCAL_H__ */
 
 /**
+ * @brief A frag event accumulated during a match, submitted to the stats service at intermission.
+ */
+typedef struct {
+  char     level[64];
+  char     attacker[64];
+  char     attacker_guid[37];
+  bool     attacker_ai;
+  char     target[64];
+  char     target_guid[37];
+  bool     target_ai;
+  char     weapon[64];
+  int32_t  mod;
+  int32_t  damage;
+  uint32_t time;
+} g_frag_t;
+
+/**
  * @brief The game import provides engine functionality and core configuration
  * such as frame intervals to the game module.
  */
@@ -612,10 +629,11 @@ typedef struct g_import_s {
   void (*ClientPrint)(const g_client_t *cl, const int32_t level, const char *fmt, ...) __attribute__((format(printf, 3, 4)));
 
   /**
-   * @brief Asynchronously `POST` a JSON payload to the given URL.
-   * @details Best-effort; failures are logged and silently discarded.
+   * @brief Submit frag events accumulated during a match to the stats service.
+   * @details The server handles URL, gating, JSON serialization, and HTTP POST.
+   * Best-effort; failures are logged and silently discarded.
    */
-  void (*HttpPostAsync)(const char *url, const char *json);
+  void (*FragLog)(const g_frag_t *frags, size_t len);
 
   /**
    * @}

--- a/src/game/game.h
+++ b/src/game/game.h
@@ -157,14 +157,14 @@ struct g_entity_s {
  * @brief A frag event accumulated during a match, submitted to the stats service at intermission.
  */
 typedef struct {
-  char     level[64];
-  char     attacker[64];
-  char     attacker_guid[37];
+  char     level[MAX_QPATH];
+  char     attacker[MAX_QPATH];
+  char     attacker_guid[MAX_QPATH];
   bool     attacker_ai;
-  char     target[64];
-  char     target_guid[37];
+  char     target[MAX_QPATH];
+  char     target_guid[MAX_QPATH];
   bool     target_ai;
-  char     weapon[64];
+  char     weapon[MAX_QPATH];
   int32_t  mod;
   int32_t  damage;
   uint32_t time;

--- a/src/game/game.h
+++ b/src/game/game.h
@@ -631,7 +631,7 @@ typedef struct g_import_s {
   /**
    * @brief Submit frag events accumulated during a match to the stats service.
    * @details The server handles URL, gating, JSON serialization, and HTTP POST.
-   * Best-effort; failures are logged and silently discarded.
+   * Best-effort; failures are silently discarded.
    */
   void (*FragLog)(const g_frag_t *frags, size_t len);
 

--- a/src/net/net_http.c
+++ b/src/net/net_http.c
@@ -21,6 +21,7 @@
 
 #include "net_http.h"
 
+#include <Objectively/URLRequest.h>
 #include <Objectively/URLSession.h>
 
 /**
@@ -97,6 +98,64 @@ void Net_HttpGetAsync(const char *url_string, Net_HttpCallback callback, void *u
   release(url);
 
   Net_HttpGetAsync_State *state = Mem_Malloc(sizeof(Net_HttpGetAsync_State));
+  state->callback = callback;
+  state->user_data = user_data;
+  task->urlSessionTask.data = state;
+
+  $((URLSessionTask *) task, resume);
+}
+
+typedef struct {
+  Net_HttpCallback callback;
+  void *user_data;
+} Net_HttpPostAsync_State;
+
+/**
+ * @brief URLSessionTaskCompletion for `Net_HttpPostAsync`.
+ */
+static void Net_HttpPostAsync_Completion(URLSessionTask *task, bool success) {
+
+  const int32_t status = task->response->httpStatusCode;
+
+  Com_Debug(DEBUG_NET, "%s: HTTP %d\n", task->request->url->urlString->chars, status);
+
+  Net_HttpPostAsync_State *state = (Net_HttpPostAsync_State *) task->data;
+
+  if (state->callback) {
+    const Data *data = ((URLSessionDataTask *) task)->data;
+    if (data) {
+      state->callback(status, (void *) data->bytes, data->length, state->user_data);
+    } else {
+      state->callback(status, NULL, 0, state->user_data);
+    }
+  }
+
+  Mem_Free(state);
+  release(task);
+}
+
+/**
+ * @brief Initiates an asynchronous HTTP `POST` request and invokes `callback` on completion.
+ */
+void Net_HttpPostAsync(const char *url_string, const void *body, size_t length,
+                       const char *content_type, Net_HttpCallback callback, void *user_data) {
+
+  Com_Debug(DEBUG_NET, "POST %s (%zu bytes)\n", url_string, length);
+
+  URL *url = $(alloc(URL), initWithCharacters, url_string);
+  URLRequest *request = $(alloc(URLRequest), initWithURL, url);
+  release(url);
+
+  request->httpMethod = HTTP_POST;
+  request->httpBody = $$(Data, dataWithBytes, (const uint8_t *) body, length);
+
+  $(request, setValueForHTTPHeaderField, content_type, "Content-Type");
+
+  URLSession *session = $$(URLSession, sharedInstance);
+  URLSessionDataTask *task = $(session, dataTaskWithRequest, request, Net_HttpPostAsync_Completion);
+  release(request);
+
+  Net_HttpPostAsync_State *state = Mem_Malloc(sizeof(Net_HttpPostAsync_State));
   state->callback = callback;
   state->user_data = user_data;
   task->urlSessionTask.data = state;

--- a/src/net/net_http.h
+++ b/src/net/net_http.h
@@ -28,7 +28,7 @@
  * @param status The HTTP response code.
  * @param body The response body.
  * @param length The response body length in bytes.
- * @param user_data The user data pointer passed to `Net_HttpGetAsync`.
+ * @param user_data The user data pointer passed to `Net_HttpGetAsync` or `Net_HttpPostAsync`.
  */
 typedef void (*Net_HttpCallback)(int32_t status, void *body, size_t length, void *user_data);
 
@@ -48,6 +48,18 @@ int32_t Net_HttpGet(const char *url_string, void **body, size_t *length);
  * @param user_data User data pointer passed through to the callback.
  */
 void Net_HttpGetAsync(const char *url_string, Net_HttpCallback callback, void *user_data);
+
+/**
+ * @brief Asynchronously `POST` data to the specified URL string.
+ * @param url_string The URL string to `POST` to.
+ * @param body The request body bytes.
+ * @param length The request body length in bytes.
+ * @param content_type The `Content-Type` header value (e.g. "application/json").
+ * @param callback The completion callback, or `NULL`.
+ * @param user_data User data pointer passed through to the callback.
+ */
+void Net_HttpPostAsync(const char *url_string, const void *body, size_t length,
+                       const char *content_type, Net_HttpCallback callback, void *user_data);
 
 /**
  * @brief Construct an HTTP URL from a `net_addr_t` and path.

--- a/src/server/Makefile.am
+++ b/src/server/Makefile.am
@@ -37,6 +37,7 @@ libserver_la_CFLAGS = \
 	@BASE_CFLAGS@ \
 	@CURSES_CFLAGS@ \
 	@GLIB_CFLAGS@ \
+	@OBJECTIVELY_CFLAGS@ \
 	@SDL3_CFLAGS@
 
 libserver_la_LDFLAGS = \

--- a/src/server/sv_game.c
+++ b/src/server/sv_game.c
@@ -204,17 +204,17 @@ static void Sv_WriteAngles(const vec3_t angles) {
 static void *game_handle;
 
 static const JsonProperty sv_frag_properties[] = MakeJsonProperties(
-  MakeJsonProperty("level",         JsonPropertyTypeCharacters, offsetof(g_frag_t, level),         sizeof(((g_frag_t *)0)->level)),
-  MakeJsonProperty("attacker",      JsonPropertyTypeCharacters, offsetof(g_frag_t, attacker),      sizeof(((g_frag_t *)0)->attacker)),
-  MakeJsonProperty("attacker_guid", JsonPropertyTypeCharacters, offsetof(g_frag_t, attacker_guid), sizeof(((g_frag_t *)0)->attacker_guid)),
-  MakeJsonProperty("attacker_ai",   JsonPropertyTypeBool,       offsetof(g_frag_t, attacker_ai),   sizeof(((g_frag_t *)0)->attacker_ai)),
-  MakeJsonProperty("target",        JsonPropertyTypeCharacters, offsetof(g_frag_t, target),        sizeof(((g_frag_t *)0)->target)),
-  MakeJsonProperty("target_guid",   JsonPropertyTypeCharacters, offsetof(g_frag_t, target_guid),   sizeof(((g_frag_t *)0)->target_guid)),
-  MakeJsonProperty("target_ai",     JsonPropertyTypeBool,       offsetof(g_frag_t, target_ai),     sizeof(((g_frag_t *)0)->target_ai)),
-  MakeJsonProperty("weapon",        JsonPropertyTypeCharacters, offsetof(g_frag_t, weapon),        sizeof(((g_frag_t *)0)->weapon)),
-  MakeJsonProperty("mod",           JsonPropertyTypeInteger,    offsetof(g_frag_t, mod),           sizeof(((g_frag_t *)0)->mod)),
-  MakeJsonProperty("damage",        JsonPropertyTypeInteger,    offsetof(g_frag_t, damage),        sizeof(((g_frag_t *)0)->damage)),
-  MakeJsonProperty("time",          JsonPropertyTypeInteger,    offsetof(g_frag_t, time),          sizeof(((g_frag_t *)0)->time))
+  MakeJsonProperty("level",         JsonPropertyCharacters, offsetof(g_frag_t, level),         sizeof(((g_frag_t *)0)->level)),
+  MakeJsonProperty("attacker",      JsonPropertyCharacters, offsetof(g_frag_t, attacker),      sizeof(((g_frag_t *)0)->attacker)),
+  MakeJsonProperty("attacker_guid", JsonPropertyCharacters, offsetof(g_frag_t, attacker_guid), sizeof(((g_frag_t *)0)->attacker_guid)),
+  MakeJsonProperty("attacker_ai",   JsonPropertyBool,       offsetof(g_frag_t, attacker_ai),   sizeof(((g_frag_t *)0)->attacker_ai)),
+  MakeJsonProperty("target",        JsonPropertyCharacters, offsetof(g_frag_t, target),        sizeof(((g_frag_t *)0)->target)),
+  MakeJsonProperty("target_guid",   JsonPropertyCharacters, offsetof(g_frag_t, target_guid),   sizeof(((g_frag_t *)0)->target_guid)),
+  MakeJsonProperty("target_ai",     JsonPropertyBool,       offsetof(g_frag_t, target_ai),     sizeof(((g_frag_t *)0)->target_ai)),
+  MakeJsonProperty("weapon",        JsonPropertyCharacters, offsetof(g_frag_t, weapon),        sizeof(((g_frag_t *)0)->weapon)),
+  MakeJsonProperty("mod",           JsonPropertyInteger,    offsetof(g_frag_t, mod),           sizeof(((g_frag_t *)0)->mod)),
+  MakeJsonProperty("damage",        JsonPropertyInteger,    offsetof(g_frag_t, damage),        sizeof(((g_frag_t *)0)->damage)),
+  MakeJsonProperty("time",          JsonPropertyInteger,    offsetof(g_frag_t, time),          sizeof(((g_frag_t *)0)->time))
 );
 
 /**

--- a/src/server/sv_game.c
+++ b/src/server/sv_game.c
@@ -203,23 +203,8 @@ static void Sv_WriteAngles(const vec3_t angles) {
 
 static void *game_handle;
 
-static const JsonProperty sv_frag_properties[] = MakeJsonProperties(
-  MakeJsonProperty(g_frag_t, level,         JsonPropertyString),
-  MakeJsonProperty(g_frag_t, attacker,      JsonPropertyString),
-  MakeJsonProperty(g_frag_t, attacker_guid, JsonPropertyString),
-  MakeJsonProperty(g_frag_t, attacker_ai,   JsonPropertyBool),
-  MakeJsonProperty(g_frag_t, target,        JsonPropertyString),
-  MakeJsonProperty(g_frag_t, target_guid,   JsonPropertyString),
-  MakeJsonProperty(g_frag_t, target_ai,     JsonPropertyBool),
-  MakeJsonProperty(g_frag_t, weapon,        JsonPropertyString),
-  MakeJsonProperty(g_frag_t, mod,           JsonPropertyInteger),
-  MakeJsonProperty(g_frag_t, damage,        JsonPropertyInteger),
-  MakeJsonProperty(g_frag_t, time,          JsonPropertyInteger)
-);
-
 /**
- * @brief Serializes frag events from the game module to JSON and POSTs them
- * asynchronously to sv_stats_url. Gated on sv_public and a non-empty URL.
+ * @brief `Net_HttpCallback` for `Sv_FragLog`.
  */
 static void Sv_FragLogCallback(int32_t status, void *body, size_t length, void *user_data) {
   if (status < 200 || status >= 300) {
@@ -228,25 +213,32 @@ static void Sv_FragLogCallback(int32_t status, void *body, size_t length, void *
   }
 }
 
+/**
+ * @brief Serializes frag events from the game module to JSON and POSTs them
+ * asynchronously to `sv_stats_url`. Gated on `sv_public` and a non-empty URL.
+ */
 static void Sv_FragLog(const g_frag_t *frags, size_t len) {
+
+  static const JsonProperty g_frag_properties[] = MakeJsonProperties(
+    MakeJsonProperty(g_frag_t, level,         JsonPropertyString),
+    MakeJsonProperty(g_frag_t, attacker,      JsonPropertyString),
+    MakeJsonProperty(g_frag_t, attacker_guid, JsonPropertyString),
+    MakeJsonProperty(g_frag_t, attacker_ai,   JsonPropertyBool),
+    MakeJsonProperty(g_frag_t, target,        JsonPropertyString),
+    MakeJsonProperty(g_frag_t, target_guid,   JsonPropertyString),
+    MakeJsonProperty(g_frag_t, target_ai,     JsonPropertyBool),
+    MakeJsonProperty(g_frag_t, weapon,        JsonPropertyString),
+    MakeJsonProperty(g_frag_t, mod,           JsonPropertyInteger),
+    MakeJsonProperty(g_frag_t, damage,        JsonPropertyInteger),
+    MakeJsonProperty(g_frag_t, time,          JsonPropertyInteger)
+  );
 
   if (!sv_stats_url->string[0] || sv_public->integer <= 0) {
     return;
   }
 
-  g_frag_t valid[len];
-  size_t count = 0;
-
-  for (size_t i = 0; i < len; i++) {
-    if (frags[i].attacker_guid[0] && frags[i].target_guid[0]) {
-      valid[count++] = frags[i];
-    } else {
-      Com_Debug(DEBUG_SERVER, "Sv_FragLog: skipping frag from %s — missing guid\n", frags[i].attacker);
-    }
-  }
-
-  if (count) {
-    Data *data = $$(JSONSerialization, dataFromInstances, sv_frag_properties, valid, count, sizeof(g_frag_t));
+  if (len) {
+    Data *data = $$(JSONSerialization, dataFromInstances, g_frag_properties, frags, len, sizeof(g_frag_t));
     if (data) {
       Net_HttpPostAsync(sv_stats_url->string, data->bytes, data->length, "application/json", Sv_FragLogCallback, NULL);
       release(data);

--- a/src/server/sv_game.c
+++ b/src/server/sv_game.c
@@ -202,10 +202,46 @@ static void Sv_WriteAngles(const vec3_t angles) {
 static void *game_handle;
 
 /**
- * @brief Asynchronously POSTs a JSON payload to the given URL. Best-effort; errors are logged.
+ * @brief Serializes frag events from the game module to JSON and POSTs them
+ * asynchronously to sv_stats_url. Gated on sv_public and a non-empty URL.
  */
-static void Sv_HttpPostAsync(const char *url, const char *json) {
-  Net_HttpPostAsync(url, json, strlen(json), "application/json", NULL, NULL);
+static void Sv_FragLog(const g_frag_t *frags, size_t len) {
+
+  if (!sv_stats_url->string[0] || sv_public->integer <= 0) {
+    return;
+  }
+
+  GString *json = g_string_new("[");
+
+  for (size_t i = 0; i < len; i++) {
+    const g_frag_t *f = &frags[i];
+
+    if (i > 0) {
+      g_string_append_c(json, ',');
+    }
+
+    g_string_append_printf(json,
+      "{\"level\":\"%s\","
+      "\"attacker\":\"%s\","
+      "\"attacker_guid\":\"%s\","
+      "\"attacker_ai\":%s,"
+      "\"target\":\"%s\","
+      "\"target_guid\":\"%s\","
+      "\"target_ai\":%s,"
+      "\"weapon\":\"%s\","
+      "\"mod\":%d,"
+      "\"damage\":%d,"
+      "\"time\":%u}",
+      f->level, f->attacker, f->attacker_guid, f->attacker_ai ? "true" : "false",
+      f->target, f->target_guid, f->target_ai ? "true" : "false",
+      f->weapon, f->mod, f->damage, f->time);
+  }
+
+  g_string_append_c(json, ']');
+
+  Net_HttpPostAsync(sv_stats_url->string, json->str, strlen(json->str), "application/json", NULL, NULL);
+
+  g_string_free(json, true);
 }
 
 /**
@@ -305,7 +341,7 @@ void Sv_InitGame(void) {
   import.BroadcastPrint = Sv_BroadcastPrint;
   import.ClientPrint = Sv_ClientPrint;
 
-  import.HttpPostAsync = Sv_HttpPostAsync;
+  import.FragLog = Sv_FragLog;
 
   game_handle = Sys_OpenLibrary("game", false);
   assert(game_handle);

--- a/src/server/sv_game.c
+++ b/src/server/sv_game.c
@@ -22,12 +22,7 @@
 #include "sv_local.h"
 #include "net/net_http.h"
 
-#include <Objectively/Boole.h>
 #include <Objectively/JSONSerialization.h>
-#include <Objectively/MutableArray.h>
-#include <Objectively/MutableDictionary.h>
-#include <Objectively/Number.h>
-#include <Objectively/String.h>
 
 /**
  * @brief Fetch the active debug mask.
@@ -208,6 +203,20 @@ static void Sv_WriteAngles(const vec3_t angles) {
 
 static void *game_handle;
 
+static const JsonProperty sv_frag_properties[] = MakeJsonProperties(
+  MakeJsonProperty("level",         JsonPropertyTypeCharacters, offsetof(g_frag_t, level),         sizeof(((g_frag_t *)0)->level)),
+  MakeJsonProperty("attacker",      JsonPropertyTypeCharacters, offsetof(g_frag_t, attacker),      sizeof(((g_frag_t *)0)->attacker)),
+  MakeJsonProperty("attacker_guid", JsonPropertyTypeCharacters, offsetof(g_frag_t, attacker_guid), sizeof(((g_frag_t *)0)->attacker_guid)),
+  MakeJsonProperty("attacker_ai",   JsonPropertyTypeBool,       offsetof(g_frag_t, attacker_ai),   sizeof(((g_frag_t *)0)->attacker_ai)),
+  MakeJsonProperty("target",        JsonPropertyTypeCharacters, offsetof(g_frag_t, target),        sizeof(((g_frag_t *)0)->target)),
+  MakeJsonProperty("target_guid",   JsonPropertyTypeCharacters, offsetof(g_frag_t, target_guid),   sizeof(((g_frag_t *)0)->target_guid)),
+  MakeJsonProperty("target_ai",     JsonPropertyTypeBool,       offsetof(g_frag_t, target_ai),     sizeof(((g_frag_t *)0)->target_ai)),
+  MakeJsonProperty("weapon",        JsonPropertyTypeCharacters, offsetof(g_frag_t, weapon),        sizeof(((g_frag_t *)0)->weapon)),
+  MakeJsonProperty("mod",           JsonPropertyTypeInteger,    offsetof(g_frag_t, mod),           sizeof(((g_frag_t *)0)->mod)),
+  MakeJsonProperty("damage",        JsonPropertyTypeInteger,    offsetof(g_frag_t, damage),        sizeof(((g_frag_t *)0)->damage)),
+  MakeJsonProperty("time",          JsonPropertyTypeInteger,    offsetof(g_frag_t, time),          sizeof(((g_frag_t *)0)->time))
+);
+
 /**
  * @brief Serializes frag events from the game module to JSON and POSTs them
  * asynchronously to sv_stats_url. Gated on sv_public and a non-empty URL.
@@ -225,68 +234,24 @@ static void Sv_FragLog(const g_frag_t *frags, size_t len) {
     return;
   }
 
-  MutableArray *array = $(alloc(MutableArray), init);
+  g_frag_t valid[len];
+  size_t count = 0;
 
   for (size_t i = 0; i < len; i++) {
-    const g_frag_t *f = &frags[i];
-
-    if (!f->attacker_guid[0] || !f->target_guid[0]) {
-      Com_Debug(DEBUG_SERVER, "Sv_FragLog: skipping frag from %s — missing guid\n", f->attacker);
-      continue;
+    if (frags[i].attacker_guid[0] && frags[i].target_guid[0]) {
+      valid[count++] = frags[i];
+    } else {
+      Com_Debug(DEBUG_SERVER, "Sv_FragLog: skipping frag from %s — missing guid\n", frags[i].attacker);
     }
-
-    MutableDictionary *frag = $(alloc(MutableDictionary), init);
-
-#define SET_STR(key, val) do { \
-    String *_k = $$(String, stringWithCharacters, (key)); \
-    String *_v = $$(String, stringWithCharacters, (val)); \
-    $(frag, setObjectForKey, _v, _k); \
-    release(_k); release(_v); \
-  } while (0)
-
-#define SET_NUM(key, val) do { \
-    String *_k = $$(String, stringWithCharacters, (key)); \
-    Number *_v = $$(Number, numberWithValue, (val)); \
-    $(frag, setObjectForKey, _v, _k); \
-    release(_k); release(_v); \
-  } while (0)
-
-#define SET_BOOL(key, val) do { \
-    String *_k = $$(String, stringWithCharacters, (key)); \
-    Boole *_v = (val) ? $$(Boole, True) : $$(Boole, False); \
-    $(frag, setObjectForKey, _v, _k); \
-    release(_k); release(_v); \
-  } while (0)
-
-    SET_STR("level",         f->level);
-    SET_STR("attacker",      f->attacker);
-    SET_STR("attacker_guid", f->attacker_guid);
-    SET_BOOL("attacker_ai",  f->attacker_ai);
-    SET_STR("target",        f->target);
-    SET_STR("target_guid",   f->target_guid);
-    SET_BOOL("target_ai",    f->target_ai);
-    SET_STR("weapon",        f->weapon);
-    SET_NUM("mod",           f->mod);
-    SET_NUM("damage",        f->damage);
-    SET_NUM("time",          f->time);
-
-#undef SET_STR
-#undef SET_NUM
-#undef SET_BOOL
-
-    $(array, addObject, frag);
-    release(frag);
   }
 
-  if (array->array.count) {
-    Data *data = $$(JSONSerialization, dataFromObject, array, 0);
+  if (count) {
+    Data *data = $$(JSONSerialization, dataFromStructs, sv_frag_properties, valid, count, sizeof(g_frag_t));
     if (data) {
       Net_HttpPostAsync(sv_stats_url->string, data->bytes, data->length, "application/json", Sv_FragLogCallback, NULL);
       release(data);
     }
   }
-
-  release(array);
 }
 
 /**

--- a/src/server/sv_game.c
+++ b/src/server/sv_game.c
@@ -204,17 +204,17 @@ static void Sv_WriteAngles(const vec3_t angles) {
 static void *game_handle;
 
 static const JsonProperty sv_frag_properties[] = MakeJsonProperties(
-  MakeJsonProperty("level",         JsonPropertyCharacters, offsetof(g_frag_t, level),         sizeof(((g_frag_t *)0)->level)),
-  MakeJsonProperty("attacker",      JsonPropertyCharacters, offsetof(g_frag_t, attacker),      sizeof(((g_frag_t *)0)->attacker)),
-  MakeJsonProperty("attacker_guid", JsonPropertyCharacters, offsetof(g_frag_t, attacker_guid), sizeof(((g_frag_t *)0)->attacker_guid)),
-  MakeJsonProperty("attacker_ai",   JsonPropertyBool,       offsetof(g_frag_t, attacker_ai),   sizeof(((g_frag_t *)0)->attacker_ai)),
-  MakeJsonProperty("target",        JsonPropertyCharacters, offsetof(g_frag_t, target),        sizeof(((g_frag_t *)0)->target)),
-  MakeJsonProperty("target_guid",   JsonPropertyCharacters, offsetof(g_frag_t, target_guid),   sizeof(((g_frag_t *)0)->target_guid)),
-  MakeJsonProperty("target_ai",     JsonPropertyBool,       offsetof(g_frag_t, target_ai),     sizeof(((g_frag_t *)0)->target_ai)),
-  MakeJsonProperty("weapon",        JsonPropertyCharacters, offsetof(g_frag_t, weapon),        sizeof(((g_frag_t *)0)->weapon)),
-  MakeJsonProperty("mod",           JsonPropertyInteger,    offsetof(g_frag_t, mod),           sizeof(((g_frag_t *)0)->mod)),
-  MakeJsonProperty("damage",        JsonPropertyInteger,    offsetof(g_frag_t, damage),        sizeof(((g_frag_t *)0)->damage)),
-  MakeJsonProperty("time",          JsonPropertyInteger,    offsetof(g_frag_t, time),          sizeof(((g_frag_t *)0)->time))
+  MakeJsonProperty(g_frag_t, level,         JsonPropertyString),
+  MakeJsonProperty(g_frag_t, attacker,      JsonPropertyString),
+  MakeJsonProperty(g_frag_t, attacker_guid, JsonPropertyString),
+  MakeJsonProperty(g_frag_t, attacker_ai,   JsonPropertyBool),
+  MakeJsonProperty(g_frag_t, target,        JsonPropertyString),
+  MakeJsonProperty(g_frag_t, target_guid,   JsonPropertyString),
+  MakeJsonProperty(g_frag_t, target_ai,     JsonPropertyBool),
+  MakeJsonProperty(g_frag_t, weapon,        JsonPropertyString),
+  MakeJsonProperty(g_frag_t, mod,           JsonPropertyInteger),
+  MakeJsonProperty(g_frag_t, damage,        JsonPropertyInteger),
+  MakeJsonProperty(g_frag_t, time,          JsonPropertyInteger)
 );
 
 /**

--- a/src/server/sv_game.c
+++ b/src/server/sv_game.c
@@ -205,6 +205,13 @@ static void *game_handle;
  * @brief Serializes frag events from the game module to JSON and POSTs them
  * asynchronously to sv_stats_url. Gated on sv_public and a non-empty URL.
  */
+static void Sv_FragLogCallback(int32_t status, void *body, size_t length, void *user_data) {
+  if (status < 200 || status >= 300) {
+    Com_Warn("Sv_FragLog: POST to %s failed (HTTP %d): %.*s\n",
+             sv_stats_url->string, status, (int) length, (const char *) body);
+  }
+}
+
 static void Sv_FragLog(const g_frag_t *frags, size_t len) {
 
   if (!sv_stats_url->string[0] || sv_public->integer <= 0) {
@@ -247,7 +254,7 @@ static void Sv_FragLog(const g_frag_t *frags, size_t len) {
   g_string_append_c(json, ']');
 
   if (!first) {
-    Net_HttpPostAsync(sv_stats_url->string, json->str, strlen(json->str), "application/json", NULL, NULL);
+    Net_HttpPostAsync(sv_stats_url->string, json->str, strlen(json->str), "application/json", Sv_FragLogCallback, NULL);
   }
 
   g_string_free(json, true);

--- a/src/server/sv_game.c
+++ b/src/server/sv_game.c
@@ -246,7 +246,7 @@ static void Sv_FragLog(const g_frag_t *frags, size_t len) {
   }
 
   if (count) {
-    Data *data = $$(JSONSerialization, dataFromStructs, sv_frag_properties, valid, count, sizeof(g_frag_t));
+    Data *data = $$(JSONSerialization, dataFromInstances, sv_frag_properties, valid, count, sizeof(g_frag_t));
     if (data) {
       Net_HttpPostAsync(sv_stats_url->string, data->bytes, data->length, "application/json", Sv_FragLogCallback, NULL);
       release(data);

--- a/src/server/sv_game.c
+++ b/src/server/sv_game.c
@@ -22,6 +22,13 @@
 #include "sv_local.h"
 #include "net/net_http.h"
 
+#include <Objectively/Boole.h>
+#include <Objectively/JSONSerialization.h>
+#include <Objectively/MutableArray.h>
+#include <Objectively/MutableDictionary.h>
+#include <Objectively/Number.h>
+#include <Objectively/String.h>
+
 /**
  * @brief Fetch the active debug mask.
  */
@@ -218,9 +225,8 @@ static void Sv_FragLog(const g_frag_t *frags, size_t len) {
     return;
   }
 
-  GString *json = g_string_new("[");
+  MutableArray *array = $(alloc(MutableArray), init);
 
-  bool first = true;
   for (size_t i = 0; i < len; i++) {
     const g_frag_t *f = &frags[i];
 
@@ -229,35 +235,58 @@ static void Sv_FragLog(const g_frag_t *frags, size_t len) {
       continue;
     }
 
-    if (!first) {
-      g_string_append_c(json, ',');
+    MutableDictionary *frag = $(alloc(MutableDictionary), init);
+
+#define SET_STR(key, val) do { \
+    String *_k = $$(String, stringWithCharacters, (key)); \
+    String *_v = $$(String, stringWithCharacters, (val)); \
+    $(frag, setObjectForKey, _v, _k); \
+    release(_k); release(_v); \
+  } while (0)
+
+#define SET_NUM(key, val) do { \
+    String *_k = $$(String, stringWithCharacters, (key)); \
+    Number *_v = $$(Number, numberWithValue, (val)); \
+    $(frag, setObjectForKey, _v, _k); \
+    release(_k); release(_v); \
+  } while (0)
+
+#define SET_BOOL(key, val) do { \
+    String *_k = $$(String, stringWithCharacters, (key)); \
+    Boole *_v = (val) ? $$(Boole, True) : $$(Boole, False); \
+    $(frag, setObjectForKey, _v, _k); \
+    release(_k); release(_v); \
+  } while (0)
+
+    SET_STR("level",         f->level);
+    SET_STR("attacker",      f->attacker);
+    SET_STR("attacker_guid", f->attacker_guid);
+    SET_BOOL("attacker_ai",  f->attacker_ai);
+    SET_STR("target",        f->target);
+    SET_STR("target_guid",   f->target_guid);
+    SET_BOOL("target_ai",    f->target_ai);
+    SET_STR("weapon",        f->weapon);
+    SET_NUM("mod",           f->mod);
+    SET_NUM("damage",        f->damage);
+    SET_NUM("time",          f->time);
+
+#undef SET_STR
+#undef SET_NUM
+#undef SET_BOOL
+
+    $(array, addObject, frag);
+    release(frag);
+  }
+
+  if (array->array.count) {
+    Data *data = $$(JSONSerialization, dataFromObject, array, 0);
+    if (data) {
+      Net_HttpPostAsync(sv_stats_url->string, data->bytes, data->length, "application/json", Sv_FragLogCallback, NULL);
+      release(data);
     }
-    first = false;
-
-    g_string_append_printf(json,
-      "{\"level\":\"%s\","
-      "\"attacker\":\"%s\","
-      "\"attacker_guid\":\"%s\","
-      "\"attacker_ai\":%s,"
-      "\"target\":\"%s\","
-      "\"target_guid\":\"%s\","
-      "\"target_ai\":%s,"
-      "\"weapon\":\"%s\","
-      "\"mod\":%d,"
-      "\"damage\":%d,"
-      "\"time\":%u}",
-      f->level, f->attacker, f->attacker_guid, f->attacker_ai ? "true" : "false",
-      f->target, f->target_guid, f->target_ai ? "true" : "false",
-      f->weapon, f->mod, f->damage, f->time);
   }
 
-  g_string_append_c(json, ']');
-
-  if (!first) {
-    Net_HttpPostAsync(sv_stats_url->string, json->str, strlen(json->str), "application/json", Sv_FragLogCallback, NULL);
-  }
-
-  g_string_free(json, true);
+  release(array);
 }
 
 /**

--- a/src/server/sv_game.c
+++ b/src/server/sv_game.c
@@ -213,12 +213,19 @@ static void Sv_FragLog(const g_frag_t *frags, size_t len) {
 
   GString *json = g_string_new("[");
 
+  bool first = true;
   for (size_t i = 0; i < len; i++) {
     const g_frag_t *f = &frags[i];
 
-    if (i > 0) {
+    if (!f->attacker_guid[0] || !f->target_guid[0]) {
+      Com_Debug(DEBUG_SERVER, "Sv_FragLog: skipping frag from %s — missing guid\n", f->attacker);
+      continue;
+    }
+
+    if (!first) {
       g_string_append_c(json, ',');
     }
+    first = false;
 
     g_string_append_printf(json,
       "{\"level\":\"%s\","
@@ -239,7 +246,9 @@ static void Sv_FragLog(const g_frag_t *frags, size_t len) {
 
   g_string_append_c(json, ']');
 
-  Net_HttpPostAsync(sv_stats_url->string, json->str, strlen(json->str), "application/json", NULL, NULL);
+  if (!first) {
+    Net_HttpPostAsync(sv_stats_url->string, json->str, strlen(json->str), "application/json", NULL, NULL);
+  }
 
   g_string_free(json, true);
 }

--- a/src/server/sv_game.c
+++ b/src/server/sv_game.c
@@ -20,6 +20,7 @@
  */
 
 #include "sv_local.h"
+#include "net/net_http.h"
 
 /**
  * @brief Fetch the active debug mask.
@@ -201,6 +202,13 @@ static void Sv_WriteAngles(const vec3_t angles) {
 static void *game_handle;
 
 /**
+ * @brief Asynchronously POSTs a JSON payload to the given URL. Best-effort; errors are logged.
+ */
+static void Sv_HttpPostAsync(const char *url, const char *json) {
+  Net_HttpPostAsync(url, json, strlen(json), "application/json", NULL, NULL);
+}
+
+/**
  * @brief Initializes the game module by exposing a subset of server functionality
  * through function pointers. In return, the game module allocates memory for
  * entities and returns a few pointers of its own.
@@ -296,6 +304,8 @@ void Sv_InitGame(void) {
 
   import.BroadcastPrint = Sv_BroadcastPrint;
   import.ClientPrint = Sv_ClientPrint;
+
+  import.HttpPostAsync = Sv_HttpPostAsync;
 
   game_handle = Sys_OpenLibrary("game", false);
   assert(game_handle);

--- a/src/server/sv_game.c
+++ b/src/server/sv_game.c
@@ -219,7 +219,7 @@ static void Sv_FragLogCallback(int32_t status, void *body, size_t length, void *
  */
 static void Sv_FragLog(const g_frag_t *frags, size_t len) {
 
-  static const JsonProperty g_frag_properties[] = MakeJsonProperties(
+  static const JsonProperty props[] = MakeJsonProperties(
     MakeJsonProperty(g_frag_t, level,         JsonPropertyString),
     MakeJsonProperty(g_frag_t, attacker,      JsonPropertyString),
     MakeJsonProperty(g_frag_t, attacker_guid, JsonPropertyString),
@@ -238,7 +238,7 @@ static void Sv_FragLog(const g_frag_t *frags, size_t len) {
   }
 
   if (len) {
-    Data *data = $$(JSONSerialization, dataFromInstances, g_frag_properties, frags, len, sizeof(g_frag_t));
+    Data *data = $$(JSONSerialization, dataFromInstances, props, frags, len, sizeof(g_frag_t));
     if (data) {
       Net_HttpPostAsync(sv_stats_url->string, data->bytes, data->length, "application/json", Sv_FragLogCallback, NULL);
       release(data);

--- a/src/server/sv_main.c
+++ b/src/server/sv_main.c
@@ -38,6 +38,7 @@ cvar_t *sv_max_clients;
 cvar_t *sv_max_entities;
 cvar_t *sv_min_clients;
 cvar_t *sv_public;
+cvar_t *sv_stats_url;
 cvar_t *sv_timeout;
 
 /**
@@ -921,6 +922,7 @@ static void Sv_InitLocal(void) {
   sv_max_clients = Cvar_Add("sv_max_clients", va("%d", MAX_CLIENTS), CVAR_SERVER_INFO | CVAR_LATCH, "The maximum number of clients the server will allow");
   sv_max_entities = Cvar_Add("sv_max_entities", va("%d", MAX_ENTITIES), CVAR_SERVER_INFO | CVAR_LATCH, "The maximum number of entities the server will allow");
   sv_public = Cvar_Add("sv_public", "0", CVAR_SERVER_INFO, "Set to 1 to to advertise this server via the master server");
+  sv_stats_url = Cvar_Add("sv_stats_url", "https://giblets.quetoo.org/api/frags", CVAR_ARCHIVE, "URL to POST per-match frag stats to. Requires sv_public 1. Leave empty to disable.");
   sv_timeout = Cvar_Add("sv_timeout", va("%d", SV_TIMEOUT), 0, "The client connection timeout threshold in seconds");
 
   sv_max_clients->integer = Mini(sv_max_clients->integer, MAX_CLIENTS);

--- a/src/server/sv_main.h
+++ b/src/server/sv_main.h
@@ -36,6 +36,7 @@ extern cvar_t *sv_hostname;
 extern cvar_t *sv_max_clients;
 extern cvar_t *sv_max_entities;
 extern cvar_t *sv_public;
+extern cvar_t *sv_stats_url;
 extern cvar_t *sv_timeout;
 
 // per-level and static server structures


### PR DESCRIPTION
## Overview

Adds a global frag leaderboard system. Dedicated servers accumulate per-kill frag events during a match and POST them to a stats API at intermission.

## Architecture

The game module accumulates frags and hands them to the server via a new `gi.FragLog` import. The server owns all infrastructure concerns (URL, gating, JSON, HTTP). Modders get frag logging for free.

## Changes

### Net
- `net_http`: add `Net_HttpPostAsync` for fire-and-forget JSON POSTs

### Server
- `sv_game`: `Sv_FragLog` — serializes `g_frag_t[]` to JSON, POSTs to `sv_stats_url`; gated on `sv_stats_url` non-empty and `sv_public 1`
- `sv_main`: add `sv_stats_url` cvar (default `https://giblets.quetoo.org/api/frags`, `CVAR_ARCHIVE`)

### Game API (`game.h`)
- Bump `GAME_API_VERSION` 26 → 27
- Add `g_frag_t` struct (level, attacker/target name+guid+ai flag, weapon, mod, damage, unix timestamp)
- Add `gi.FragLog(const g_frag_t *frags, size_t len)`

### Game Module
- `cl_main`: add `guid` cvar (`CVAR_USER_INFO|CVAR_ARCHIVE|CVAR_NO_SET`); auto-generates UUID v4 on first launch
- `g_client`: read `guid` from userinfo into `client->persistent.guid`
- `g_types`: add `char guid[37]` to `g_client_persistent_t`; add `GArray *frag_events` to `g_level_t`
- `g_ai_types`: add `const char *guid` to `g_ai_roster_t`
- `g_ai_info`: assign stable hardcoded UUID v4 per bot; set in bot userinfo
- `g_combat`: on kill, drop ai-on-ai frags silently; otherwise append `g_frag_t` with `attacker_ai`/`target_ai` flags
- `g_main`: `G_Stats_PostMatchSummary` calls `gi.FragLog` at intermission; no URL/JSON/HTTP in game module

## Stats API

Lives in `jdolan/quetoo-stats` (already deployed to `https://giblets.quetoo.org`):
- `POST /api/frags` — ingest endpoint; GUIDs HMAC-SHA256 hashed server-side before storage
- `GET /api/stats` — global leaderboard with `?weapon`, `?mod`, `?level`, `?ai`, `?limit`
- `GET /api/stats/<guid>` — player deep stats (kills/deaths by weapon and opponent)