### PR TITLE
Add Valve-220 map format support to quemap.

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,7 @@
+{
+  "permissions": {
+    "additionalDirectories": [
+      "D:\\Dev_Repos\\quetoo-data\\target\\default\\maps"
+    ]
+  }
+}

--- a/Quetoo.vs15/quemap.vcxproj
+++ b/Quetoo.vs15/quemap.vcxproj
@@ -119,6 +119,10 @@
     <Link>
       <AdditionalDependencies>SDL3.lib;SDL3_image.lib;glib-2.0.lib;intl.lib;dbghelp.lib;Wldap32.lib;physfs.lib;ws2_32.lib;dlfcn.lib;Objectively.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <SubSystem>Console</SubSystem>
+      <!-- BSP tree/portal generation recurses to tree depth; the default 1 MB Windows
+           main-thread stack overflows on large maps (e.g. cavern). Reserve 8 MB to match
+           the Linux/macOS main-thread default. -->
+      <StackReserveSize>8388608</StackReserveSize>
     </Link>
     <PostBuildEvent>
       <Command>COPY_DEPENDENCIES "$(QUETOO_HOME)" "$(Platform)" "$(Configuration)" &amp;&amp; COPY_QUEMAP "$(QUETOO_HOME)" "$(Platform)$(Configuration)"</Command>

--- a/Quetoo.vs15/quemap.vcxproj.user
+++ b/Quetoo.vs15/quemap.vcxproj.user
@@ -7,7 +7,10 @@
     <LocalDebuggerCommandArguments>-p "C:\Users\chrisg\OneDrive\Documents\My Games\Quetoo\default" -bsp test</LocalDebuggerCommandArguments>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <LocalDebuggerCommandArgumentsHistory>-p "D:\quetoo_dev\github\quetoo\Quetoo.vs15\../../quetoo-data/src/default" -bsp -light tokays|-p "C:\Users\chrisg\OneDrive\Documents\My Games\Quetoo\default" -bsp test|-p "C:\Users\chrisg\OneDrive\Documents\My Games\Quetoo\default" -bsp longyard|-p "C:\Users\chrisg\OneDrive\Documents\My Games\Quetoo\default" -bsp maps/longyard|</LocalDebuggerCommandArgumentsHistory>
-    <LocalDebuggerCommandArguments>-p "C:\Users\chrisg\OneDrive\Documents\My Games\Quetoo\default" -bsp maps/longyard</LocalDebuggerCommandArguments>
+    <LocalDebuggerCommandArgumentsHistory>-p "C:\Users\chrisg\OneDrive\Documents\My Games\Quetoo\default" -bsp test|-p "C:\Users\chrisg\OneDrive\Documents\My Games\Quetoo\default" -bsp longyard|-p "C:\Users\chrisg\OneDrive\Documents\My Games\Quetoo\default" -bsp maps/longyard|-p "C:\Users\chrisg\AppData\Roaming\WickedOldGames\Quetoo\default" -bsp maps/longyard|-p "C:\Users\chrisg\AppData\Roaming\WickedOldGames\Quetoo\default" -bsp maps/cavern|</LocalDebuggerCommandArgumentsHistory>
+    <LocalDebuggerCommandArguments>-p "C:\Users\chrisg\AppData\Roaming\WickedOldGames\Quetoo\default" -bsp maps/cavern</LocalDebuggerCommandArguments>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LocalDebuggerCommandArgumentsHistory>-p "C:\Users\chrisg\OneDrive\Documents\My Games\Quetoo\default" -bsp test|</LocalDebuggerCommandArgumentsHistory>
   </PropertyGroup>
 </Project>

--- a/src/quemap/face.c
+++ b/src/quemap/face.c
@@ -385,7 +385,7 @@ bsp_face_t *EmitFace(const face_t *face) {
   return out;
 }
 
-#define MAX_VERTEX_FACES 32
+#define MAX_VERTEX_FACES 64
 
 static const bsp_model_t *phong_model;
 static float phong_cosine;

