### PR TITLE
Add shooter category to Quetoo.desktop

### DIFF
--- a/linux/quetoo/Quetoo.desktop
+++ b/linux/quetoo/Quetoo.desktop
@@ -5,6 +5,6 @@ Exec=quetoo %U
 Icon=quetoo
 Terminal=false
 Type=Application
-Categories=Game;ActionGame;
+Categories=Game;ActionGame;Shooter;
 MimeType=x-scheme-handler/quetoo;
 StartupNotify=true


### PR DESCRIPTION
This will better categorize the game on Flathub and other Linux software centers/frontends.