### PR TITLE
Anchor the first-person hook cable to the player, not the gun muzzle (#867)

### DIFF
--- a/src/cgame/default/cg_entity_trail.c
+++ b/src/cgame/default/cg_entity_trail.c
@@ -1202,7 +1202,14 @@ void Cg_EntityTrail(cl_entity_t *ent) {
 
       // we own this beam (lightning, grapple, etc..)
       // anchor start to the client-side muzzle; keep end as the server-authoritative termination
-      start = cg_state.clients[ent->current.client].weapon_muzzle;
+      if (s->trail == TRAIL_HOOK) {
+        // the grapple cable reads better leaving the player than the view
+        // weapon muzzle, which floats well ahead of the eye and shifts with
+        // cg_fov (#867)
+        start = Cg_Self()->origin;
+      } else {
+        start = cg_state.clients[ent->current.client].weapon_muzzle;
+      }
     }
   } else {
     end = ent->origin;


### PR DESCRIPTION
## Summary

In first person the grappling-hook cable started well in front of the
player rather than at the player, and the offset grew with `cg_fov`
(e.g. `cg_fov 130`). Part of #867.

The owned-beam start was anchored to the view weapon's muzzle for every
beam we own. That muzzle is a point on the first-person view model, so in
world space it floats ahead of the eye and shifts as the view weapon is
repositioned for different FOVs. For a long grapple cable this read as
the line starting far in front of you.

## Changes

- `cg_entity_trail.c`: for a hook beam we own, anchor the cable start to
  the player's own origin (`Cg_Self()->origin`) instead of the view
  weapon muzzle. This is FOV-independent and reads as the cable leaving
  the body. Other owned beams (lightning, etc.) are unchanged.

## Testing

- [x] Builds without warnings (`make -j$(nproc)`)
- [ ] Tests pass (`make check`)
- [ ] Tested in-game on <!-- needs a visual confirmation pass -->

## Notes

This implements the `Cg_Self()->s.origin` approach suggested in the
issue. The exact start height is the player entity origin (roughly
mid-body); if a different anchor height reads better in-game it's a
one-line tweak.
