### PR TITLE
Exclude human spectators from sv_min_clients count (#867)

### DIFF
--- a/src/game/default/g_ai_main.c
+++ b/src/game/default/g_ai_main.c
@@ -1847,7 +1847,7 @@ void G_Ai_Frame(void) {
     G_ForEachClient(cl, {
       if (cl->ai) {
         ai_clients++;
-      } else {
+      } else if (!cl->persistent.spectator) {
         human_clients++;
       }
     });


### PR DESCRIPTION
## Summary

`sv_min_clients` counted human spectators as players, so bot backfill
was suppressed whenever a human sat in spectator mode. Part of #867.

## Changes

- `g_ai_main.c`: when tallying active players for bot balancing, only
  count humans who are actually playing (skip `persistent.spectator`).
  Bots are counted as before.

## Testing

- [x] Builds without warnings (`make -j$(nproc)`)
- [ ] Tests pass (`make check`)
- [ ] Tested in-game on <!-- pending -->

## Notes

With this, a server using `sv_min_clients` keeps the requested number of
*active* players, filling with bots while humans spectate and kicking a
bot when a human joins the game.
