### PR TITLE
sv_game: fix GCC 11 build-linux failure (JSONProperties descriptors → locals)

### DIFF
--- a/src/server/sv_game.c
+++ b/src/server/sv_game.c
@@ -217,28 +217,6 @@ static void Sv_PostStatsCallback(int32_t status, Data *data, void *user_data) {
   }
 }
 
-static const JSONProperties sv_frag_properties = MakeJSONProperties(g_frag_t,
-  MakeJSONProperty(g_frag_t, level,         JSONSerializeCharacters, NULL, NULL),
-  MakeJSONProperty(g_frag_t, attacker,      JSONSerializeCharacters, NULL, NULL),
-  MakeJSONProperty(g_frag_t, attacker_guid, JSONSerializeCharacters, NULL, NULL),
-  MakeJSONProperty(g_frag_t, attacker_ai,   JSONSerializeBoole,      NULL, NULL),
-  MakeJSONProperty(g_frag_t, target,        JSONSerializeCharacters, NULL, NULL),
-  MakeJSONProperty(g_frag_t, target_guid,   JSONSerializeCharacters, NULL, NULL),
-  MakeJSONProperty(g_frag_t, target_ai,     JSONSerializeBoole,      NULL, NULL),
-  MakeJSONProperty(g_frag_t, weapon,        JSONSerializeCharacters, NULL, NULL),
-  MakeJSONProperty(g_frag_t, mod,           JSONSerializeInt32,      NULL, NULL),
-  MakeJSONProperty(g_frag_t, time,          JSONSerializeInt32,      NULL, NULL)
-);
-
-static const JSONProperties sv_capture_properties = MakeJSONProperties(g_capture_t,
-  MakeJSONProperty(g_capture_t, level,       JSONSerializeCharacters, NULL, NULL),
-  MakeJSONProperty(g_capture_t, player,      JSONSerializeCharacters, NULL, NULL),
-  MakeJSONProperty(g_capture_t, player_guid, JSONSerializeCharacters, NULL, NULL),
-  MakeJSONProperty(g_capture_t, player_ai,   JSONSerializeBoole,      NULL, NULL),
-  MakeJSONProperty(g_capture_t, team,        JSONSerializeCharacters, NULL, NULL),
-  MakeJSONProperty(g_capture_t, time,        JSONSerializeInt32,      NULL, NULL)
-);
-
 /**
  * @brief Serializes frag events from the game module to JSON and POSTs them
  * asynchronously to `sv_stats_url`. Gated on `sv_public` and a non-empty URL.
@@ -250,6 +228,19 @@ static void Sv_PostStats(const g_frag_t *frags, size_t frags_len, const g_captur
   }
 
   if (frags_len) {
+
+    const JSONProperties sv_frag_properties = MakeJSONProperties(g_frag_t,
+      MakeJSONProperty(g_frag_t, level,         JSONSerializeCharacters, NULL, NULL),
+      MakeJSONProperty(g_frag_t, attacker,      JSONSerializeCharacters, NULL, NULL),
+      MakeJSONProperty(g_frag_t, attacker_guid, JSONSerializeCharacters, NULL, NULL),
+      MakeJSONProperty(g_frag_t, attacker_ai,   JSONSerializeBoole,      NULL, NULL),
+      MakeJSONProperty(g_frag_t, target,        JSONSerializeCharacters, NULL, NULL),
+      MakeJSONProperty(g_frag_t, target_guid,   JSONSerializeCharacters, NULL, NULL),
+      MakeJSONProperty(g_frag_t, target_ai,     JSONSerializeBoole,      NULL, NULL),
+      MakeJSONProperty(g_frag_t, weapon,        JSONSerializeCharacters, NULL, NULL),
+      MakeJSONProperty(g_frag_t, mod,           JSONSerializeInt32,      NULL, NULL),
+      MakeJSONProperty(g_frag_t, time,          JSONSerializeInt32,      NULL, NULL)
+    );
 
     static char frags_url[MAX_STRING_CHARS];
     g_snprintf(frags_url, sizeof(frags_url), "%s/api/frags", sv_stats_url->string);
@@ -266,6 +257,15 @@ static void Sv_PostStats(const g_frag_t *frags, size_t frags_len, const g_captur
   }
 
   if (captures_len) {
+
+    const JSONProperties sv_capture_properties = MakeJSONProperties(g_capture_t,
+      MakeJSONProperty(g_capture_t, level,       JSONSerializeCharacters, NULL, NULL),
+      MakeJSONProperty(g_capture_t, player,      JSONSerializeCharacters, NULL, NULL),
+      MakeJSONProperty(g_capture_t, player_guid, JSONSerializeCharacters, NULL, NULL),
+      MakeJSONProperty(g_capture_t, player_ai,   JSONSerializeBoole,      NULL, NULL),
+      MakeJSONProperty(g_capture_t, team,        JSONSerializeCharacters, NULL, NULL),
+      MakeJSONProperty(g_capture_t, time,        JSONSerializeInt32,      NULL, NULL)
+    );
 
     static char captures_url[MAX_STRING_CHARS];
     g_snprintf(captures_url, sizeof(captures_url), "%s/api/captures", sv_stats_url->string);


### PR DESCRIPTION
Fixes the `build-linux` failure on #851.

`build-linux` pins `ubuntu-22.04` (gcc 11.4.0), which rejects the two file-scope `static const JSONProperties` descriptors in `src/server/sv_game.c`:

```
sv_game.c:220:50: error: initializer element is not constant
sv_game.c:233:53: error: initializer element is not constant
```

`MakeJSONProperties(...)` expands to a compound literal whose `.properties` is the address of a nested `(const JSONProperty[]){ … }` built from per-field `(JSONProperty){ … }` literals; gcc-11 won't treat that as an address constant in a static initializer. MSVC accepts it (so `build-windows` is green), and so does the newer gcc on `ubuntu-latest` — Objectively itself keeps the same file-scope-static form in `Tests/Objectively/JSON.c` and that CI passes.

Both descriptors are used only inside `Sv_PostStats`, so this moves each into an automatic `const JSONProperties` local in the branch that uses it. Automatic objects permit non-constant initializers, so it compiles on gcc-11 as well. It's a pure move — the property lists are unchanged and the `&`-of call sites are untouched. Cold POST-path code, so per-call construction is negligible.

Full diagnosis: https://github.com/jdolan/quetoo/pull/851#issuecomment-4712697840

🤖 Generated with [Claude Code](https://claude.com/claude-code)
