### PR TITLE
quetoo-update: Use /var/tmp instead of /tmp to avoid RAM exhaustion

### DIFF
--- a/linux/quetoo/usr/lib/quetoo/bin/quetoo-update
+++ b/linux/quetoo/usr/lib/quetoo/bin/quetoo-update
@@ -128,7 +128,7 @@ done < <(
 )
 
 # Download and install packages.
-TMPDIR=$(mktemp -d)
+TMPDIR=$(mktemp -d -p /var/tmp)
 trap 'rm -rf "$TMPDIR"' EXIT
 
 QUETOO_BASE="https://github.com/jdolan/quetoo/releases/download/v${LATEST}"


### PR DESCRIPTION
## Summary

changes TMPDIR to use `/var/tmp` instead of `/tmp` in quetoo-update. on Debian 13, /tmp is RAM-backed which causes the update to fail when downloading large files