### PR TITLE
Mask lock keys so editor key binds work while they're on (#839)

### DIFF
--- a/src/cgame/default/ui/editor/EntityViewController.c
+++ b/src/cgame/default/ui/editor/EntityViewController.c
@@ -157,7 +157,9 @@ static void respondToKeyEvent(EntityViewController *self, const SDL_Event *event
   cm_entity_t *e = self->entity ? self->entity->def : NULL;
 
   const SDL_Keycode key = event->key.key;
-  const int32_t mod = event->key.mod;
+  // Mask out lock keys (Num/Caps/Scroll); their sticky modifier bits otherwise
+  // suppress all un-modified editor key binds while toggled on (#839).
+  const int32_t mod = event->key.mod & ~(SDL_KMOD_NUM | SDL_KMOD_CAPS | SDL_KMOD_SCROLL);
 
   if (mod & SDL_KMOD_CLIPBOARD) {
     switch (key) {


### PR DESCRIPTION
## Summary

When any lock key (Num/Caps/Scroll Lock) is toggled on, the in-game level editor stops responding to un-modified key binds. This makes grid sizing (1-8), the `G` func_group bbox toggle, and the WASD/QE/arrow/keypad light and entity movement keys all dead until the lock is turned back off.

The cause is in `respondToKeyEvent()` in `src/cgame/default/ui/editor/EntityViewController.c`. The un-modified key block was gated behind `mod == SDL_KMOD_NONE`. SDL packs the sticky lock-key states (`SDL_KMOD_NUM` / `SDL_KMOD_CAPS` / `SDL_KMOD_SCROLL`) into `event->key.mod`, so any active lock makes that exact-equality check false and the whole block is skipped.

The fix masks those three lock bits out of `mod` before the modifier checks, so the sticky states no longer interfere. The copy/paste branch above it uses a bitmask test (`mod & SDL_KMOD_CLIPBOARD`) and was already unaffected; in-game binds (`Cl_KeyGame` in `src/client/cl_keys.c`) key off scancode and never read `mod`, so they were unaffected too.

Fixes #839

## Changes

- Mask `SDL_KMOD_NUM | SDL_KMOD_CAPS | SDL_KMOD_SCROLL` out of `mod` in `respondToKeyEvent()` (`src/cgame/default/ui/editor/EntityViewController.c`) so a toggled-on lock key no longer suppresses un-modified editor key binds.

## Testing

- [x] Builds without warnings (`make -j$(nproc)`)
- [ ] Tests pass (`make check`)
- [ ] Tested in-game on <!-- platform(s) -->

## Notes

- Clean build of the full project (gcc, `make -j8`). The changed translation unit (`EntityViewController.o`) compiled with zero diagnostics. The build emits 8 warnings total, all pre-existing and in unrelated files (`voxel.c` `-Wenum-conversion`, `check_mem.c` unused variables); this change adds none.
- The editor unit test passes 9/9 (`./src/tests/check_editor_map`).
- Full `make check` was not run: linking `check_master` currently fails on a known, pre-existing undefined-reference issue unrelated to this change, so the suite cannot complete end to end. The relevant editor test was run directly and passes (above).
- The runtime fix could not be exercised headlessly, since SDL key events require a live input loop. The masking behavior was reasoned about against the SDL modifier semantics rather than observed at runtime; the bug reporter's platform was Windows.
