### PR TITLE
Fix gravity from worldspawn not applying on initial map load (#857)

### DIFF
--- a/src/game/default/g_entity.c
+++ b/src/game/default/g_entity.c
@@ -817,7 +817,9 @@ static void G_worldspawn(g_entity_t *ent) {
   gi.SetConfigString(CS_MAX_CLIENTS, va("%d", sv_max_clients->integer));
 
   const cm_entity_t *gravity_map = G_MapValue("gravity");
-  if (gravity_map && (gravity_map->parsed & ENTITY_INTEGER) && gravity_map->integer > 0) { // prefer map metadata gravity
+  if (g_strcmp0(g_gravity->string, g_gravity->default_string)) { // prefer an explicit g_gravity override
+    g_level.gravity = g_gravity->integer;
+  } else if (gravity_map && (gravity_map->parsed & ENTITY_INTEGER) && gravity_map->integer > 0) { // then map metadata gravity
     g_level.gravity = gravity_map->integer;
   } else { // or fall back on worldspawn
     const cm_entity_t *gravity = gi.EntityValue(ent->def, "gravity");
@@ -827,6 +829,10 @@ static void G_worldspawn(g_entity_t *ent) {
       g_level.gravity = DEFAULT_GRAVITY;
     }
   }
+
+  // clear the flag the cvar carried from creation so the first G_CheckRules frame
+  // can't overwrite the resolved value with g_gravity's default (runtime changes still apply)
+  g_gravity->modified = false;
 
   const cm_entity_t *gameplay_map = G_MapValue("gameplay");
   if (g_strcmp0(g_gameplay->string, "default")) { // prefer g_gameplay


### PR DESCRIPTION
## Summary

`gravity` set in a map's worldspawn (or `maps.lst` metadata) was ignored on the
initial load of a map and only took effect after reloading the same level.

Root cause: every cvar is created with its `modified` flag set (`cvar.c`), so on the
first map load the first `G_CheckRules` frame runs the `if (g_gravity->modified)`
block and overwrites the gravity that `G_worldspawn` had just resolved with the
cvar's default (`800`). On a reload the flag has already been cleared, so the
worldspawn/map value survives — which is why gravity worked on the *second* load but
not the first.

Fixes #857

## Changes

- `G_worldspawn` (`src/game/default/g_entity.c`): resolve level gravity with the same
  precedence the neighbouring `gameplay` block already uses — an explicit `g_gravity`
  override wins, then `maps.lst` metadata, then the worldspawn `gravity` key, then
  `DEFAULT_GRAVITY`.
- Clear `g_gravity->modified` once gravity is resolved for the level, so the stale
  creation-time flag can't clobber the seeded value on the first frame. Genuine
  runtime `g_gravity` changes still apply via `G_CheckRules`, and servers that set
  `g_gravity` (e.g. low-gravity configs, including on maps with no worldspawn gravity)
  are unaffected.

No wire-format change, so no `PROTOCOL_MINOR` bump.

## Testing

- [x] Builds without warnings (`make -j$(nproc)`)
- [ ] Tests pass (`make check`)
- [ ] Tested in-game

Built clean (`game.so` + engine) from source on Debian 12; the change adds no
warnings (the few emitted — `voxel.c`, `check_mem.c` — predate it). `make check` was
not run to completion because linking `check_master` fails on `main` independently of
this change (`undefined reference to Net_HttpPostAsync`), and there is no unit harness
covering `G_worldspawn` entity parsing. Behaviour verified by analysis; happy to add an
in-game confirmation if you'd like.

## Notes

The override is detected with `g_strcmp0(g_gravity->string, g_gravity->default_string)`,
mirroring the adjacent `g_strcmp0(g_gameplay->string, "default")` test, so an admin who
explicitly sets `g_gravity` still takes precedence over a map's worldspawn value.