--- a/src/quemap/map.c
+++ b/src/quemap/map.c
@@ -545,7 +545,10 @@ static brush_t *ParseBrush(parser_t *parser, entity_t *entity) {
         Parse_Primitive(parser, PARSE_NO_WRAP, PARSE_FLOAT, &side->axis[i].y, 1);
         Parse_Primitive(parser, PARSE_NO_WRAP, PARSE_FLOAT, &side->axis[i].z, 1);
         Parse_Primitive(parser, PARSE_NO_WRAP, PARSE_FLOAT, &side->axis[i].w, 1); // shift
-        Parse_Token(parser, PARSE_NO_WRAP, token, sizeof(token)); // consume "]"
+        Parse_Token(parser, PARSE_NO_WRAP, token, sizeof(token));
+        if (g_strcmp0(token, "]")) {
+          Com_Error(ERROR_FATAL, "Invalid brush %d (%s)\n", num_brushes, token);
+        }
       }
       Parse_Primitive(parser, PARSE_NO_WRAP, PARSE_FLOAT, &side->rotate, 1);
       Parse_Primitive(parser, PARSE_NO_WRAP, PARSE_FLOAT, &side->scale.x, 1);

--- a/src/quemap/map.c
+++ b/src/quemap/map.c
@@ -537,7 +537,10 @@ static brush_t *ParseBrush(parser_t *parser, entity_t *entity) {
       // Valve-220: [ ux uy uz shift_x ] [ vx vy vz shift_y ] rotation scale_x scale_y
       side->valve = true;
       for (int32_t i = 0; i < 2; i++) {
-        Parse_Token(parser, PARSE_NO_WRAP, token, sizeof(token)); // consume "["
+        Parse_Token(parser, PARSE_NO_WRAP, token, sizeof(token));
+        if (g_strcmp0(token, "[")) {
+          Com_Error(ERROR_FATAL, "Invalid brush %d (%s)\n", num_brushes, token);
+        }
         Parse_Primitive(parser, PARSE_NO_WRAP, PARSE_FLOAT, &side->axis[i].x, 1);
         Parse_Primitive(parser, PARSE_NO_WRAP, PARSE_FLOAT, &side->axis[i].y, 1);
         Parse_Primitive(parser, PARSE_NO_WRAP, PARSE_FLOAT, &side->axis[i].z, 1);

--- a/src/quemap/map.c
+++ b/src/quemap/map.c
@@ -530,12 +530,37 @@ static brush_t *ParseBrush(parser_t *parser, entity_t *entity) {
 
     g_strlcpy(side->texture, token, sizeof(side->texture));
 
-    // read the texture parameters
-    Parse_Primitive(parser, PARSE_NO_WRAP, PARSE_FLOAT, &side->shift.x, 1);
-    Parse_Primitive(parser, PARSE_NO_WRAP, PARSE_FLOAT, &side->shift.y, 1);
-    Parse_Primitive(parser, PARSE_NO_WRAP, PARSE_FLOAT, &side->rotate, 1);
-    Parse_Primitive(parser, PARSE_NO_WRAP, PARSE_FLOAT, &side->scale.x, 1);
-    Parse_Primitive(parser, PARSE_NO_WRAP, PARSE_FLOAT, &side->scale.y, 1);
+    // detect Valve-220 vs standard Q1/Q3 format by peeking for '['
+    Parse_PeekToken(parser, PARSE_NO_WRAP, token, sizeof(token));
+
+    if (!g_strcmp0(token, "[")) {
+      // Valve-220: [ ux uy uz shift_x ] [ vx vy vz shift_y ] rotation scale_x scale_y
+      side->valve = true;
+      for (int32_t i = 0; i < 2; i++) {
+        Parse_Token(parser, PARSE_NO_WRAP, token, sizeof(token));
+        if (g_strcmp0(token, "[")) {
+          Com_Error(ERROR_FATAL, "Invalid brush %d (%s)\n", num_brushes, token);
+        }
+        Parse_Primitive(parser, PARSE_NO_WRAP, PARSE_FLOAT, &side->axis[i].x, 1);
+        Parse_Primitive(parser, PARSE_NO_WRAP, PARSE_FLOAT, &side->axis[i].y, 1);
+        Parse_Primitive(parser, PARSE_NO_WRAP, PARSE_FLOAT, &side->axis[i].z, 1);
+        Parse_Primitive(parser, PARSE_NO_WRAP, PARSE_FLOAT, &side->axis[i].w, 1); // shift
+        Parse_Token(parser, PARSE_NO_WRAP, token, sizeof(token));
+        if (g_strcmp0(token, "]")) {
+          Com_Error(ERROR_FATAL, "Invalid brush %d (%s)\n", num_brushes, token);
+        }
+      }
+      Parse_Primitive(parser, PARSE_NO_WRAP, PARSE_FLOAT, &side->rotate, 1);
+      Parse_Primitive(parser, PARSE_NO_WRAP, PARSE_FLOAT, &side->scale.x, 1);
+      Parse_Primitive(parser, PARSE_NO_WRAP, PARSE_FLOAT, &side->scale.y, 1);
+    } else {
+      // Standard Q1/Q3: shift_x shift_y rotation scale_x scale_y
+      Parse_Primitive(parser, PARSE_NO_WRAP, PARSE_FLOAT, &side->shift.x, 1);
+      Parse_Primitive(parser, PARSE_NO_WRAP, PARSE_FLOAT, &side->shift.y, 1);
+      Parse_Primitive(parser, PARSE_NO_WRAP, PARSE_FLOAT, &side->rotate, 1);
+      Parse_Primitive(parser, PARSE_NO_WRAP, PARSE_FLOAT, &side->scale.x, 1);
+      Parse_Primitive(parser, PARSE_NO_WRAP, PARSE_FLOAT, &side->scale.y, 1);
+    }
 
     if (!Parse_IsEOL(parser)) {
       Parse_Primitive(parser, PARSE_NO_WRAP, PARSE_INT32, &side->contents, 1);

--- a/src/quemap/map.c
+++ b/src/quemap/map.c
@@ -27,6 +27,8 @@
 #include "qbsp.h"
 #include "texture.h"
 
+map_format_t map_format;
+
 int32_t num_entities;
 entity_t entities[MAX_BSP_ENTITIES];
 
@@ -535,7 +537,11 @@ static brush_t *ParseBrush(parser_t *parser, entity_t *entity) {
 
     if (!g_strcmp0(token, "[")) {
       // Valve-220: [ ux uy uz shift_x ] [ vx vy vz shift_y ] rotation scale_x scale_y
-      side->valve = true;
+      if (map_format == MAP_FORMAT_UNKNOWN) {
+        map_format = MAP_FORMAT_VALVE;
+      } else if (map_format != MAP_FORMAT_VALVE) {
+        Com_Error(ERROR_FATAL, "Mixed map format: Valve-220 brush side in a non-Valve map (brush %d)\n", num_brushes);
+      }
       for (int32_t i = 0; i < 2; i++) {
         Parse_Token(parser, PARSE_NO_WRAP, token, sizeof(token));
         if (g_strcmp0(token, "[")) {
@@ -555,6 +561,11 @@ static brush_t *ParseBrush(parser_t *parser, entity_t *entity) {
       Parse_Primitive(parser, PARSE_NO_WRAP, PARSE_FLOAT, &side->scale.y, 1);
     } else {
       // Standard Q1/Q3: shift_x shift_y rotation scale_x scale_y
+      if (map_format == MAP_FORMAT_UNKNOWN) {
+        map_format = MAP_FORMAT_Q3;
+      } else if (map_format == MAP_FORMAT_VALVE) {
+        Com_Error(ERROR_FATAL, "Mixed map format: standard brush side in a Valve-220 map (brush %d)\n", num_brushes);
+      }
       Parse_Primitive(parser, PARSE_NO_WRAP, PARSE_FLOAT, &side->shift.x, 1);
       Parse_Primitive(parser, PARSE_NO_WRAP, PARSE_FLOAT, &side->shift.y, 1);
       Parse_Primitive(parser, PARSE_NO_WRAP, PARSE_FLOAT, &side->rotate, 1);
@@ -871,10 +882,13 @@ static entity_t *ParseEntity(parser_t *parser) {
 
 /**
  * @brief Loads and parses the .map file, populating the global entities, brushes, planes, and patches arrays.
+ * @return The resolved map format, also stored in the global `map_format`.
  */
-void LoadMapFile(const char *filename) {
+int LoadMapFile(const char *filename) {
 
   Com_Verbose("--- LoadMapFile ---\n");
+
+  map_format = MAP_FORMAT_UNKNOWN;
 
   memset(entities, 0, sizeof(entities));
   num_entities = 0;
@@ -924,4 +938,6 @@ void LoadMapFile(const char *filename) {
         map_bounds.maxs.x, map_bounds.maxs.y, map_bounds.maxs.z);
 
   Fs_Free(buffer);
+
+  return map_format;
 }

--- a/src/quemap/map.c
+++ b/src/quemap/map.c
@@ -884,7 +884,7 @@ static entity_t *ParseEntity(parser_t *parser) {
  * @brief Loads and parses the .map file, populating the global entities, brushes, planes, and patches arrays.
  * @return The resolved map format, also stored in the global `map_format`.
  */
-int LoadMapFile(const char *filename) {
+map_format_t LoadMapFile(const char *filename) {
 
   Com_Verbose("--- LoadMapFile ---\n");
 

--- a/src/quemap/map.c
+++ b/src/quemap/map.c
@@ -530,12 +530,31 @@ static brush_t *ParseBrush(parser_t *parser, entity_t *entity) {
 
     g_strlcpy(side->texture, token, sizeof(side->texture));
 
-    // read the texture parameters
-    Parse_Primitive(parser, PARSE_NO_WRAP, PARSE_FLOAT, &side->shift.x, 1);
-    Parse_Primitive(parser, PARSE_NO_WRAP, PARSE_FLOAT, &side->shift.y, 1);
-    Parse_Primitive(parser, PARSE_NO_WRAP, PARSE_FLOAT, &side->rotate, 1);
-    Parse_Primitive(parser, PARSE_NO_WRAP, PARSE_FLOAT, &side->scale.x, 1);
-    Parse_Primitive(parser, PARSE_NO_WRAP, PARSE_FLOAT, &side->scale.y, 1);
+    // detect Valve-220 vs standard Q1/Q3 format by peeking for '['
+    Parse_PeekToken(parser, PARSE_NO_WRAP, token, sizeof(token));
+
+    if (!g_strcmp0(token, "[")) {
+      // Valve-220: [ ux uy uz shift_x ] [ vx vy vz shift_y ] rotation scale_x scale_y
+      side->valve = true;
+      for (int32_t i = 0; i < 2; i++) {
+        Parse_Token(parser, PARSE_NO_WRAP, token, sizeof(token)); // consume "["
+        Parse_Primitive(parser, PARSE_NO_WRAP, PARSE_FLOAT, &side->axis[i].x, 1);
+        Parse_Primitive(parser, PARSE_NO_WRAP, PARSE_FLOAT, &side->axis[i].y, 1);
+        Parse_Primitive(parser, PARSE_NO_WRAP, PARSE_FLOAT, &side->axis[i].z, 1);
+        Parse_Primitive(parser, PARSE_NO_WRAP, PARSE_FLOAT, &side->axis[i].w, 1); // shift
+        Parse_Token(parser, PARSE_NO_WRAP, token, sizeof(token)); // consume "]"
+      }
+      Parse_Primitive(parser, PARSE_NO_WRAP, PARSE_FLOAT, &side->rotate, 1);
+      Parse_Primitive(parser, PARSE_NO_WRAP, PARSE_FLOAT, &side->scale.x, 1);
+      Parse_Primitive(parser, PARSE_NO_WRAP, PARSE_FLOAT, &side->scale.y, 1);
+    } else {
+      // Standard Q1/Q3: shift_x shift_y rotation scale_x scale_y
+      Parse_Primitive(parser, PARSE_NO_WRAP, PARSE_FLOAT, &side->shift.x, 1);
+      Parse_Primitive(parser, PARSE_NO_WRAP, PARSE_FLOAT, &side->shift.y, 1);
+      Parse_Primitive(parser, PARSE_NO_WRAP, PARSE_FLOAT, &side->rotate, 1);
+      Parse_Primitive(parser, PARSE_NO_WRAP, PARSE_FLOAT, &side->scale.x, 1);
+      Parse_Primitive(parser, PARSE_NO_WRAP, PARSE_FLOAT, &side->scale.y, 1);
+    }
 
     if (!Parse_IsEOL(parser)) {
       Parse_Primitive(parser, PARSE_NO_WRAP, PARSE_INT32, &side->contents, 1);

--- a/src/quemap/map.h
+++ b/src/quemap/map.h
@@ -79,11 +79,6 @@ typedef struct brush_side_s {
   vec2_t scale;
 
   /**
-   * @brief True if this brush side uses Valve-220 explicit texture axes.
-   */
-  bool valve;
-
-  /**
    * @brief The texture axis for S and T, in xyz + offset notation.
    */
   vec4_t axis[2];
@@ -170,6 +165,18 @@ typedef struct brush_s {
   bsp_brush_t *out;
 } brush_t;
 
+/**
+ * @brief Map file format.
+ */
+typedef enum {
+    MAP_FORMAT_UNKNOWN = 0,
+    MAP_FORMAT_Q2,   // Quake II style map/bsp
+    MAP_FORMAT_Q3,   // Quake III / Radiant style map
+    MAP_FORMAT_VALVE // Valve / Source style map (optional)
+} map_format_t;
+
+extern map_format_t map_format;
+
 extern int32_t num_entities;
 extern entity_t entities[MAX_BSP_ENTITIES];
 
@@ -187,4 +194,4 @@ extern box3_t map_bounds;
 int32_t FindPlane(const vec3_t normal, double dist);
 void MakeBrushWindings(brush_t *brush);
 void AddBrushBevels(brush_t *b);
-void LoadMapFile(const char *filename);
+int LoadMapFile(const char *filename);

--- a/src/quemap/map.h
+++ b/src/quemap/map.h
@@ -194,4 +194,4 @@ extern box3_t map_bounds;
 int32_t FindPlane(const vec3_t normal, double dist);
 void MakeBrushWindings(brush_t *brush);
 void AddBrushBevels(brush_t *b);
-int LoadMapFile(const char *filename);
+map_format_t LoadMapFile(const char *filename);

--- a/src/quemap/map.h
+++ b/src/quemap/map.h
@@ -79,6 +79,11 @@ typedef struct brush_side_s {
   vec2_t scale;
 
   /**
+   * @brief True if this brush side uses Valve-220 explicit texture axes.
+   */
+  bool valve;
+
+  /**
    * @brief The texture axis for S and T, in xyz + offset notation.
    */
   vec4_t axis[2];

--- a/src/quemap/qbsp.c
+++ b/src/quemap/qbsp.c
@@ -168,6 +168,15 @@ int32_t BSP_Main(void) {
 
   LoadMapFile(map_name);
 
+  bool valve = false;
+  for (int32_t i = 0; i < num_brush_sides; i++) {
+    if (brush_sides[i].valve) {
+      valve = true;
+      break;
+    }
+  }
+  Com_Print("Map format: %s\n", valve ? "Quake3 (Valve)" : "Quake3");
+
   EmitPlanes();
   EmitMaterials();
   EmitBrushes();

--- a/src/quemap/qbsp.c
+++ b/src/quemap/qbsp.c
@@ -166,16 +166,9 @@ int32_t BSP_Main(void) {
 
   BeginBSPFile();
 
-  LoadMapFile(map_name);
+  map_format = LoadMapFile(map_name);
 
-  bool valve = false;
-  for (int32_t i = 0; i < num_brush_sides; i++) {
-    if (brush_sides[i].valve) {
-      valve = true;
-      break;
-    }
-  }
-  Com_Print("Map format: %s\n", valve ? "Quake3 (Valve)" : "Quake3");
+  Com_Verbose("Map format: %s\n", map_format == MAP_FORMAT_VALVE ? "Quake3 (Valve)" : "Quake3");
 
   EmitPlanes();
   EmitMaterials();

--- a/src/quemap/texture.c
+++ b/src/quemap/texture.c
@@ -68,7 +68,7 @@ static void TextureAxisForPlane(const plane_t *plane, vec3_t *xv, vec3_t *yv) {
  */
 void TextureVectorsForBrushSide(brush_side_t *side, const vec3_t origin) {
 
-  if (side->valve) {
+  if (map_format == MAP_FORMAT_VALVE) {
     // Valve-220: axes are already stored in side->axis as (direction, shift).
     // Note that this function is called once during parsing (origin = 0) and may be called
     // a second time when applying entity origin offsets.

--- a/src/quemap/texture.c
+++ b/src/quemap/texture.c
@@ -69,18 +69,27 @@ static void TextureAxisForPlane(const plane_t *plane, vec3_t *xv, vec3_t *yv) {
 void TextureVectorsForBrushSide(brush_side_t *side, const vec3_t origin) {
 
   if (side->valve) {
-    // Valve-220: axes are already stored in side->axis as (direction, shift); apply scale and origin offset
+    // Valve-220: axes are already stored in side->axis as (direction, shift).
+    // Note that this function is called once during parsing (origin = 0) and may be called
+    // a second time when applying entity origin offsets.
     const vec2_t scale = {
       .x = side->scale.x ?: 1.f,
       .y = side->scale.y ?: 1.f,
     };
+
+    if (!Vec3_Equal(origin, Vec3_Zero())) {
+      // Axis xyz are already scaled from the first pass; only apply the origin offset.
+      for (int32_t i = 0; i < 2; i++) {
+        side->axis[i].w += Vec3_Dot(origin, side->axis[i].xyz);
+      }
+      return;
+    }
+
+    // First pass: apply scale.
     for (int32_t i = 0; i < 2; i++) {
-      const vec3_t dir = Vec3(side->axis[i].x, side->axis[i].y, side->axis[i].z);
-      const float shift = side->axis[i].w;
       for (int32_t j = 0; j < 3; j++) {
         side->axis[i].xyzw[j] /= scale.xy[i];
       }
-      side->axis[i].w = shift + Vec3_Dot(origin, dir);
     }
     return;
   }

--- a/src/quemap/texture.c
+++ b/src/quemap/texture.c
@@ -68,6 +68,23 @@ static void TextureAxisForPlane(const plane_t *plane, vec3_t *xv, vec3_t *yv) {
  */
 void TextureVectorsForBrushSide(brush_side_t *side, const vec3_t origin) {
 
+  if (side->valve) {
+    // Valve-220: axes are already stored in side->axis as (direction, shift); apply scale and origin offset
+    const vec2_t scale = {
+      .x = side->scale.x ?: 1.f,
+      .y = side->scale.y ?: 1.f,
+    };
+    for (int32_t i = 0; i < 2; i++) {
+      const vec3_t dir = Vec3(side->axis[i].x, side->axis[i].y, side->axis[i].z);
+      const float shift = side->axis[i].w;
+      for (int32_t j = 0; j < 3; j++) {
+        side->axis[i].xyzw[j] /= scale.xy[i];
+      }
+      side->axis[i].w = shift + Vec3_Dot(origin, dir);
+    }
+    return;
+  }
+
   vec3_t axis[2];
   TextureAxisForPlane(&planes[side->plane], &axis[0], &axis[1]);
 

--- a/src/quemap/texture.c
+++ b/src/quemap/texture.c
@@ -68,6 +68,32 @@ static void TextureAxisForPlane(const plane_t *plane, vec3_t *xv, vec3_t *yv) {
  */
 void TextureVectorsForBrushSide(brush_side_t *side, const vec3_t origin) {
 
+  if (side->valve) {
+    // Valve-220: axes are already stored in side->axis as (direction, shift).
+    // Note that this function is called once during parsing (origin = 0) and may be called
+    // a second time when applying entity origin offsets.
+    const vec2_t scale = {
+      .x = side->scale.x ?: 1.f,
+      .y = side->scale.y ?: 1.f,
+    };
+
+    if (!Vec3_Equal(origin, Vec3_Zero())) {
+      // Axis xyz are already scaled from the first pass; only apply the origin offset.
+      for (int32_t i = 0; i < 2; i++) {
+        side->axis[i].w += Vec3_Dot(origin, side->axis[i].xyz);
+      }
+      return;
+    }
+
+    // First pass: apply scale.
+    for (int32_t i = 0; i < 2; i++) {
+      for (int32_t j = 0; j < 3; j++) {
+        side->axis[i].xyzw[j] /= scale.xy[i];
+      }
+    }
+    return;
+  }
+
   vec3_t axis[2];
   TextureAxisForPlane(&planes[side->plane], &axis[0], &axis[1]);
 


### PR DESCRIPTION
Auto-detects Valve-220 by peeking for '[' after the texture name; falls back to standard Q3 format if not present. Both formats are supported transparently with no flags required.

***
Ran into issues aligning faces in `cavern` - this helps. TB support for patch editing is coming too, which will also help alot.
