### PR TITLE
feat: kd-tree plus heap for a* optimizations

### DIFF
--- a/Quetoo.vs15/game.vcxproj
+++ b/Quetoo.vs15/game.vcxproj
@@ -27,6 +27,7 @@
     <ClInclude Include="..\src\game\default\g_ai_item.h" />
     <ClInclude Include="..\src\game\default\g_ai_main.h" />
     <ClInclude Include="..\src\game\default\g_ai_node.h" />
+    <ClInclude Include="..\src\game\default\grid.h" />
     <ClInclude Include="..\src\game\default\g_ai_types.h" />
     <ClInclude Include="..\src\game\default\g_ballistics.h" />
     <ClInclude Include="..\src\game\default\g_client.h" />
@@ -58,6 +59,7 @@
     <ClCompile Include="..\src\game\default\g_ai_item.c" />
     <ClCompile Include="..\src\game\default\g_ai_main.c" />
     <ClCompile Include="..\src\game\default\g_ai_node.c" />
+    <ClCompile Include="..\src\game\default\grid_ds.c" />
     <ClCompile Include="..\src\game\default\g_ballistics.c" />
     <ClCompile Include="..\src\game\default\g_client.c" />
     <ClCompile Include="..\src\game\default\g_client_chase.c" />

--- a/Quetoo.vs15/game.vcxproj.filters
+++ b/Quetoo.vs15/game.vcxproj.filters
@@ -96,6 +96,9 @@
     <ClInclude Include="..\src\game\default\g_ai_node.h">
       <Filter>src\default</Filter>
     </ClInclude>
+    <ClInclude Include="..\src\game\default\grid.h">
+      <Filter>src\default</Filter>
+    </ClInclude>
     <ClInclude Include="..\src\game\default\g_ai_types.h">
       <Filter>src\default</Filter>
     </ClInclude>
@@ -174,6 +177,9 @@
       <Filter>src\default</Filter>
     </ClCompile>
     <ClCompile Include="..\src\game\default\g_ai_node.c">
+      <Filter>src\default</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\game\default\grid_ds.c">
       <Filter>src\default</Filter>
     </ClCompile>
   </ItemGroup>

--- a/src/game/default/Makefile.am
+++ b/src/game/default/Makefile.am
@@ -7,6 +7,7 @@ noinst_HEADERS = \
 	g_ai_main.h \
 	g_ai_node.h \
 	g_ai_types.h \
+	grid.h \
 	g_ballistics.h \
 	g_client_chase.h \
 	g_client_stats.h \
@@ -67,6 +68,7 @@ game_la_SOURCES = \
 	g_ai_item.c \
 	g_ai_main.c \
 	g_ai_node.c \
+	grid_ds.c \
 	g_ballistics.c \
 	g_client_chase.c \
 	g_client_stats.c \

--- a/src/game/default/g_ai_node.c
+++ b/src/game/default/g_ai_node.c
@@ -1259,6 +1259,11 @@ void G_Ai_DeleteNodes(void) {
     g_array_set_size(g_ai_nodes, 0);
   }
 
+  if (g_ai_platforms) {
+    g_array_free(g_ai_platforms, true);
+    g_ai_platforms = NULL;
+  }
+
   G_Ai_Node_InvalidateSpatialIndex();
   G_Ai_Node_FreePathPool();
 }
