### PR TITLE
Server cvars for player movement parameters (pm_params_t)

### DIFF
--- a/src/game/default/bg_pmove.c
+++ b/src/game/default/bg_pmove.c
@@ -369,25 +369,27 @@ static void Pm_Friction(const bool flying) {
     return;
   }
 
-  const float control = Maxf(PM_SPEED_STOP, speed);
+  const float control = Maxf(pm->s.params.speed_stop, speed);
 
   float friction = 0.f;
 
   if (pm->s.type == PM_SPECTATOR) { // spectator friction
-    friction = PM_FRICT_SPECTATOR;
+    friction = pm->s.params.friction_spectator;
   } else if (pm->s.flags & PMF_ON_LADDER) { // ladder friction
-    friction = PM_FRICT_LADDER;
+    friction = pm->s.params.friction_ladder;
   } else if (pm->water_level > WATER_FEET) { // water friction
-    friction = PM_FRICT_WATER;
+    friction = pm->s.params.friction_water;
   } else if (pm->s.flags & PMF_ON_GROUND) { // ground friction
     if (pm_locals.ground.ent && (pm_locals.ground.surface & SURF_SLICK)) {
-      friction = PM_FRICT_GROUND_SLICK;
+      friction = pm->s.params.friction_ground_slick;
     } else {
-      friction = PM_FRICT_GROUND;
+      friction = pm->s.params.friction_ground;
     }
   } else { // everything else friction
-    friction = PM_FRICT_AIR;
+    friction = pm->s.params.friction_air;
   }
+
+  friction = Maxf(0.f, friction); // never reverse direction
 
   // scale the velocity, taking care to not reverse direction
   const float scale = Maxf(0.f, speed - (friction * control * pm_locals.time)) / speed;
@@ -424,10 +426,10 @@ static void Pm_Gravity(void) {
     return;
   }
 
-  float gravity = pm->s.gravity;
+  float gravity = pm->s.params.gravity;
 
   if (pm->water_level > WATER_WAIST) {
-    gravity *= PM_GRAVITY_WATER;
+    gravity *= pm->s.params.gravity_water;
   }
 
   pm->s.velocity.z -= gravity * pm_locals.time;
@@ -781,12 +783,13 @@ static void Pm_CheckDuck(void) {
     }
 
     const float height = Box3_Size(pm->bounds).z;
