### PR TITLE
Add org.quetoo.Quetoo.metainfo.xml

### DIFF
--- a/linux/quetoo/org.quetoo.Quetoo.metainfo.xml
+++ b/linux/quetoo/org.quetoo.Quetoo.metainfo.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>org.quetoo.Quetoo</id>
+  <launchable type="desktop-id">org.quetoo.Quetoo.desktop</launchable>
+  <name>Quetoo</name>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>GPL-2.0+</project_license>
+  <developer id="org.quetoo">
+    <name>jdolan</name>
+  </developer>
+  <branding>
+    <color type="primary" scheme_preference="light">#158477</color>
+    <color type="primary" scheme_preference="dark">#0d4e47</color>
+  </branding>
+  <summary>A free first person shooter for Mac, PC and Linux</summary>
+  <description>
+    <p>
+      Quetoo ("Q2") is a free first person shooter for Mac, PC and Linux.
+      Our goal is to bring the fun of oldschool deathmatch to a new generation of gamers.
+      We're pwning nubz, one rail slug at a time.
+    </p>
+    <ul>
+      <li>Deathmatch, Team DM, Capture the Flag, Instagib and Rocket Arena gameplay modes</li>
+      <li>High quality remakes of id Software's legendary Quake series deathmatch levels, as well as many originals</li>
+      <li>Realtime lighting with soft shadowmapping</li>
+      <li>Steep parallax occlusion mapping with self-shadowing</li>
+      <li>Dramatically improved artwork pipeline with in-game editor for level artists</li>
+      <li>TrenchBroom support</li>
+      <li>100% free to download, play and modify. Source code licensed under GPL v2, artwork under Creative Commons.</li>
+    </ul>
+  </description>
+  <url type="homepage">https://quetoo.org</url>
+  <url type="bugtracker">https://github.com/jdolan/quetoo/issues</url>
+  <url type="vcs-browser">https://github.com/jdolan/quetoo</url>
+  <screenshots>
+    <screenshot type="default">
+      <caption>In-game screenshot</caption>
+      <image>https://quetoo.org/images/screenshots/quetoo001.jpg</image>
+    </screenshot>
+    <screenshot>
+      <caption>In-game screenshot</caption>
+      <image>https://quetoo.org/images/screenshots/quetoo004.jpg</image>
+    </screenshot>
+    <screenshot>
+      <caption>In-game screenshot</caption>
+      <image>https://quetoo.org/images/screenshots/quetoo008.jpg</image>
+    </screenshot>
+    <screenshot>
+      <caption>In-game screenshot</caption>
+      <image>https://quetoo.org/images/screenshots/quetoo013.jpg</image>
+    </screenshot>
+    <screenshot>
+      <caption>In-game screenshot</caption>
+      <image>https://quetoo.org/images/screenshots/quetoo051.jpg</image>
+    </screenshot>
+  </screenshots>
+  <update_contact>jay@jaydolan.com</update_contact>
+  <content_rating type="oars-1.1">
+    <content_attribute id="violence-cartoon">intense</content_attribute>
+    <content_attribute id="violence-fantasy">intense</content_attribute>
+    <content_attribute id="violence-bloodshed">intense</content_attribute>
+    <content_attribute id="social-chat">intense</content_attribute>
+  </content_rating>
+  <releases>
+    <release version="1.0.24" date="2026-05-27"/>
+  </releases>
+</component>


### PR DESCRIPTION
Added the Appstream file as requested by the Flathub admin.
It currently includes some conventions required by Flathub (like the reverse dns id - org.quetoo.Quetoo), but other Linux distributions can reuse it in this form without modifications (It's actually considered a good practice to be used this way).

Its main purpose is to display all of the app details (name, summary, descriptions, license, screenshots, etc) in Flathub or other Linux software center frontends. So besides Flathub, this will be useful for other Linux distributions if they'll ever pacakge Quetoo in their repos, but I don't know if it will be useful in your tarballs that are downloaded from Github, since (at least from my experience), the appstream format works properly only with a repository type of distribution like Flathub or Linux distro repos.

As mentioned, every time before you release a new version, you have to add the new version number to the releases section at the bottom of the file. Each new release should be placed above the previous one.
Speaking of that, if you can, you can tell me when you'll release your next version and I'll update the version number and its date in this PR.