### PR TITLE
Quetoo: update for Objectively 2.x (collapse Mutable* classes)

### DIFF
--- a/src/cgame/default/ui/common/BindTextView.c
+++ b/src/cgame/default/ui/common/BindTextView.c
@@ -74,7 +74,7 @@ static void updateBindings(View *self) {
   BindTextView *this = (BindTextView *) self;
   if (this->bind) {
 
-    MutableArray *keys = $$(MutableArray, array);
+    Array *keys = $$(Array, array);
     SDL_Scancode key = SDL_SCANCODE_UNKNOWN;
     while (true) {
       key = cgi.KeyForBind(key, ((BindTextView *) this)->bind);

--- a/src/cgame/default/ui/editor/EntityView.c
+++ b/src/cgame/default/ui/editor/EntityView.c
@@ -41,8 +41,8 @@ static void didEndEditing(TextView *textView) {
 
   cm_entity_t *e = self->pair ?: cgi.AllocEntity();
 
-  const char *key = self->key->attributedText->string.chars;
-  const char *value = self->value->attributedText->string.chars;
+  const char *key = self->key->attributedText->chars;
+  const char *value = self->value->attributedText->chars;
 
   g_strlcpy(e->key, key ?: "", sizeof(e->key));
   g_strlcpy(e->string, value ?: "", sizeof(e->string));

--- a/src/cgame/default/ui/editor/MeshViewController.c
+++ b/src/cgame/default/ui/editor/MeshViewController.c
@@ -61,7 +61,7 @@ static void didEndEditing(TextView *textView) {
     return;
   }
 
-  const char *text = textView->attributedText->string.chars ?: "";
+  const char *text = textView->attributedText->chars ?: "";
 
   r_mesh_config_t *world = &this->model->mesh->config.world;
   r_mesh_config_t *link  = &this->model->mesh->config.link;

--- a/src/cgame/default/ui/main/UpdateViewController.c
+++ b/src/cgame/default/ui/main/UpdateViewController.c
@@ -162,7 +162,7 @@ static void loadView(ViewController *self) {
 
 	this->pendingImagesLock = SDL_CreateMutex();
 	assert(this->pendingImagesLock);
-	this->pendingImages = $(alloc(MutableArray), init);
+	this->pendingImages = $(alloc(Array), init);
 	assert(this->pendingImages);
 
 	$(this->logo, setImageWithResourceName, "ui/loading.png");

--- a/src/cgame/default/ui/main/UpdateViewController.h
+++ b/src/cgame/default/ui/main/UpdateViewController.h
@@ -68,7 +68,7 @@ struct UpdateViewController {
 	/**
 	 * @brief Pending hero images fetched by the background thread, then added to slideShow on the main thread.
 	 */
-	MutableArray *pendingImages;
+	Array *pendingImages;
 
   /**
    * @brief A mutex for ensuring consistent access to the pendingImages array.

--- a/src/cgame/default/ui/play/CreateServerViewController.c
+++ b/src/cgame/default/ui/play/CreateServerViewController.c
@@ -65,7 +65,7 @@ static void createServer(Button *button) {
     file_t *file = cgi.OpenFileWrite(MAP_LIST_UI);
     if (file) {
 
-      MutableString *string = mstr("");
+      String *string = $(alloc(String), init);
 
       for (size_t i = 0; i < selectedMaps->count; i++) {
 
@@ -78,7 +78,7 @@ static void createServer(Button *button) {
         $(string, appendFormat, "{\n\tname %s\n}\n", name);
       }
 
-      const int64_t len = cgi.WriteFile(file, string->string.chars, string->string.length, 1);
+      const int64_t len = cgi.WriteFile(file, string->chars, string->length, 1);
 
       if (len == -1) {
         Cg_Warn("Failed to write %s\n", MAP_LIST_UI);

--- a/src/cgame/default/ui/play/CreateServerViewController.c
+++ b/src/cgame/default/ui/play/CreateServerViewController.c
@@ -65,7 +65,8 @@ static void createServer(Button *button) {
     file_t *file = cgi.OpenFileWrite(MAP_LIST_UI);
     if (file) {
 
-      String *string = $(alloc(String), init);
+      String *string = str("");
+      assert(string);
 
       for (size_t i = 0; i < selectedMaps->count; i++) {
 

--- a/src/cgame/default/ui/play/MapListCollectionView.c
+++ b/src/cgame/default/ui/play/MapListCollectionView.c
@@ -266,7 +266,7 @@ static MapListCollectionView *initWithFrame(MapListCollectionView *self, const S
     self->lock = $(alloc(Lock), init);
     assert(self->lock);
 
-    self->maps = $$(MutableArray, array);
+    self->maps = $$(Array, array);
     assert(self->maps);
 
     cgi.Thread(__func__, loadMaps, self, THREAD_NO_WAIT);
@@ -289,7 +289,7 @@ static Array *selectedMaps(const MapListCollectionView *self) {
 
   const CollectionView *this = (const CollectionView *) self;
 
-  MutableArray *selectedMaps = $$(MutableArray, array);
+  Array *selectedMaps = $$(Array, array);
 
   Array *selection = $(this, selectionIndexPaths);
   for (size_t i = 0; i < selection->count; i++) {

--- a/src/cgame/default/ui/play/MapListCollectionView.h
+++ b/src/cgame/default/ui/play/MapListCollectionView.h
@@ -59,7 +59,7 @@ struct MapListCollectionView {
   /**
    * @brief Available maps.
    */
-  MutableArray *maps;
+  Array *maps;
 };
 
 /**


### PR DESCRIPTION
Absorbs https://github.com/jdolan/Objectively/pull/31 and http://github.com/jdolan/ObjectivelyMVC/pull/40