+    const float duck_stand_speed = Maxf(0.f, pm->s.params.speed_duck_stand); // never reverse the transition
 
     if (pm->s.flags & PMF_DUCKED) { // ducked, reduce height
       const float target = pm->bounds.mins.z + height * 0.5f;
 
       if (pm->s.view_offset.z > target) { // go down
-        pm->s.view_offset.z -= pm_locals.time * PM_SPEED_DUCK_STAND;
+        pm->s.view_offset.z -= pm_locals.time * duck_stand_speed;
       }
 
       if (pm->s.view_offset.z < target) {
@@ -799,7 +802,7 @@ static void Pm_CheckDuck(void) {
       const float target = pm->bounds.mins.z + height * 0.9f;
 
       if (pm->s.view_offset.z < target) { // go up
-        pm->s.view_offset.z += pm_locals.time * PM_SPEED_DUCK_STAND;
+        pm->s.view_offset.z += pm_locals.time * duck_stand_speed;
       }
 
       if (pm->s.view_offset.z > target) {
@@ -838,7 +841,7 @@ static bool Pm_CheckJump(void) {
   }
 
   // finally, do the jump
-  float jump = PM_SPEED_JUMP;
+  float jump = Maxf(0.f, pm->s.params.speed_jump);
 
   // factoring in water level
   if (pm->water_level > WATER_FEET) {
@@ -951,7 +954,7 @@ static bool Pm_CheckWaterJump(void) {
     }
 
     // jump out of water
-    pm->s.velocity.z = PM_SPEED_WATER_JUMP;
+    pm->s.velocity.z = Maxf(0.f, pm->s.params.speed_water_jump);
 
     pm->s.flags |= PMF_TIME_WATER_JUMP | PMF_JUMP_HELD;
     pm->s.time = 2000;
@@ -973,12 +976,15 @@ static void Pm_LadderMove(void) {
 
   Pm_Currents();
 
+  const float ladder_speed = Maxf(0.f, pm->s.params.speed_ladder);
+  const float ladder_accel = Maxf(0.f, pm->s.params.accel_ladder);
+
   // user intentions in X/Y
   vec3_t vel = Vec3_Zero();
   vel = Vec3_Fmaf(vel, pm->cmd.forward, pm_locals.forward_xy);
   vel = Vec3_Fmaf(vel, pm->cmd.right, pm_locals.right_xy);
 
-  const float s = PM_SPEED_LADDER * 0.125f;
+  const float s = ladder_speed * 0.125f;
 
   // limit horizontal speed when on a ladder
   vel.x = Clampf(vel.x, -s, s);
@@ -986,16 +992,16 @@ static void Pm_LadderMove(void) {
   vel.z = 0.f;
 
   // handle Z intentions differently
-  if (fabsf(pm->s.velocity.z) < PM_SPEED_LADDER) {
+  if (fabsf(pm->s.velocity.z) < ladder_speed) {
 
     if ((pm->angles.x <= -15.f) && (pm->cmd.forward > 0)) {
-      vel.z = PM_SPEED_LADDER;
+      vel.z = ladder_speed;
     } else if ((pm->angles.x >= 15.f) && (pm->cmd.forward > 0)) {
-      vel.z = -PM_SPEED_LADDER;
+      vel.z = -ladder_speed;
     } else if (pm->cmd.up > 0) {
-      vel.z = PM_SPEED_LADDER;
+      vel.z = ladder_speed;
     } else if (pm->cmd.up < 0) {
-      vel.z = -PM_SPEED_LADDER;
+      vel.z = -ladder_speed;
     } else {
       vel.z = 0.f;
     }
@@ -1007,13 +1013,13 @@ static void Pm_LadderMove(void) {
 
   float speed;
   const vec3_t dir = Vec3_NormalizeLength(vel, &speed);
-  speed = Clampf(speed, 0.f, PM_SPEED_LADDER);
+  speed = Clampf(speed, 0.f, ladder_speed);
 
   if (speed < PM_STOP_EPSILON) {
     speed = 0.f;
   }
 
-  Pm_Accelerate(dir, speed, PM_ACCEL_LADDER);
+  Pm_Accelerate(dir, speed, ladder_accel);
 
   Pm_StepSlideMove();
 }
@@ -1034,7 +1040,7 @@ static void Pm_WaterJumpMove(void) {
 
   // if we've reached a usable spot, clamp the jump to avoid launching
   if (Pm_Trace(pm->s.origin, pos, pm->bounds).fraction == 1.f) {
-    pm->s.velocity.z = Clampf(pm->s.velocity.z, 0.f, PM_SPEED_JUMP);
+    pm->s.velocity.z = Clampf(pm->s.velocity.z, 0.f, Maxf(0.f, pm->s.params.speed_jump));
   }
 
   // if we're falling back down, clear the timer to regain control
@@ -1058,10 +1064,12 @@ static void Pm_WaterMove(void) {
 
   Pm_Debug("%s\n", vtos(pm->s.origin));
 
+  const float water_speed = Maxf(1.f, pm->s.params.speed_water); // also a loop divisor below
+
   // apply friction, slowing rapidly when first entering the water
   float speed = Vec3_Length(pm->s.velocity);
 
-  for (int32_t i = speed / PM_SPEED_WATER; i >= 0; i--) {
+  for (int32_t i = speed / water_speed; i >= 0; i--) {
     Pm_Friction(true);
   }
 
@@ -1096,13 +1104,13 @@ static void Pm_WaterMove(void) {
   }
 
   const vec3_t dir = Vec3_NormalizeLength(vel, &speed);
-  speed = Clampf(speed, 0, PM_SPEED_WATER);
+  speed = Clampf(speed, 0, water_speed);
 
   if (speed < PM_STOP_EPSILON) {
     speed = 0.f;
   }
 
-  Pm_Accelerate(dir, speed, PM_ACCEL_WATER);
+  Pm_Accelerate(dir, speed, Maxf(0.f, pm->s.params.accel_water));
 
   if (pm->cmd.up > 0) {
     Pm_SlideMove();
@@ -1127,7 +1135,7 @@ static void Pm_AirMove(void) {
   vel = Vec3_Fmaf(vel, pm->cmd.right, pm_locals.right_xy);
   vel.z = 0.f;
 
-  float max_speed = PM_SPEED_AIR;
+  float max_speed = Maxf(1.f, pm->s.params.speed_air); // air_speed must stay positive to bound the wish-speed
 
   // accounting for walk modulus
   if (pm->cmd.buttons & BUTTON_WALK) {
@@ -1142,7 +1150,7 @@ static void Pm_AirMove(void) {
     speed = 0.f;
   }
 
-  float accel = PM_ACCEL_AIR;
+  float accel = Maxf(0.f, pm->s.params.accel_air);
 
   if (pm->s.flags & PMF_DUCKED) {
     accel *= PM_ACCEL_AIR_MOD_DUCKED;
@@ -1194,12 +1202,14 @@ static void Pm_WalkMove(void) {
 
   // clamp to max speed
   if (pm->water_level > WATER_FEET) {
-    max_speed = PM_SPEED_WATER;
+    max_speed = pm->s.params.speed_water;
   } else if (pm->s.flags & PMF_DUCKED) {
-    max_speed = PM_SPEED_DUCKED;
+    max_speed = pm->s.params.speed_ducked;
   } else {
-    max_speed = PM_SPEED_RUN;
+    max_speed = pm->s.params.speed_ground;
   }
+
+  max_speed = Maxf(0.f, max_speed); // keep the Clampf range valid
 
   // accounting for walk modulus
   if (pm->cmd.buttons & BUTTON_WALK) {
@@ -1216,7 +1226,8 @@ static void Pm_WalkMove(void) {
   }
 
   // accelerate based on slickness of ground surface
-  const float accel = (pm_locals.ground.surface & SURF_SLICK) ? PM_ACCEL_GROUND_SLICK : PM_ACCEL_GROUND;
+  const float accel = Maxf(0.f, (pm_locals.ground.surface & SURF_SLICK)
+      ? pm->s.params.accel_ground_slick : pm->s.params.accel_ground);
 
   Pm_Accelerate(dir, speed, accel);
 
@@ -1250,14 +1261,14 @@ static void Pm_SpectatorMove(void) {
 
   float speed;
   vel = Vec3_NormalizeLength(vel, &speed);
-  speed = Clampf(speed, 0.f, PM_SPEED_SPECTATOR);
+  speed = Clampf(speed, 0.f, Maxf(0.f, pm->s.params.speed_spectator));
 
   if (speed < PM_STOP_EPSILON) {
     speed = 0.f;
   }
 
   // accelerate
-  Pm_Accelerate(vel, speed, PM_ACCEL_SPECTATOR);
+  Pm_Accelerate(vel, speed, Maxf(0.f, pm->s.params.accel_spectator));
 
   // do the move
   pm->s.origin = Vec3_Fmaf(pm->s.origin, pm_locals.time, pm->s.velocity);

--- a/src/game/default/g_client.c
+++ b/src/game/default/g_client.c
@@ -1613,8 +1613,9 @@ static void G_ClientMove(g_client_t *cl, pm_cmd_t *cmd) {
     cl->ps.pm_state.type = PM_NORMAL;
   }
 
-  // copy the current gravity in
-  cl->ps.pm_state.gravity = g_level.gravity;
+  // hydrate the current movement parameters (gravity, accel, friction, speeds);
+  // a class-based mod could override fields here for per-player physics
+  cl->ps.pm_state.params = G_MovementParams();
 
   pm_move_t pm;
   memset(&pm, 0, sizeof(pm));

--- a/src/game/default/g_main.c
+++ b/src/game/default/g_main.c
@@ -146,7 +146,32 @@ cvar_t *g_hook_style;
 cvar_t *g_frag_limit;
 cvar_t *g_friendly_fire;
 cvar_t *g_gameplay;
+
+// player movement parameters (hydrated into pm_params_t by G_MovementParams)
+cvar_t *g_air_acceleration;
+cvar_t *g_air_friction;
+cvar_t *g_air_speed;
+cvar_t *g_duck_speed;
+cvar_t *g_duck_stand_speed;
 cvar_t *g_gravity;
+cvar_t *g_ground_acceleration;
+cvar_t *g_ground_acceleration_slick;
+cvar_t *g_ground_friction;
+cvar_t *g_ground_friction_slick;
+cvar_t *g_ground_speed;
+cvar_t *g_jump_speed;
+cvar_t *g_ladder_acceleration;
+cvar_t *g_ladder_friction;
+cvar_t *g_ladder_speed;
+cvar_t *g_spectator_acceleration;
+cvar_t *g_spectator_friction;
+cvar_t *g_spectator_speed;
+cvar_t *g_stop_speed;
+cvar_t *g_water_acceleration;
+cvar_t *g_water_friction;
+cvar_t *g_water_gravity;
+cvar_t *g_water_jump_speed;
+cvar_t *g_water_speed;
 cvar_t *g_motd;
 cvar_t *g_num_teams;
 cvar_t *g_password;
@@ -557,6 +582,44 @@ static char *G_FormatTime(uint32_t time) {
 }
 
 /**
+ * @brief Factory for `pm_params_t`, hydrated fresh from the g_* movement cvars at
+ * each `Pm_Move` call site. Gravity carries map/worldspawn precedence, so it is
+ * taken from `g_level`. Values are passed through verbatim; `Pm_Move` performs all
+ * sanitization (clamping, divide-by-zero guards).
+ */
+pm_params_t G_MovementParams(void) {
+  return (pm_params_t) {
+    .gravity = g_level.gravity,
+    .gravity_water = g_water_gravity->value,
+
+    .accel_ground = g_ground_acceleration->value,
+    .accel_ground_slick = g_ground_acceleration_slick->value,
+    .accel_air = g_air_acceleration->value,
+    .accel_water = g_water_acceleration->value,
+    .accel_spectator = g_spectator_acceleration->value,
+    .accel_ladder = g_ladder_acceleration->value,
+
+    .friction_ground = g_ground_friction->value,
+    .friction_ground_slick = g_ground_friction_slick->value,
+    .friction_air = g_air_friction->value,
+    .friction_water = g_water_friction->value,
+    .friction_spectator = g_spectator_friction->value,
+    .friction_ladder = g_ladder_friction->value,
+
+    .speed_ground = g_ground_speed->value,
+    .speed_air = g_air_speed->value,
+    .speed_water = g_water_speed->value,
+    .speed_ladder = g_ladder_speed->value,
+    .speed_spectator = g_spectator_speed->value,
+    .speed_stop = g_stop_speed->value,
+    .speed_jump = g_jump_speed->value,
+    .speed_ducked = g_duck_speed->value,
+    .speed_duck_stand = g_duck_stand_speed->value,
+    .speed_water_jump = g_water_jump_speed->value,
+  };
+}
+
+/**
  * @brief Inspects and enforces gameplay rules each server frame, including frag/capture/time
  * limits and live cvar-driven gameplay changes.
  */
@@ -677,7 +740,7 @@ static void G_CheckRules(void) {
     gi.BroadcastPrint(PRINT_HIGH, "Hook style has been changed to %s\n", g_hook_style->string);
   }
 
-  if (g_gravity->modified) { // set gravity, G_ClientMove will read it
+  if (g_gravity->modified) { // G_MovementParams() reads g_level.gravity each move
     g_gravity->modified = false;
 
     g_level.gravity = g_gravity->integer;
@@ -1059,7 +1122,33 @@ void G_Init(void) {
   g_frag_limit = gi.AddCvar("g_frag_limit", "30", CVAR_SERVER_INFO, "The frag limit per level.");
   g_friendly_fire = gi.AddCvar("g_friendly_fire", "1", CVAR_SERVER_INFO, "Factor of how much damage can be dealt to teammates.");
   g_gameplay = gi.AddCvar("g_gameplay", "default", CVAR_SERVER_INFO, "Selects deathmatch, instagib or arena combat.");
+
+  // player movement parameters (hydrated into pm_params_t by G_MovementParams)
+  g_air_acceleration = gi.AddCvar("g_air_acceleration", "2.0", 0, "Acceleration applied while airborne. Default 2.0; set 0 for classic-Quake2 movement.");
+  g_air_friction = gi.AddCvar("g_air_friction", "0.125", 0, "Friction applied while airborne. Default 0.125; set 0 to remove air drag.");
+  g_air_speed = gi.AddCvar("g_air_speed", "350", 0, "Wish-speed cap while airborne. Default 350.");
+  g_duck_speed = gi.AddCvar("g_duck_speed", "140.0", 0, "Maximum ground speed while ducked. Default 140.0.");
+  g_duck_stand_speed = gi.AddCvar("g_duck_stand_speed", "200.0", 0, "Rate the view rises/falls when standing/ducking. Default 200.0.");
   g_gravity = gi.AddCvar("g_gravity", "800", CVAR_SERVER_INFO, NULL);
+  g_ground_acceleration = gi.AddCvar("g_ground_acceleration", "10.0", 0, "Ground acceleration. Default 10.0.");
+  g_ground_acceleration_slick = gi.AddCvar("g_ground_acceleration_slick", "4.375", 0, "Ground acceleration on slick surfaces. Default 4.375.");
+  g_ground_friction = gi.AddCvar("g_ground_friction", "6.0", 0, "Ground friction. Default 6.0.");
+  g_ground_friction_slick = gi.AddCvar("g_ground_friction_slick", "2.0", 0, "Ground friction on slick surfaces. Default 2.0.");
+  g_ground_speed = gi.AddCvar("g_ground_speed", "300.0", 0, "Maximum ground running speed. Default 300.0.");
+  g_jump_speed = gi.AddCvar("g_jump_speed", "270.0", 0, "Upward velocity imparted by a jump. Default 270.0.");
+  g_ladder_acceleration = gi.AddCvar("g_ladder_acceleration", "16.0", 0, "Acceleration while on ladders. Default 16.0.");
+  g_ladder_friction = gi.AddCvar("g_ladder_friction", "5.0", 0, "Friction while on ladders. Default 5.0.");
+  g_ladder_speed = gi.AddCvar("g_ladder_speed", "125.0", 0, "Maximum ladder-climbing speed. Default 125.0.");
+  g_spectator_acceleration = gi.AddCvar("g_spectator_acceleration", "2.5", 0, "Spectator free-fly acceleration. Default 2.5.");
+  g_spectator_friction = gi.AddCvar("g_spectator_friction", "2.5", 0, "Spectator free-fly friction. Default 2.5.");
+  g_spectator_speed = gi.AddCvar("g_spectator_speed", "500.0", 0, "Maximum spectator free-fly speed. Default 500.0.");
+  g_stop_speed = gi.AddCvar("g_stop_speed", "100.0", 0, "Speed below which friction is amplified to stop the player. Default 100.0.");
+  g_water_acceleration = gi.AddCvar("g_water_acceleration", "3.0", 0, "Acceleration applied underwater. Default 3.0.");
+  g_water_friction = gi.AddCvar("g_water_friction", "2.0", 0, "Friction applied underwater. Default 2.0.");
+  g_water_gravity = gi.AddCvar("g_water_gravity", "0.33", 0, "Fraction of gravity applied underwater. Default 0.33.");
+  g_water_jump_speed = gi.AddCvar("g_water_jump_speed", "420.0", 0, "Upward velocity when jumping out of water. Default 420.0.");
+  g_water_speed = gi.AddCvar("g_water_speed", "140.0", 0, "Maximum swimming speed. Default 140.0.");
+
   g_num_teams = gi.AddCvar("g_num_teams", "default", CVAR_SERVER_INFO, "The number of teams allowed. By default, picks the valid amount for the map, or 2.");
   g_motd = gi.AddCvar("g_motd", "", CVAR_SERVER_INFO, "Message of the day, shown to clients on initial connect.");
   g_password = gi.AddCvar("g_password", "", CVAR_USER_INFO, "The server password.");

--- a/src/game/default/g_main.h
+++ b/src/game/default/g_main.h
@@ -28,6 +28,8 @@
 extern g_level_t g_level;
 extern g_media_t g_media;
 
+pm_params_t G_MovementParams(void);
+
 extern g_import_t gi;
 extern g_export_t ge;
 
@@ -149,7 +151,32 @@ extern cvar_t *g_hook_style;
 extern cvar_t *g_frag_limit;
 extern cvar_t *g_friendly_fire;
 extern cvar_t *g_gameplay;
+
+// player movement parameters (hydrated into pm_params_t by G_MovementParams)
+extern cvar_t *g_air_acceleration;
+extern cvar_t *g_air_friction;
+extern cvar_t *g_air_speed;
+extern cvar_t *g_duck_speed;
+extern cvar_t *g_duck_stand_speed;
 extern cvar_t *g_gravity;
+extern cvar_t *g_ground_acceleration;
+extern cvar_t *g_ground_acceleration_slick;
+extern cvar_t *g_ground_friction;
+extern cvar_t *g_ground_friction_slick;
+extern cvar_t *g_ground_speed;
+extern cvar_t *g_jump_speed;
+extern cvar_t *g_ladder_acceleration;
+extern cvar_t *g_ladder_friction;
+extern cvar_t *g_ladder_speed;
+extern cvar_t *g_spectator_acceleration;
+extern cvar_t *g_spectator_friction;
+extern cvar_t *g_spectator_speed;
+extern cvar_t *g_stop_speed;
+extern cvar_t *g_water_acceleration;
+extern cvar_t *g_water_friction;
+extern cvar_t *g_water_gravity;
+extern cvar_t *g_water_jump_speed;
+extern cvar_t *g_water_speed;
 extern cvar_t *g_num_teams;
 extern cvar_t *g_motd;
 extern cvar_t *g_password;

--- a/src/game/default/g_types.h
+++ b/src/game/default/g_types.h
@@ -29,7 +29,7 @@
  * @brief Game protocol version (protocol minor version). To be incremented
  * whenever the game protocol changes.
  */
-#define PROTOCOL_MINOR 1041
+#define PROTOCOL_MINOR 1043
 
 /**
  * @brief Game-specific server protocol commands. These are parsed directly by
@@ -835,7 +835,8 @@ typedef struct {
   char name[MAX_QPATH];
 
   /**
-   * @brief Gravity override.
+   * @brief Resolved world gravity (maps.lst / worldspawn / g_gravity). Seeded at
+   * spawn and on cvar change; hydrated into pm_params_t by G_MovementParams().
    */
   int16_t gravity;
 

--- a/src/net/net_message.c
+++ b/src/net/net_message.c
@@ -245,7 +245,7 @@ void Net_WriteDeltaMoveCmd(mem_buf_t *msg, const pm_cmd_t *from, const pm_cmd_t 
  */
 void Net_WriteDeltaPlayerState(mem_buf_t *msg, const player_state_t *from, const player_state_t *to) {
 
-  uint16_t bits = 0;
+  uint32_t bits = 0;
 
   if (to->client != from->client) {
     bits |= PS_PM_CLIENT;
@@ -275,7 +275,7 @@ void Net_WriteDeltaPlayerState(mem_buf_t *msg, const player_state_t *from, const
     bits |= PS_PM_TIME;
   }
 
-  if (to->pm_state.gravity != from->pm_state.gravity) {
+  if (to->pm_state.params.gravity != from->pm_state.params.gravity) {
     bits |= PS_PM_GRAVITY;
   }
 
@@ -303,7 +303,12 @@ void Net_WriteDeltaPlayerState(mem_buf_t *msg, const player_state_t *from, const
     bits |= PS_PM_STEP_OFFSET;
   }
 
-  Net_WriteShort(msg, bits);
+  if (memcmp(&to->pm_state.params.gravity_water, &from->pm_state.params.gravity_water,
+             sizeof(pm_params_t) - offsetof(pm_params_t, gravity_water)) != 0) {
+    bits |= PS_PM_PARAMS;
+  }
+
+  Net_WriteLong(msg, bits);
 
   if (bits & PS_PM_CLIENT) {
     Net_WriteByte(msg, to->client);
@@ -334,7 +339,7 @@ void Net_WriteDeltaPlayerState(mem_buf_t *msg, const player_state_t *from, const
   }
 
   if (bits & PS_PM_GRAVITY) {
-    Net_WriteShort(msg, to->pm_state.gravity);
+    Net_WriteShort(msg, to->pm_state.params.gravity);
   }
 
   if (bits & PS_PM_VIEW_OFFSET) {
@@ -359,6 +364,32 @@ void Net_WriteDeltaPlayerState(mem_buf_t *msg, const player_state_t *from, const
 
   if (bits & PS_PM_STEP_OFFSET) {
     Net_WriteFloat(msg, to->pm_state.step_offset);
+  }
+
+  if (bits & PS_PM_PARAMS) {
+    Net_WriteFloat(msg, to->pm_state.params.gravity_water);
+    Net_WriteFloat(msg, to->pm_state.params.accel_ground);
+    Net_WriteFloat(msg, to->pm_state.params.accel_ground_slick);
+    Net_WriteFloat(msg, to->pm_state.params.accel_air);
+    Net_WriteFloat(msg, to->pm_state.params.accel_water);
+    Net_WriteFloat(msg, to->pm_state.params.accel_spectator);
+    Net_WriteFloat(msg, to->pm_state.params.accel_ladder);
+    Net_WriteFloat(msg, to->pm_state.params.friction_ground);
+    Net_WriteFloat(msg, to->pm_state.params.friction_ground_slick);
+    Net_WriteFloat(msg, to->pm_state.params.friction_air);
+    Net_WriteFloat(msg, to->pm_state.params.friction_water);
+    Net_WriteFloat(msg, to->pm_state.params.friction_spectator);
+    Net_WriteFloat(msg, to->pm_state.params.friction_ladder);
+    Net_WriteFloat(msg, to->pm_state.params.speed_ground);
+    Net_WriteFloat(msg, to->pm_state.params.speed_air);
+    Net_WriteFloat(msg, to->pm_state.params.speed_water);
+    Net_WriteFloat(msg, to->pm_state.params.speed_ladder);
+    Net_WriteFloat(msg, to->pm_state.params.speed_spectator);
+    Net_WriteFloat(msg, to->pm_state.params.speed_stop);
+    Net_WriteFloat(msg, to->pm_state.params.speed_jump);
+    Net_WriteFloat(msg, to->pm_state.params.speed_ducked);
+    Net_WriteFloat(msg, to->pm_state.params.speed_duck_stand);
+    Net_WriteFloat(msg, to->pm_state.params.speed_water_jump);
   }
 
   uint32_t stat_bits = 0;
@@ -795,7 +826,7 @@ void Net_ReadDeltaPlayerState(mem_buf_t *msg, const player_state_t *from, player
 
   *to = *from;
 
-  const uint16_t bits = Net_ReadShort(msg);
+  const uint32_t bits = Net_ReadLong(msg);
 
   if (bits & PS_PM_CLIENT) {
     to->client = Net_ReadByte(msg);
@@ -826,7 +857,7 @@ void Net_ReadDeltaPlayerState(mem_buf_t *msg, const player_state_t *from, player
   }
 
   if (bits & PS_PM_GRAVITY) {
-    to->pm_state.gravity = Net_ReadShort(msg);
+    to->pm_state.params.gravity = Net_ReadShort(msg);
   }
 
   if (bits & PS_PM_VIEW_OFFSET) {
@@ -851,6 +882,32 @@ void Net_ReadDeltaPlayerState(mem_buf_t *msg, const player_state_t *from, player
 
   if (bits & PS_PM_STEP_OFFSET) {
     to->pm_state.step_offset = Net_ReadFloat(msg);
+  }
+
+  if (bits & PS_PM_PARAMS) {
+    to->pm_state.params.gravity_water = Net_ReadFloat(msg);
+    to->pm_state.params.accel_ground = Net_ReadFloat(msg);
+    to->pm_state.params.accel_ground_slick = Net_ReadFloat(msg);
+    to->pm_state.params.accel_air = Net_ReadFloat(msg);
+    to->pm_state.params.accel_water = Net_ReadFloat(msg);
+    to->pm_state.params.accel_spectator = Net_ReadFloat(msg);
+    to->pm_state.params.accel_ladder = Net_ReadFloat(msg);
+    to->pm_state.params.friction_ground = Net_ReadFloat(msg);
+    to->pm_state.params.friction_ground_slick = Net_ReadFloat(msg);
+    to->pm_state.params.friction_air = Net_ReadFloat(msg);
+    to->pm_state.params.friction_water = Net_ReadFloat(msg);
+    to->pm_state.params.friction_spectator = Net_ReadFloat(msg);
+    to->pm_state.params.friction_ladder = Net_ReadFloat(msg);
+    to->pm_state.params.speed_ground = Net_ReadFloat(msg);
+    to->pm_state.params.speed_air = Net_ReadFloat(msg);
+    to->pm_state.params.speed_water = Net_ReadFloat(msg);
+    to->pm_state.params.speed_ladder = Net_ReadFloat(msg);
+    to->pm_state.params.speed_spectator = Net_ReadFloat(msg);
+    to->pm_state.params.speed_stop = Net_ReadFloat(msg);
+    to->pm_state.params.speed_jump = Net_ReadFloat(msg);
+    to->pm_state.params.speed_ducked = Net_ReadFloat(msg);
+    to->pm_state.params.speed_duck_stand = Net_ReadFloat(msg);
+    to->pm_state.params.speed_water_jump = Net_ReadFloat(msg);
   }
 
   const int32_t stat_bits = Net_ReadLong(msg);

--- a/src/net/net_message.h
+++ b/src/net/net_message.h
@@ -40,6 +40,7 @@
 #define PS_PM_HOOK_POSITION (1 << 11)
 #define PS_PM_HOOK_LENGTH   (1 << 12)
 #define PS_PM_STEP_OFFSET   (1 << 13)
+#define PS_PM_PARAMS        (1 << 14)
 
 /**
  * @brief Delta compression flags for `user_cmd_t`.

--- a/src/shared/shared.h
+++ b/src/shared/shared.h
@@ -278,6 +278,25 @@ typedef enum {
 #define PMF_GAME (1 << 0)
 
 /**
+ * @brief Server-tunable player-movement parameters, networked per-player
+ * inside `pm_state_t` so that client-side prediction matches the server.
+ * Each field defaults to the `PM_*` constant it replaces (see bg_pmove.h).
+ */
+typedef struct {
+  int16_t gravity;     // world gravity; default from g_gravity / map (int16)
+  float gravity_water; // PM_GRAVITY_WATER
+
+  float accel_ground, accel_ground_slick, accel_air, accel_water,
+        accel_spectator, accel_ladder;
+
+  float friction_ground, friction_ground_slick, friction_air, friction_water,
+        friction_spectator, friction_ladder;
+
+  float speed_ground, speed_air, speed_water, speed_ladder, speed_spectator,
+        speed_stop, speed_jump, speed_ducked, speed_duck_stand, speed_water_jump;
+} pm_params_t;
+
+/**
  * @brief The player movement state contains quantized snapshots of player
  * position, orientation, velocity and world interaction state. This should
  * be modified only through invoking `Pm_Move`.
@@ -288,7 +307,7 @@ typedef struct {
   vec3_t velocity;
   uint16_t flags; // game-specific state flags
   uint16_t time; // duration for temporal state flags
-  int16_t gravity;
+  pm_params_t params; // server-tunable movement parameters (incl. gravity)
   vec3_t view_offset; // add to origin to resolve eyes
   float step_offset; // add to final origin to resolve step interpolation
   vec3_t view_angles; // base view angles

--- a/src/tests/Makefile.am
+++ b/src/tests/Makefile.am
@@ -44,6 +44,7 @@ TESTS = \
 	check_http \
 	check_master \
 	check_mem \
+	check_net_message \
 	check_r_media \
 	check_shared \
 	check_thread \
@@ -155,6 +156,15 @@ check_mem_CFLAGS = \
 	$(TESTS_CFLAGS)
 check_mem_LDADD = \
 	$(TESTS_LIBS)
+
+check_net_message_SOURCES = \
+	check_net_message.c
+check_net_message_CFLAGS = \
+	-I$(top_srcdir)/src \
+	$(TESTS_CFLAGS)
+check_net_message_LDADD = \
+	$(TESTS_LIBS) \
+	$(top_builddir)/src/net/libnet.la
 
 check_r_media_SOURCES = \
 	check_r_media.c

--- a/src/tests/check_net_message.c
+++ b/src/tests/check_net_message.c
@@ -1,0 +1,139 @@
+/*
+ * Copyright(c) 1997-2001 id Software, Inc.
+ * Copyright(c) 2002 The Quakeforge Project.
+ * Copyright(c) 2006 Quetoo.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+#include "tests.h"
+
+#include "net/net_message.h"
+
+quetoo_t quetoo;
+
+/**
+ * @brief Setup fixture.
+ */
+void setup(void) {
+  Mem_Init();
+}
+
+/**
+ * @brief Teardown fixture.
+ */
+void teardown(void) {
+  Mem_Shutdown();
+}
+
+/**
+ * @brief Helper: populate every pm_params_t field with a distinct non-default
+ * value so a round-trip can detect any dropped or mis-ordered field.
+ */
+static void Fill_TestParams(pm_params_t *p) {
+  p->gravity = 750;
+  p->gravity_water = 0.5f;
+  p->accel_ground = 11.f;       p->accel_ground_slick = 4.5f;
+  p->accel_air = 3.f;           p->accel_water = 3.5f;
+  p->accel_spectator = 2.75f;   p->accel_ladder = 17.f;
+  p->friction_ground = 6.5f;    p->friction_ground_slick = 2.5f;
+  p->friction_air = 0.25f;      p->friction_water = 2.25f;
+  p->friction_spectator = 2.6f; p->friction_ladder = 5.5f;
+  p->speed_ground = 310.f;      p->speed_air = 360.f;
+  p->speed_water = 150.f;       p->speed_ladder = 130.f;
+  p->speed_spectator = 510.f;   p->speed_stop = 110.f;
+  p->speed_jump = 280.f;        p->speed_ducked = 145.f;
+  p->speed_duck_stand = 205.f;  p->speed_water_jump = 430.f;
+}
+
+/**
+ * @brief Every server-tunable movement parameter must survive a player-state
+ * delta round-trip so that client prediction reads identical values.
+ */
+START_TEST(check_PlayerState_Params_RoundTrip) {
+  byte buffer[MAX_MSG_SIZE];
+  mem_buf_t buf;
+  Mem_InitBuffer(&buf, buffer, sizeof(buffer));
+
+  player_state_t from;
+  memset(&from, 0, sizeof(from));
+
+  player_state_t to;
+  memset(&to, 0, sizeof(to));
+  Fill_TestParams(&to.pm_state.params);
+
+  Net_WriteDeltaPlayerState(&buf, &from, &to);
+  buf.read = 0;
+
+  player_state_t result;
+  memset(&result, 0, sizeof(result));
+  Net_ReadDeltaPlayerState(&buf, &from, &result);
+
+  ck_assert_int_eq(result.pm_state.params.gravity, to.pm_state.params.gravity);
+
+  ck_assert_msg(memcmp(&result.pm_state.params.gravity_water, &to.pm_state.params.gravity_water,
+                       sizeof(pm_params_t) - offsetof(pm_params_t, gravity_water)) == 0,
+                "pm_params_t (non-gravity) did not survive the round-trip");
+} END_TEST
+
+/**
+ * @brief When the params are unchanged from the delta baseline, no params
+ * payload should be written (delta compression must skip the block).
+ */
+START_TEST(check_PlayerState_Params_DeltaCompressed) {
+  byte buf_a[MAX_MSG_SIZE], buf_b[MAX_MSG_SIZE];
+  mem_buf_t equal, diff;
+  Mem_InitBuffer(&equal, buf_a, sizeof(buf_a));
+  Mem_InitBuffer(&diff, buf_b, sizeof(buf_b));
+
+  player_state_t base;
+  memset(&base, 0, sizeof(base));
+  Fill_TestParams(&base.pm_state.params);
+
+  player_state_t zero;
+  memset(&zero, 0, sizeof(zero));
+
+  // identical params: no PS_PM_PARAMS payload
+  Net_WriteDeltaPlayerState(&equal, &base, &base);
+  // changed params: full PS_PM_PARAMS payload
+  Net_WriteDeltaPlayerState(&diff, &zero, &base);
+
+  ck_assert_msg(equal.size < diff.size,
+                "unchanged params still wrote a payload (%zu vs %zu)",
+                equal.size, diff.size);
+} END_TEST
+
+/**
+ * @brief Test entry point.
+ */
+int32_t main(int32_t argc, char **argv) {
+
+  Test_Init(argc, argv);
+
+  TCase *tcase = tcase_create("check_net_message");
+  tcase_add_checked_fixture(tcase, setup, teardown);
+
+  tcase_add_test(tcase, check_PlayerState_Params_RoundTrip);
+  tcase_add_test(tcase, check_PlayerState_Params_DeltaCompressed);
+
+  Suite *suite = suite_create("check_net_message");
+  suite_add_tcase(suite, tcase);
+
+  int32_t failed = Test_Run(suite);
+
+  Test_Shutdown();
+  return failed;
+}


### PR DESCRIPTION
## Summary

Makes Quetoo's player-movement tuning server-controllable. Acceleration, friction and speed for ground / air / water / spectator / ladder, plus gravity and the water-gravity modifier, move from compile-time constants in `bg_pmove.h` into a networked `pm_params_t` struct.

Because `Pm_Move` runs in client-side prediction (`cg_predict.c`) as well as on the authoritative server, a server-only change to these shared constants would make stock clients mispredict (rubber-banding). So the params are carried per-player in `pm_state_t` — the same channel the client already predicts from — exactly the way `gravity` already travels. Every value defaults to the constant it replaces, so out-of-the-box behavior is unchanged until an admin sets one.

Fixes #589

## Changes

- **`src/shared/shared.h`** — new `pm_params_t` struct (gravity + `gravity_water` + accel/friction/speed for ground, ground-slick, air, water, spectator, ladder), embedded in `pm_state_t` as `params`.
- **`src/game/default/g_main.{c,h}`** — 23 movement cvars in their own alphabetized block (`g_air_acceleration`, `g_water_friction`, `g_jump_speed`, …), deliberately *not* `CVAR_SERVER_INFO` to keep the server-info string under its 1024-byte limit. A `G_MovementParams()` factory hydrates a fresh `pm_params_t` from the cvars — no singleton cache, no dirty-checking.
- **`src/game/default/g_client.c`** — assigns `pm.s.params = G_MovementParams()` at the `Pm_Move` call site, so a mod can override fields per player there. Gravity keeps its existing precedence (maps.lst > worldspawn key > `g_gravity` > default) via `g_level.gravity`, which the factory reads.
- **`src/game/default/bg_pmove.c`** — `Pm_Move` reads `pm->s.params.*` and sanitizes every parameter at its point of use: divisors kept positive, rates and impulses floored at zero. The `PM_*` constants remain as the default seed values.
- **`src/net/net_message.{h,c}`** — the `pm_state` delta bitmask widens `uint16_t` → `uint32_t`; the float params share one new delta flag `PS_PM_PARAMS`, written only when they change (≈zero cost under delta compression). Gravity keeps its existing `PS_PM_GRAVITY` int16 path.
- **`src/game/default/g_types.h`** — `PROTOCOL_MINOR` bumped to 1043 (wire format changed).
- **`src/tests/check_net_message.c`** (new) — round-trips a fully-populated `pm_params_t` through `Net_WriteDeltaPlayerState` / `Net_ReadDeltaPlayerState`, and asserts the params block is skipped when unchanged.

## Testing

- [x] Builds without warnings — client, dedicated, `game.so` and `cgame.so` build on Debian 12 (deps per `linux/docker/Dockerfile.build`); no warnings on the changed files.
- [ ] Tests pass (`make check`) — the new `check_net_message` passes (`100%: Checks: 2, Failures: 0`). Full `make check` remains blocked by the pre-existing `check_master` link failure on `main` (`undefined reference to Net_HttpPostAsync`), unrelated to this change.
- [ ] Tested in-game — not yet; needs a client built from this branch, since the `PROTOCOL_MINOR` bump (correctly) rejects stock clients. Plan is to exercise non-default values on a couple of rotation maps alongside the physics-enum follow-on.

## Notes

- **Follow-on (per review):** a `physics`/`movement` worldspawn + maps.lst enum (`quake` / `quake2` / `default`) alongside the existing `items` key, with a single `CVAR_SERVER_INFO` cvar exposing the active model; the `gravity` worldspawn key retires then.
- **Scope.** This exposes the "feel" surface (accel / friction / speed per movement state + gravity). Engine internals (stop-epsilon, clip-bounce, snap distance, step-normal, fall/land thresholds) stay compile-time.
- Field / cvar names follow the surrounding `snake_case` convention (`pm_state.view_offset`, `g_gravity`) rather than the style-guide table's `camelCase`, for local consistency.
