### PR TITLE
Disable the grappling hook through teleporters (#867)

### DIFF
--- a/src/game/default/g_entity_misc.c
+++ b/src/game/default/g_entity_misc.c
@@ -27,8 +27,21 @@
  */
 static void G_misc_teleporter_Touch(g_entity_t *ent, g_entity_t *other, const cm_trace_t *trace) {
 
+  // a grappling hook shouldn't reach through teleporters: detach a hook
+  // projectile that flies into one rather than letting it pass through (#867)
+  if (other->owner && other->owner->client &&
+      other->owner->client->hook_entity == other) {
+    G_HookDetach(other->owner->client);
+    return;
+  }
+
   if (!G_IsMeat(other)) {
     return;
+  }
+
+  // release a hooked player as they warp, so they aren't tethered across the portal
+  if (other->client && other->client->hook_entity) {
+    G_HookDetach(other->client);
   }
 
   const g_entity_t *dest = G_Find(NULL, EOFS(target_name), ent->target);


### PR DESCRIPTION
## Summary

The grappling hook passed straight through teleporters and attached on
the far side. Part of #867.

A hook projectile is `SOLID_PROJECTILE`, not "meat", so
`G_misc_teleporter_Touch` ignored it (`G_IsMeat` early-out) and let it
fly through the portal volume unaffected.

## Changes

- `g_entity_misc.c`: in the teleporter touch handler, detach the hook
  when its projectile enters a teleporter (identified via
  `owner->client->hook_entity == other`), rather than letting it pass
  through. Also release a hooked player as they warp, so they aren't left
  tethered across the portal.

Both paths reuse the existing `G_HookDetach()`, which frees the hook
projectile and trail, resets client hook state, and plays the detach
sound.

## Testing

- [x] Builds without warnings (`make -j$(nproc)`)
- [ ] Tests pass (`make check`)
- [ ] Tested in-game on <!-- pending -->

## Notes

Covers both the model and model-less teleporter forms, since both use
`G_misc_teleporter_Touch`.
