### PR TITLE
Size active_lights uniform to MAX_DYNAMIC_LIGHTS, fixing startup crash on older NVIDIA drivers

### DIFF
--- a/src/client/renderer/r_light.c
+++ b/src/client/renderer/r_light.c
@@ -99,11 +99,11 @@ void R_UpdateLights(r_view_t *view) {
  * @brief Writes the indexes of active lights intersecting bounds to the given uniform name.
  * @details In normal gameplay, these are dynamic light sources (rockets, explosions, etc).
  * @details When the in-game editor is enabled, all lights use this code path.
- * @remarks The uniform must be an `int[MAX_LIGHTS]`.
+ * @remarks The uniform must be an `int[MAX_DYNAMIC_LIGHTS]`.
  */
 void R_ActiveLights(const r_view_t *view, const box3_t bounds, GLint name) {
 
-  GLint active_lights[MAX_LIGHTS];
+  GLint active_lights[MAX_DYNAMIC_LIGHTS];
   GLint len = 0;
 
   const r_light_t *l = view->lights;
@@ -116,13 +116,13 @@ void R_ActiveLights(const r_view_t *view, const box3_t bounds, GLint name) {
     if (Box3_Intersects(l->bounds, bounds)) {
       active_lights[len++] = i;
 
-      if (len == MAX_LIGHTS - 1) {
+      if (len == MAX_DYNAMIC_LIGHTS) {
         break;
       }
     }
   }
 
-  if (len < MAX_LIGHTS) {
+  if (len < MAX_DYNAMIC_LIGHTS) {
     active_lights[len++] = -1;
   }
 

--- a/src/client/renderer/shaders/uniforms.glsl
+++ b/src/client/renderer/shaders/uniforms.glsl
@@ -211,8 +211,11 @@ layout (std140) uniform lights_block {
 
 /**
  * @brief The -1 terminated array of active light indexes for the current render operation.
+ * @details Sized to MAX_DYNAMIC_LIGHTS rather than MAX_LIGHTS because all consumers only
+ * iterate the first MAX_DYNAMIC_LIGHTS entries, and a larger default-block uniform array
+ * exceeds the vertex program parameter limits of older GL drivers (#842).
  */
-uniform int active_lights[MAX_LIGHTS];
+uniform int active_lights[MAX_DYNAMIC_LIGHTS];
 
 /**
  * @brief The diffusemap texture, for non-material passes such as sprites.


### PR DESCRIPTION
## Summary

The `active_lights` default-block uniform array is declared `int[MAX_LIGHTS]` (576 elements), but every consumer only ever reads the first `MAX_DYNAMIC_LIGHTS` (64) entries, and `R_ActiveLights()` only writes dynamic (non-BSP) light indexes. On older NVIDIA drivers (e.g. 441.08 on a GTX 980, as reported in #842), the GLSL compiler lowers default-block uniform arrays into vertex program parameter space, and 576 ints exceeds the legacy parameter limit — the BSP vertex shader fails to compile with `invalid parameter array size` / `out of bounds array access`, and startup aborts via `Com_Error` in `R_LoadProgram` (`r_program.c:174`). Full analysis in the issue: https://github.com/jdolan/quetoo/issues/842#issuecomment-4695607651

This sizes the array to what is actually consumed, which fits comfortably within legacy parameter limits and changes nothing in rendered output.

Fixes #842

## Changes

- `shaders/uniforms.glsl`: declare `active_lights[MAX_DYNAMIC_LIGHTS]` instead of `[MAX_LIGHTS]`. All read sites (`light.glsl:248`, `light.glsl:407`, `sprite_vs.glsl:73`) already iterate `for (int i = 0; i < MAX_DYNAMIC_LIGHTS; i++)`, so entries 64–575 were never read.
- `r_light.c` (`R_ActiveLights`): bound the staging array at `MAX_DYNAMIC_LIGHTS` to match. When the array fills completely (64 dynamic lights), no `-1` terminator is appended — the shader loop bound terminates iteration, exactly as it does today. Capacity for all 64 dynamic lights is preserved.

## Testing

- [x] Builds without warnings (`make -j$(nproc)`) — Debian 12 (bookworm) container; the only warnings in the build log are pre-existing on `main` (`voxel.c` enum conversions, `check_mem.c` unused variables), none from files touched here
- [ ] Tests pass (`make check`) — blocked by the pre-existing `check_master` link failure on `main` (`undefined reference to Net_HttpPostAsync`); unrelated to this change
- [x] Tested in-game on Windows 11 / RTX 4090 (driver 610.47): patched `uniforms.glsl` into a current install — all GLSL programs compile and link, renderer initializes past the exact failure point (`Shadow atlas` → `Client initialized`), menu renders normally

## Notes

- I don't have hardware running the failing driver (NVIDIA 441.08 / GTX 980), so the in-game test above demonstrates *no regression on modern drivers* rather than reproducing the original failure. The fix rationale for the old driver is arithmetic: legacy NVIDIA vertex-program profiles cap parameters at 256 vec4 slots, which 576 scalars exceed and 64 fits easily. It would be great if the reporter in #842 could confirm on the affected machine.
- Independent of this fix, a fatal shader compile error currently presents to users as a crash + minidump (and reads like an installer failure). A friendlier "please update your graphics driver" path in `R_LoadProgram` might be worth a follow-up — happy to take that on if there's interest.