@@ -1283,6 +1288,7 @@ void G_Ai_ShutdownNodes(void) {
 
   if (g_ai_platforms) {
     g_array_free(g_ai_platforms, true);
+    g_ai_platforms = NULL;
   }
 
   G_Ai_Node_InvalidateSpatialIndex();

--- a/src/game/default/g_ai_node.c
+++ b/src/game/default/g_ai_node.c
@@ -21,6 +21,33 @@
 
 #include "g_local.h"
 #include "bg_pmove.h"
+#include "grid.h"
+
+/**
+ * @brief Cached spatial acceleration structures for the navigation graph.
+ *
+ * The kd-tree accelerates G_Ai_Node_FindClosest queries (O(log n) average vs.
+ * the previous O(n) linear scan), and is rebuilt lazily after any mutation
+ * of the global node array.
+ */
+static struct gridkdtree_s *g_ai_nodes_kdtree = NULL;
+static vec3_t *g_ai_nodes_kdtree_positions = NULL;
+static guint g_ai_nodes_kdtree_count = 0;
+
+/**
+ * @brief Invalidates the cached kd-tree. Must be called whenever the
+ * underlying g_ai_nodes array is mutated (add/remove/move/reload).
+ */
+static void G_Ai_Node_InvalidateSpatialIndex(void) {
+  if (g_ai_nodes_kdtree) {
+    gridkdtree_free(&g_ai_nodes_kdtree);
+  }
+  if (g_ai_nodes_kdtree_positions) {
+    free(g_ai_nodes_kdtree_positions);
+    g_ai_nodes_kdtree_positions = NULL;
+  }
+  g_ai_nodes_kdtree_count = 0;
+}
 
 /**
  * @brief State used during player roam recording for AI node development.
@@ -92,6 +119,8 @@ static inline ai_node_id_t G_Ai_Node_Index(const ai_node_t *node) {
   return node - (ai_node_t *) g_ai_nodes->data;
 }
 
+static void G_Ai_Node_FreePathPool(void);
+
 /**
  * @brief Returns true if the given node is visible (unobstructed) from the specified position.
  */
@@ -109,22 +138,99 @@ guint G_Ai_Node_Count(void) {
 }
 
 /**
+ * @brief Lazily (re)builds the kd-tree spatial index over g_ai_nodes.
+ * Returns true on success. The index is invalidated whenever the node
+ * array is mutated (see G_Ai_Node_InvalidateSpatialIndex callers).
+ */
+static bool G_Ai_Node_EnsureSpatialIndex(void) {
+
+  if (!g_ai_nodes || g_ai_nodes->len == 0) {
+    return false;
+  }
+
+  if (g_ai_nodes_kdtree && g_ai_nodes_kdtree_count == g_ai_nodes->len) {
+    return true;
+  }
+
+  G_Ai_Node_InvalidateSpatialIndex();
+
+  const guint n = g_ai_nodes->len;
+  g_ai_nodes_kdtree_positions = malloc(sizeof(vec3_t) * n);
+  if (!g_ai_nodes_kdtree_positions) {
+    return false;
+  }
+
+  for (guint i = 0; i < n; i++) {
+    g_ai_nodes_kdtree_positions[i] = g_array_index(g_ai_nodes, ai_node_t, i).position;
+  }
+
+  g_ai_nodes_kdtree = gridkdtree_create(g_ai_nodes_kdtree_positions, n);
+  if (!g_ai_nodes_kdtree) {
+    free(g_ai_nodes_kdtree_positions);
+    g_ai_nodes_kdtree_positions = NULL;
+    return false;
+  }
+
+  g_ai_nodes_kdtree_count = n;
+  return true;
+}
+
+typedef struct {
+  vec3_t position;
+  bool only_visible;
+  bool prefer_level;
+} ai_node_query_filter_t;
+
+static bool G_Ai_Node_FindClosestFilter(const size_t nodenum, void *data, float *distance) {
+  const ai_node_query_filter_t *filter = data;
+  const ai_node_t *node = &g_array_index(g_ai_nodes, ai_node_t, nodenum);
+
+  vec3_t dir = Vec3_Subtract(filter->position, node->position);
+
+  if (filter->prefer_level && !(gi.PointContents(node->position) & CONTENTS_MASK_LIQUID)) {
+    dir.z *= 4.0f;
+  }
+
+  *distance = Vec3_LengthSquared(dir);
+
+  return !filter->only_visible || G_Ai_Node_Visible(filter->position, nodenum);
+}
+
+/**
  * @brief Finds the closest navigation node to the given position within the specified distance.
+ *
+ * Uses the cached kd-tree spatial index (built lazily) to gather candidate
+ * nodes within `max_distance` and selects the best one that passes the
+ * `only_visible` / `prefer_level` filters. Falls back to a linear scan if
+ * the spatial index is unavailable.
  */
 ai_node_id_t G_Ai_Node_FindClosest(const vec3_t position, const float max_distance, const bool only_visible, const bool prefer_level) {
 
-  if (!g_ai_nodes)
+  if (!g_ai_nodes || g_ai_nodes->len == 0) {
     return AI_NODE_INVALID;
+  }
 
   ai_node_id_t closest = AI_NODE_INVALID;
   float closest_dist = 0;
   const float dist_squared = max_distance * max_distance;
 
+  if (G_Ai_Node_EnsureSpatialIndex()) {
+    ai_node_query_filter_t filter = {
+      .position = position,
+      .only_visible = only_visible,
+      .prefer_level = prefer_level
+    };
+
+    const size_t node = gridkdtree_query_filter(g_ai_nodes_kdtree, position, max_distance, G_Ai_Node_FindClosestFilter, &filter);
+
+    return node == SIZE_MAX ? AI_NODE_INVALID : (ai_node_id_t) node;
+  }
+
+  // Fallback: linear scan (kd-tree build failed).
   for (guint i = 0; i < g_ai_nodes->len; i++) {
     const ai_node_t *node = &g_array_index(g_ai_nodes, ai_node_t, i);
 
     vec3_t dir = Vec3_Subtract(position, node->position);
-    // weigh the Z axis more heavily
     if (prefer_level && !(gi.PointContents(node->position) & CONTENTS_MASK_LIQUID)) {
       dir.z *= 4.0f;
     }
@@ -156,6 +262,8 @@ ai_node_id_t G_Ai_Node_Create(const vec3_t position) {
   g_ai_nodes = g_array_append_val(g_ai_nodes, (ai_node_t) {
     .position = position
   });
+
+  G_Ai_Node_InvalidateSpatialIndex();
 
   G_Ai_Debug("Dropped new node %d\n", g_ai_nodes->len - 1);
 
@@ -331,6 +439,8 @@ void G_Ai_Node_Destroy(const ai_node_id_t id) {
 
   G_Ai_Node_UnlinkAll(id);
   g_ai_nodes = g_array_remove_index(g_ai_nodes, id);
+
+  G_Ai_Node_InvalidateSpatialIndex();
 
   if (!g_ai_nodes->len) {
     g_array_free(g_ai_nodes, true);
@@ -967,6 +1077,8 @@ void G_Ai_InitNodes(void) {
   g_ai_nodes = g_array_sized_new(false, true, sizeof(ai_node_t), num_nodes);
   g_array_set_size(g_ai_nodes, num_nodes);
 
+  G_Ai_Node_InvalidateSpatialIndex();
+
   guint total_links = 0;
 
   for (guint i = 0; i < g_ai_nodes->len; i++) {
@@ -1132,6 +1244,9 @@ void G_Ai_DeleteNodes(void) {
 
     g_array_set_size(g_ai_nodes, 0);
   }
+
+  G_Ai_Node_InvalidateSpatialIndex();
+  G_Ai_Node_FreePathPool();
 }
 
 /**
@@ -1151,12 +1266,60 @@ void G_Ai_ShutdownNodes(void) {
     g_array_free(g_ai_nodes, true);
     g_ai_nodes = NULL;
   }
+
+  G_Ai_Node_InvalidateSpatialIndex();
+  G_Ai_Node_FreePathPool();
 }
 
 typedef struct {
   ai_node_id_t id;
   float priority;
 } ai_node_priority_t;
+
+static struct gheap_s *g_ai_node_path_queue;
+static ai_node_priority_t *g_ai_node_path_entries;
+static size_t g_ai_node_path_capacity;
+static size_t g_ai_node_path_count;
+
+static void G_Ai_Node_FreePathPool(void) {
+
+  gheap_free(&g_ai_node_path_queue);
+  free(g_ai_node_path_entries);
+  g_ai_node_path_entries = NULL;
+  g_ai_node_path_capacity = 0;
+  g_ai_node_path_count = 0;
+}
+
+static bool G_Ai_Node_EnsurePathPool(const size_t capacity) {
+
+  if (g_ai_node_path_queue && g_ai_node_path_capacity >= capacity) {
+    gheap_reset(g_ai_node_path_queue);
+    g_ai_node_path_count = 0;
+    return true;
+  }
+
+  G_Ai_Node_FreePathPool();
+
+  g_ai_node_path_queue = gheap_create(capacity);
+  g_ai_node_path_entries = malloc(sizeof(ai_node_priority_t) * capacity);
+
+  if (!g_ai_node_path_queue || !g_ai_node_path_entries) {
+    G_Ai_Node_FreePathPool();
+    return false;
+  }
+
+  g_ai_node_path_capacity = capacity;
+  return true;
+}
+
+static ai_node_priority_t *G_Ai_Node_AllocPathEntry(void) {
+
+  if (g_ai_node_path_count == g_ai_node_path_capacity) {
+    return NULL;
+  }
+
+  return &g_ai_node_path_entries[g_ai_node_path_count++];
+}
 
 #define AI_MAX_DROP_HEIGHT 512.f
 #define AI_DROP_PENALTY_START 128.f
@@ -1255,29 +1418,52 @@ GArray *G_Ai_Node_FindPath(const g_client_t *cl, const ai_node_id_t start, const
   });
 
   GHashTable *costs_started = g_hash_table_new(g_direct_hash, g_direct_equal);
-  GArray *queue = g_array_new(false, false, sizeof(ai_node_priority_t));
+  // Min-heap open set (priority = f-cost). Replaces the previous sorted-array
+  // queue (O(n) insertion) with an O(log n) binary heap from grid_ds.c.
+  // Capacity is bounded by the node count plus headroom for re-insertions
+  // (A* may push a better-cost duplicate before popping the stale one).
+  const size_t heap_capacity = (size_t) g_ai_nodes->len * 4 + 16;
+  if (!G_Ai_Node_EnsurePathPool(heap_capacity)) {
+    g_hash_table_destroy(costs_started);
+    if (platforms) {
+      g_array_free(platforms, true);
+    }
+    return NULL;
+  }
+
+  struct gheap_s *queue = g_ai_node_path_queue;
   bool finished = false;
 
-  queue = g_array_append_vals(queue, &(ai_node_priority_t) {
-    .id = start,
-    .priority = 0
-  }, 1);
+  {
+    ai_node_priority_t *e = G_Ai_Node_AllocPathEntry();
+    e->id = start;
+    e->priority = 0;
+    gheap_push(queue, e->priority, e);
+  }
 
   ai_node_t *start_node = &g_array_index(g_ai_nodes, ai_node_t, start);
   start_node->cost = 0;
   g_hash_table_add(costs_started, start_node);
 
-  while (queue->len) {
-    
-    ai_node_priority_t current = g_array_index(queue, ai_node_priority_t, queue->len - 1);
-    queue = g_array_remove_index_fast(queue, queue->len - 1);
+  for (;;) {
+    ai_node_priority_t *current = (ai_node_priority_t *) gheap_pop(queue);
+    if (!current) {
+      break;
+    }
 
-    if (current.id == end) {
+    if (current->id == end) {
       finished = true;
       break;
     }
 
-    ai_node_t *node = &g_array_index(g_ai_nodes, ai_node_t, current.id);
+    ai_node_t *node = &g_array_index(g_ai_nodes, ai_node_t, current->id);
+
+    // Stale entry guard: if this entry's priority is worse than the node's
+    // best-known f-cost approximation (cost + 0 heuristic lower bound), the
+    // node has already been processed via a better path.
+    if (current->priority > node->cost + heuristic(current->id, end) + 0.0001f) {
+      continue;
+    }
 
     if (!node->links || !node->links->len) {
       continue;
@@ -1354,30 +1540,21 @@ GArray *G_Ai_Node_FindPath(const g_client_t *cl, const ai_node_id_t start, const
         link_node->cost = new_cost;
         const float priority = new_cost + heuristic(link->id, end);
 
-        if (!queue->len) {
-          queue = g_array_insert_vals(queue, 0, &(ai_node_priority_t) {
-            .id = link->id,
-            .priority = priority
-          }, 1);
-        } else {
-          for (gint x = queue->len - 1; ; x--) {
+        ai_node_priority_t *e = G_Ai_Node_AllocPathEntry();
+        if (!e) {
+          gi.Warn("A* open-set entry pool exhausted (capacity %zu)\n", heap_capacity);
+          break;
+        }
 
-            if (priority < g_array_index(queue, ai_node_priority_t, x).priority) {
-              queue = g_array_insert_vals(queue, x + 1, &(ai_node_priority_t) {
-                .id = link->id,
-                .priority = priority
-              }, 1);
-              break;
-            }
-
-            if (x == 0) {
-              queue = g_array_insert_vals(queue, 0, &(ai_node_priority_t) {
-                .id = link->id,
-                .priority = priority
-              }, 1);
-              break;
-            }
-          }
+        e->id = link->id;
+        e->priority = priority;
+        // If the heap is somehow full (large maps with many revisits),
+        // fall back to allocating a larger one is overkill; we simply
+        // log and stop expanding from this node. The capacity heuristic
+        // above (4 * N + 16) is generous for typical Quetoo maps.
+        if (!gheap_push(queue, priority, e)) {
+          gi.Warn("A* open-set heap exhausted (capacity %zu)\n", heap_capacity);
+          break;
         }
 
         link_node->came_from = G_Ai_Node_Index(node);
@@ -1420,7 +1597,6 @@ GArray *G_Ai_Node_FindPath(const g_client_t *cl, const ai_node_id_t start, const
     G_Ai_Debug("Couldn't find path from %u -> %u\n", start, end);
   }
 
-  g_array_free(queue, true);
   g_hash_table_destroy(costs_started);
   if (platforms) {
     g_array_free(platforms, true);
@@ -1453,6 +1629,8 @@ void G_Ai_OffsetNodes_f(void) {
     ai_node_t *node = &g_array_index(g_ai_nodes, ai_node_t, i);
     node->position = Vec3_Add(node->position, translate);
   }
+
+  G_Ai_Node_InvalidateSpatialIndex();
 }
 
 /**

--- a/src/game/default/g_ai_node.c
+++ b/src/game/default/g_ai_node.c
@@ -1456,7 +1456,7 @@ GArray *G_Ai_Node_FindPath(const g_client_t *cl, const ai_node_id_t start, const
 
   ai_node_t *start_node = &g_array_index(g_ai_nodes, ai_node_t, start);
   start_node->cost = 0;
-  costs_started[start / 32] |= 1 << (start % 32);
+  costs_started[start / 32] |= (uint32_t)1 << (start % 32);
   visited++;
   // g_hash_table_add(costs_started, start_node);
 
@@ -1549,9 +1549,9 @@ GArray *G_Ai_Node_FindPath(const g_client_t *cl, const ai_node_id_t start, const
       const float new_cost = node->cost + link->cost + drop_penalty;
 
       ai_node_id_t link_index = G_Ai_Node_Index(link_node);
-      bool found = costs_started[link_index / 32] & (1 << (link_index % 32));
+      bool found = costs_started[link_index / 32] & ((uint32_t)1 << (link_index % 32));
       if (!found || new_cost < link_node->cost) {
-        costs_started[link_index / 32] |= 1 << (link_index % 32);
+        costs_started[link_index / 32] |= (uint32_t)1 << (link_index % 32);
         visited++;
 
         link_node->cost = new_cost;

--- a/src/game/default/g_ai_node.c
+++ b/src/game/default/g_ai_node.c
@@ -113,6 +113,11 @@ typedef struct {
 static GArray *g_ai_nodes;
 
 /**
+ * @brief The global array of platforms for the current map.
+ */
+static GArray *g_ai_platforms;
+
+/**
  * @brief Returns the index of a node pointer within the global node array.
  */
 static inline ai_node_id_t G_Ai_Node_Index(const ai_node_t *node) {
@@ -1171,6 +1176,15 @@ void G_Ai_NodesReady(void) {
   added_links -= g_ai_player_roam.file_links;
   gi.Print("  Game loaded %u additional nodes with %u new links.\n", added_nodes, added_links);
 
+  G_ForEachEntity(ent, {
+    if (ent->classname && strcmp(ent->classname, "func_plat") == 0) {
+      if (!g_ai_platforms) {
+        g_ai_platforms = g_array_new(false, false, sizeof(g_entity_t *));
+      }
+      g_ai_platforms = g_array_append_vals(g_ai_platforms, &ent, 1);
+    }
+  });
+
   /*if (g_ai_node_dev->integer != 1) {
     const guint optimized = Ai_OptimizeNodes();
     gi.Print("  %u nodes optimized\n", optimized);
@@ -1407,27 +1421,16 @@ GArray *G_Ai_Node_FindPath(const g_client_t *cl, const ai_node_id_t start, const
   
   // Pre-collect func_plat entities once so G_Ai_PlatformAccessible doesn't
   // call G_ForEachEntity for every link expansion inside the A* loop.
-  GArray *platforms = NULL;
-  G_ForEachEntity(ent, {
-    if (ent->classname && strcmp(ent->classname, "func_plat") == 0) {
-      if (!platforms) {
-        platforms = g_array_new(false, false, sizeof(g_entity_t *));
-      }
-      platforms = g_array_append_vals(platforms, &ent, 1);
-    }
-  });
 
-  GHashTable *costs_started = g_hash_table_new(g_direct_hash, g_direct_equal);
+  // size on 64k nodes is, say, 8kb.
+  uint32_t costs_started[g_ai_nodes->len / 32 + 1];
+  size_t visited = 0;
   // Min-heap open set (priority = f-cost). Replaces the previous sorted-array
   // queue (O(n) insertion) with an O(log n) binary heap from grid_ds.c.
   // Capacity is bounded by the node count plus headroom for re-insertions
   // (A* may push a better-cost duplicate before popping the stale one).
   const size_t heap_capacity = (size_t) g_ai_nodes->len * 4 + 16;
   if (!G_Ai_Node_EnsurePathPool(heap_capacity)) {
-    g_hash_table_destroy(costs_started);
-    if (platforms) {
-      g_array_free(platforms, true);
-    }
     return NULL;
   }
 
@@ -1443,7 +1446,9 @@ GArray *G_Ai_Node_FindPath(const g_client_t *cl, const ai_node_id_t start, const
 
   ai_node_t *start_node = &g_array_index(g_ai_nodes, ai_node_t, start);
   start_node->cost = 0;
-  g_hash_table_add(costs_started, start_node);
+  costs_started[start / 32] |= 1 << (start % 32);
+  visited++;
+  // g_hash_table_add(costs_started, start_node);
 
   for (;;) {
     ai_node_priority_t *current = (ai_node_priority_t *) gheap_pop(queue);
@@ -1481,10 +1486,10 @@ GArray *G_Ai_Node_FindPath(const g_client_t *cl, const ai_node_id_t start, const
       const bool to_hazard = (link_contents & (CONTENTS_LAVA | CONTENTS_SLIME)) != 0;
 
       // Check platform accessibility using the pre-collected list.
-      if (platforms) {
+      if (g_ai_platforms) {
         bool blocked = false;
-        for (guint p = 0; p < platforms->len; p++) {
-          const g_entity_t *plat = g_array_index(platforms, g_entity_t *, p);
+        for (guint p = 0; p < g_ai_platforms->len; p++) {
+          const g_entity_t *plat = g_array_index(g_ai_platforms, g_entity_t *, p);
           if (link_node->position.x < plat->abs_bounds.mins.x || link_node->position.x > plat->abs_bounds.maxs.x ||
               link_node->position.y < plat->abs_bounds.mins.y || link_node->position.y > plat->abs_bounds.maxs.y) {
             continue;
@@ -1533,9 +1538,11 @@ GArray *G_Ai_Node_FindPath(const g_client_t *cl, const ai_node_id_t start, const
 
       const float new_cost = node->cost + link->cost + drop_penalty;
 
-      if (!g_hash_table_lookup(costs_started, link_node) || new_cost < link_node->cost) {
-
-        g_hash_table_add(costs_started, link_node);
+      ai_node_id_t link_index = G_Ai_Node_Index(link_node);
+      bool found = costs_started[link_index / 32] & (1 << (link_index % 32));
+      if (!found || new_cost < link_node->cost) {
+        costs_started[link_index / 32] |= 1 << (link_index % 32);
+        visited++;
 
         link_node->cost = new_cost;
         const float priority = new_cost + heuristic(link->id, end);
@@ -1565,9 +1572,9 @@ GArray *G_Ai_Node_FindPath(const g_client_t *cl, const ai_node_id_t start, const
   GArray *return_path = NULL;
 
   if (finished) {
-    G_Ai_Debug("Found path from %u -> %u with %u nodes visited\n", start, end, g_hash_table_size(costs_started));
+    G_Ai_Debug("Found path from %u -> %u with %zu nodes visited\n", start, end, visited);
 
-    return_path = g_array_sized_new(false, false, sizeof(ai_node_id_t), g_hash_table_size(costs_started));
+    return_path = g_array_sized_new(false, false, sizeof(ai_node_id_t), visited);
 
     return_path = g_array_prepend_val(return_path, end);
 
@@ -1595,11 +1602,6 @@ GArray *G_Ai_Node_FindPath(const g_client_t *cl, const ai_node_id_t start, const
     }
   } else {
     G_Ai_Debug("Couldn't find path from %u -> %u\n", start, end);
-  }
-
-  g_hash_table_destroy(costs_started);
-  if (platforms) {
-    g_array_free(platforms, true);
   }
 
   return return_path;

--- a/src/game/default/g_ai_node.c
+++ b/src/game/default/g_ai_node.c
@@ -1281,6 +1281,10 @@ void G_Ai_ShutdownNodes(void) {
     g_ai_nodes = NULL;
   }
 
+  if (g_ai_platforms) {
+    g_array_free(g_ai_platforms, true);
+  }
+
   G_Ai_Node_InvalidateSpatialIndex();
   G_Ai_Node_FreePathPool();
 }
@@ -1423,7 +1427,7 @@ GArray *G_Ai_Node_FindPath(const g_client_t *cl, const ai_node_id_t start, const
   // call G_ForEachEntity for every link expansion inside the A* loop.
 
   // size on 64k nodes is, say, 8kb.
-  uint32_t costs_started[g_ai_nodes->len / 32 + 1];
+  uint32_t costs_started[g_ai_nodes->len / 32 + 1] = {};
   size_t visited = 0;
   // Min-heap open set (priority = f-cost). Replaces the previous sorted-array
   // queue (O(n) insertion) with an O(log n) binary heap from grid_ds.c.

--- a/src/game/default/grid.h
+++ b/src/game/default/grid.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include "g_local.h"
+
+typedef bool (*gridkdtree_filter_t)(size_t nodenum, void *data, float *distance);
+
+struct gheap_entry_s {
+  float cost;
+  void *data;
+};
+
+struct gheap_s {
+  size_t count;
+  size_t capacity;
+  struct gheap_entry_s entries[];
+};
+
+struct kdtree_node_s {
+  size_t nodenum;
+  struct kdtree_node_s *left;
+  struct kdtree_node_s *right;
+};
+
+struct gridkdtree_s {
+  size_t nodecount;
+  size_t capacity;
+  vec3_t *srcdata;
+  struct kdtree_node_s *root;
+  struct kdtree_node_s nodes[];
+};
+
+void gridkdtree_free(struct gridkdtree_s **tree);
+struct gridkdtree_s *gridkdtree_create(vec3_t *srcdata, size_t count);
+size_t gridkdtree_query_filter(struct gridkdtree_s *tree, const vec3_t querypos, float max_distance,
+                               gridkdtree_filter_t filter, void *data);
+
+struct gheap_s *gheap_create(size_t capacity);
+void gheap_free(struct gheap_s **heap);
+bool gheap_push(struct gheap_s *heap, float cost, void *data);
+void *gheap_pop(struct gheap_s *heap);
+void gheap_reset(struct gheap_s *heap);

--- a/src/game/default/grid.h
+++ b/src/game/default/grid.h
@@ -1,3 +1,24 @@
+/*
+* Copyright(c) 1997-2001 id Software, Inc.
+ * Copyright(c) 2002 The Quakeforge Project.
+ * Copyright(c) 2006 Quetoo.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
 #pragma once
 
 #include "g_local.h"

--- a/src/game/default/grid_ds.c
+++ b/src/game/default/grid_ds.c
@@ -1,3 +1,24 @@
+/*
+* Copyright(c) 1997-2001 id Software, Inc.
+ * Copyright(c) 2002 The Quakeforge Project.
+ * Copyright(c) 2006 Quetoo.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
 #include "g_local.h"
 #include "grid.h"
 

--- a/src/game/default/grid_ds.c
+++ b/src/game/default/grid_ds.c
@@ -1,0 +1,290 @@
+#include "g_local.h"
+#include "grid.h"
+
+void gridkdtree_free(struct gridkdtree_s **tree) {
+
+  if (!*tree) {
+    return;
+  }
+
+  free(*tree);
+  *tree = nullptr;
+}
+
+thread_local struct cmpstr_s {
+  uint8_t dim;
+  vec3_t *srcdata;
+} cmpstr;
+
+struct kdtbuildctx_s {
+  struct gridkdtree_s *tree;
+  int *sortedx;
+  size_t slicesize;
+};
+
+static int compare_v(const void *_l, const void *_r) {
+  const int l = *(const int *) _l;
+  const int r = *(const int *) _r;
+  const vec3_t *srcdata = cmpstr.srcdata;
+  const uint8_t dim = cmpstr.dim;
+
+  if (srcdata[l].xyz[dim] < srcdata[r].xyz[dim]) {
+    return -1;
+  }
+  if (srcdata[l].xyz[dim] > srcdata[r].xyz[dim]) {
+    return 1;
+  }
+
+  return 0;
+}
+
+static struct kdtree_node_s *gkdt_alloc_node(struct gridkdtree_s *tree) {
+
+  if (tree->nodecount < tree->capacity) {
+    return &tree->nodes[tree->nodecount++];
+  }
+
+  return nullptr;
+}
+
+static struct kdtree_node_s *kdtree_build(struct kdtbuildctx_s *ctx, const size_t dim) {
+
+  if (ctx->slicesize == 0) {
+    return nullptr;
+  }
+
+  cmpstr.srcdata = ctx->tree->srcdata;
+  cmpstr.dim = dim;
+  qsort(ctx->sortedx, ctx->slicesize, sizeof(ctx->sortedx[0]), compare_v);
+
+  struct kdtree_node_s *node = gkdt_alloc_node(ctx->tree);
+  const size_t mid = (ctx->slicesize - 1) / 2;
+  const size_t next_dim = (dim + 1) % 3;
+
+  node->nodenum = ctx->sortedx[mid];
+  node->left = kdtree_build(&(struct kdtbuildctx_s) {
+    .tree = ctx->tree,
+    .sortedx = ctx->sortedx,
+    .slicesize = mid
+  }, next_dim);
+  node->right = kdtree_build(&(struct kdtbuildctx_s) {
+    .tree = ctx->tree,
+    .sortedx = ctx->sortedx + mid + 1,
+    .slicesize = ctx->slicesize - mid - 1
+  }, next_dim);
+
+  return node;
+}
+
+struct gridkdtree_s *gridkdtree_create(vec3_t *srcdata, const size_t count) {
+  int *sortedx = malloc(count * sizeof(int));
+  const size_t capacity = count;
+  const size_t size = sizeof(struct gridkdtree_s) + capacity * sizeof(struct kdtree_node_s);
+  struct gridkdtree_s *tree = malloc(size);
+
+  if (!tree || !sortedx) {
+    free(tree);
+    free(sortedx);
+    return nullptr;
+  }
+
+  for (size_t i = 0; i < count; i++) {
+    sortedx[i] = i;
+  }
+
+  for (size_t i = 0; i < capacity; i++) {
+    tree->nodes[i].nodenum = SIZE_MAX;
+    tree->nodes[i].left = nullptr;
+    tree->nodes[i].right = nullptr;
+  }
+
+  tree->srcdata = srcdata;
+  tree->nodecount = 0;
+  tree->capacity = capacity;
+
+  tree->root = kdtree_build(&(struct kdtbuildctx_s) {
+    .tree = tree,
+    .sortedx = sortedx,
+    .slicesize = count
+  }, 0);
+
+  free(sortedx);
+  return tree;
+}
+struct kdtree_filter_ctx_s {
+  struct gridkdtree_s *tree;
+  vec3_t querypos;
+  double bestdist;
+  size_t best;
+  gridkdtree_filter_t filter;
+  void *data;
+};
+
+static void kdtree_query_filter_rec(struct kdtree_filter_ctx_s *ctx, const struct kdtree_node_s *node, const size_t dim) {
+
+  if (node == nullptr || node->nodenum == SIZE_MAX) {
+    return;
+  }
+
+  const vec3_t pos = ctx->tree->srcdata[node->nodenum];
+  float filter_dist = INFINITY;
+
+  if (ctx->filter(node->nodenum, ctx->data, &filter_dist) && filter_dist < ctx->bestdist) {
+    ctx->best = node->nodenum;
+    ctx->bestdist = filter_dist;
+  }
+
+  const double sdist = ctx->querypos.xyz[dim] - pos.xyz[dim];
+  const struct kdtree_node_s *near_node = sdist < 0 ? node->left : node->right;
+  const struct kdtree_node_s *far_node = sdist < 0 ? node->right : node->left;
+  const size_t next_dim = (dim + 1) % 3;
+
+  kdtree_query_filter_rec(ctx, near_node, next_dim);
+
+  if (sdist * sdist <= ctx->bestdist) {
+    kdtree_query_filter_rec(ctx, far_node, next_dim);
+  }
+}
+
+size_t gridkdtree_query_filter(struct gridkdtree_s *tree, const vec3_t querypos, const float max_distance,
+                               gridkdtree_filter_t filter, void *data) {
+
+  if (!tree || !tree->root || !filter || max_distance <= 0.f) {
+    return SIZE_MAX;
+  }
+
+  struct kdtree_filter_ctx_s ctx = {
+    .tree = tree,
+    .querypos = querypos,
+    .bestdist = (double) max_distance * max_distance,
+    .best = SIZE_MAX,
+    .filter = filter,
+    .data = data
+  };
+
+  kdtree_query_filter_rec(&ctx, tree->root, 0);
+  return ctx.best;
+}
+
+struct gheap_s *gheap_create(const size_t capacity) {
+  struct gheap_s *ret = malloc(sizeof(struct gheap_s) + sizeof(struct gheap_entry_s) * capacity);
+
+  if (ret == nullptr) {
+    return nullptr;
+  }
+
+  for (size_t i = 0; i < capacity; i++) {
+    ret->entries[i].cost = INFINITY;
+    ret->entries[i].data = nullptr;
+  }
+
+  ret->capacity = capacity;
+  ret->count = 0;
+  return ret;
+}
+
+void gheap_free(struct gheap_s **heap) {
+
+  if (!*heap) {
+    return;
+  }
+
+  free(*heap);
+  *heap = nullptr;
+}
+
+static void hswap(struct gheap_entry_s *a, struct gheap_entry_s *b) {
+  struct gheap_entry_s tmp = *a;
+  *a = *b;
+  *b = tmp;
+}
+
+bool gheap_push(struct gheap_s *heap, const float cost, void *data) {
+  assert(data != nullptr);
+
+  if (heap->count >= heap->capacity) {
+    return false;
+  }
+
+  heap->count++;
+  size_t i = heap->count - 1;
+  heap->entries[i].cost = cost;
+  heap->entries[i].data = data;
+
+  if (i == 0) {
+    return true;
+  }
+
+  while (i != 0) {
+    const size_t parent_index = (i - 1) / 2;
+    struct gheap_entry_s *parent = &heap->entries[parent_index];
+
+    if (heap->entries[i].cost < parent->cost) {
+      hswap(&heap->entries[i], parent);
+      i = parent_index;
+    } else {
+      break;
+    }
+  }
+
+  return true;
+}
+
+static float gheap_peek_cost(const struct gheap_s *heap, const size_t node) {
+
+  if (node >= heap->count) {
+    return INFINITY;
+  }
+
+  const struct gheap_entry_s *entry = &heap->entries[node];
+  return entry->cost;
+}
+
+static struct gheap_entry_s gheap_pop_inner(struct gheap_s *heap) {
+
+  if (heap->count == 0) {
+    return (struct gheap_entry_s) { INFINITY, nullptr };
+  }
+
+  const struct gheap_entry_s ret = heap->entries[0];
+  heap->count--;
+  heap->entries[0] = heap->entries[heap->count];
+
+  size_t node = 0;
+  for (;;) {
+    const size_t left = node * 2 + 1;
+    const size_t right = node * 2 + 2;
+
+    if (node >= heap->count) {
+      break;
+    }
+
+    struct gheap_entry_s *cur = &heap->entries[node];
+    size_t smallest = node;
+
+    if (left < heap->count && gheap_peek_cost(heap, left) < cur->cost) {
+      smallest = left;
+    }
+
+    if (right < heap->count && gheap_peek_cost(heap, right) < heap->entries[smallest].cost) {
+      smallest = right;
+    }
+
+    if (smallest == node) {
+      break;
+    }
+
+    hswap(cur, &heap->entries[smallest]);
+    node = smallest;
+  }
+
+  return ret;
+}
+
+void gheap_reset(struct gheap_s *heap) {
+  heap->count = 0;
+}
+
+void *gheap_pop(struct gheap_s *heap) {
+  return gheap_pop_inner(heap).data;
+}

--- a/src/game/default/grid_ds.c
+++ b/src/game/default/grid_ds.c
@@ -8,10 +8,10 @@ void gridkdtree_free(struct gridkdtree_s **tree) {
   }
 
   free(*tree);
-  *tree = nullptr;
+  *tree = NULL;
 }
 
-thread_local struct cmpstr_s {
+_Thread_local struct cmpstr_s {
   uint8_t dim;
   vec3_t *srcdata;
 } cmpstr;
@@ -44,13 +44,13 @@ static struct kdtree_node_s *gkdt_alloc_node(struct gridkdtree_s *tree) {
     return &tree->nodes[tree->nodecount++];
   }
 
-  return nullptr;
+  return NULL;
 }
 
 static struct kdtree_node_s *kdtree_build(struct kdtbuildctx_s *ctx, const size_t dim) {
 
   if (ctx->slicesize == 0) {
-    return nullptr;
+    return NULL;
   }
 
   cmpstr.srcdata = ctx->tree->srcdata;
@@ -85,7 +85,7 @@ struct gridkdtree_s *gridkdtree_create(vec3_t *srcdata, const size_t count) {
   if (!tree || !sortedx) {
     free(tree);
     free(sortedx);
-    return nullptr;
+    return NULL;
   }
 
   for (size_t i = 0; i < count; i++) {
@@ -94,8 +94,8 @@ struct gridkdtree_s *gridkdtree_create(vec3_t *srcdata, const size_t count) {
 
   for (size_t i = 0; i < capacity; i++) {
     tree->nodes[i].nodenum = SIZE_MAX;
-    tree->nodes[i].left = nullptr;
-    tree->nodes[i].right = nullptr;
+    tree->nodes[i].left = NULL;
+    tree->nodes[i].right = NULL;
   }
 
   tree->srcdata = srcdata;
@@ -122,7 +122,7 @@ struct kdtree_filter_ctx_s {
 
 static void kdtree_query_filter_rec(struct kdtree_filter_ctx_s *ctx, const struct kdtree_node_s *node, const size_t dim) {
 
-  if (node == nullptr || node->nodenum == SIZE_MAX) {
+  if (node == NULL || node->nodenum == SIZE_MAX) {
     return;
   }
 
@@ -169,13 +169,13 @@ size_t gridkdtree_query_filter(struct gridkdtree_s *tree, const vec3_t querypos,
 struct gheap_s *gheap_create(const size_t capacity) {
   struct gheap_s *ret = malloc(sizeof(struct gheap_s) + sizeof(struct gheap_entry_s) * capacity);
 
-  if (ret == nullptr) {
-    return nullptr;
+  if (ret == NULL) {
+    return NULL;
   }
 
   for (size_t i = 0; i < capacity; i++) {
     ret->entries[i].cost = INFINITY;
-    ret->entries[i].data = nullptr;
+    ret->entries[i].data = NULL;
   }
 
   ret->capacity = capacity;
@@ -190,7 +190,7 @@ void gheap_free(struct gheap_s **heap) {
   }
 
   free(*heap);
-  *heap = nullptr;
+  *heap = NULL;
 }
 
 static void hswap(struct gheap_entry_s *a, struct gheap_entry_s *b) {
@@ -200,7 +200,7 @@ static void hswap(struct gheap_entry_s *a, struct gheap_entry_s *b) {
 }
 
 bool gheap_push(struct gheap_s *heap, const float cost, void *data) {
-  assert(data != nullptr);
+  assert(data != NULL);
 
   if (heap->count >= heap->capacity) {
     return false;
@@ -243,7 +243,7 @@ static float gheap_peek_cost(const struct gheap_s *heap, const size_t node) {
 static struct gheap_entry_s gheap_pop_inner(struct gheap_s *heap) {
 
   if (heap->count == 0) {
-    return (struct gheap_entry_s) { INFINITY, nullptr };
+    return (struct gheap_entry_s) { INFINITY, NULL };
   }
 
   const struct gheap_entry_s ret = heap->entries[0];


### PR DESCRIPTION
This pull request introduces significant improvements to the AI navigation node system, focusing on performance and memory efficiency. The main changes include adding a spatial acceleration structure (kd-tree) for faster nearest-node queries, replacing linear scans with efficient heap-based data structures for A* pathfinding, and optimizing memory usage. Additionally, the changes improve resource management and maintainability by centralizing platform entity tracking and cleaning up memory when nodes are deleted or the game shuts down.

**AI Navigation System Performance and Memory Improvements:**

* Added a lazily-built kd-tree spatial index (from `grid_ds.c`) to accelerate `G_Ai_Node_FindClosest` queries from O(n) to O(log n) average case, with proper invalidation and rebuilding on node mutations (`src/game/default/g_ai_node.c`, `grid.h`, `grid_ds.c`, project files, and build scripts updated). [[1]](diffhunk://#diff-46ac9155f5ea0dd7133a9cb9663916072626c1c566f44206681af03888dc7680R24-R50) [[2]](diffhunk://#diff-46ac9155f5ea0dd7133a9cb9663916072626c1c566f44206681af03888dc7680R145-L127) [[3]](diffhunk://#diff-46ac9155f5ea0dd7133a9cb9663916072626c1c566f44206681af03888dc7680R271-R272) [[4]](diffhunk://#diff-46ac9155f5ea0dd7133a9cb9663916072626c1c566f44206681af03888dc7680R1085-R1086) [[5]](diffhunk://#diff-46ac9155f5ea0dd7133a9cb9663916072626c1c566f44206681af03888dc7680R1644-R1645) [[6]](diffhunk://#diff-e7f0ede19653dfe0bf02d8eb0fb49410edb5c7ea1d95b690d88b7ae069fc45efR30) [[7]](diffhunk://#diff-e7f0ede19653dfe0bf02d8eb0fb49410edb5c7ea1d95b690d88b7ae069fc45efR62) [[8]](diffhunk://#diff-faa3aa3b50e532f00dd514ce7c6cda736af436ac9b9bf4383aac67dfcb173338R99-R101) [[9]](diffhunk://#diff-faa3aa3b50e532f00dd514ce7c6cda736af436ac9b9bf4383aac67dfcb173338R182-R184) [[10]](diffhunk://#diff-6b93bf7467ddb085b48a17e876735c47bc107069bdf329bf1b618185acdb6f0eR10) [[11]](diffhunk://#diff-6b93bf7467ddb085b48a17e876735c47bc107069bdf329bf1b618185acdb6f0eR71)

* Rewrote the A* pathfinding open set to use a binary heap (from `grid_ds.c`) and a fixed-size entry pool, replacing GLib's dynamic hash tables and arrays for better performance and reduced allocations. Also replaced per-path platform entity collection with a global cached array. [[1]](diffhunk://#diff-46ac9155f5ea0dd7133a9cb9663916072626c1c566f44206681af03888dc7680R115-R128) [[2]](diffhunk://#diff-46ac9155f5ea0dd7133a9cb9663916072626c1c566f44206681af03888dc7680R1179-R1187) [[3]](diffhunk://#diff-46ac9155f5ea0dd7133a9cb9663916072626c1c566f44206681af03888dc7680L1247-R1481) [[4]](diffhunk://#diff-46ac9155f5ea0dd7133a9cb9663916072626c1c566f44206681af03888dc7680L1298-R1502)

**Resource Management and Cleanup:**

* Ensured proper cleanup of kd-tree, platform arrays, and pathfinding pools when nodes are deleted or the game shuts down, preventing memory leaks and stale state. [[1]](diffhunk://#diff-46ac9155f5ea0dd7133a9cb9663916072626c1c566f44206681af03888dc7680R1261-R1268) [[2]](diffhunk://#diff-46ac9155f5ea0dd7133a9cb9663916072626c1c566f44206681af03888dc7680R1288-R1347)

**Code Maintainability:**

* Centralized and clarified platform entity tracking for navigation, improving maintainability and reducing redundant entity searches during pathfinding. [[1]](diffhunk://#diff-46ac9155f5ea0dd7133a9cb9663916072626c1c566f44206681af03888dc7680R115-R128) [[2]](diffhunk://#diff-46ac9155f5ea0dd7133a9cb9663916072626c1c566f44206681af03888dc7680R1179-R1187) [[3]](diffhunk://#diff-46ac9155f5ea0dd7133a9cb9663916072626c1c566f44206681af03888dc7680L1298-R1502)

**Debugging and Diagnostics:**

* Updated debug output to reflect the new data structures and provide more accurate visited node counts.

These changes collectively make the AI navigation system more scalable and robust, especially on large maps with thousands of nodes.