### PR TITLE
collision: null-terminate manifest buffer before parsing

### DIFF
--- a/src/collision/cm_manifest.c
+++ b/src/collision/cm_manifest.c
@@ -118,7 +118,15 @@ GHashTable *Cm_ParseManifest(const char *data, size_t len) {
 		return manifest;
 	}
 
-	gchar **lines = g_strsplit((const char *) data, "\n", -1);
+	// `data` is not guaranteed to be null-terminated (e.g. buffers returned by
+	// Net_HttpGet are exactly `len` bytes), so copy into a null-terminated buffer
+	// before splitting. Passing the raw buffer to g_strsplit() reads past its end
+	// into adjacent heap memory, yielding bogus trailing entries.
+	char *buffer = Mem_Malloc(len + 1);
+	memcpy(buffer, data, len);
+	buffer[len] = '\0';
+
+	gchar **lines = g_strsplit(buffer, "\n", -1);
 
 	for (gchar **line = lines; *line; line++) {
 		g_strstrip(*line);
@@ -150,6 +158,7 @@ GHashTable *Cm_ParseManifest(const char *data, size_t len) {
 	}
 
 	g_strfreev(lines);
+	Mem_Free(buffer);
 
 	return manifest;
 }

--- a/src/tests/check_cm_manifest.c
+++ b/src/tests/check_cm_manifest.c
@@ -103,6 +103,35 @@ START_TEST(check_Cm_ReadManifest_missing_file) {
 
 } END_TEST
 
+START_TEST(check_Cm_ParseManifest_respects_len) {
+
+	// Simulates a buffer from Net_HttpGet, which is not null-terminated: the
+	// valid manifest is followed by stale bytes that look like another (bogus)
+	// entry. Cm_ParseManifest must honor `len` and never read past it.
+	static const char valid[] =
+		"d41d8cd98f00b204e9800998ecf8427e 1234 textures/edge/floor01_d.tga\n";
+	static const char garbage[] =
+		"deadbeefdeadbeefdeadbeefdeadbeef 9999 textures/overrun.tga\n";
+
+	const size_t len = sizeof(valid) - 1; // valid content only, no null terminator
+
+	char *buffer = Mem_Malloc(len + sizeof(garbage));
+	memcpy(buffer, valid, len);
+	memcpy(buffer + len, garbage, sizeof(garbage)); // trailing bytes past `len`
+
+	GHashTable *manifest = Cm_ParseManifest(buffer, len);
+	ck_assert_msg(manifest != NULL, "Cm_ParseManifest returned NULL");
+	ck_assert_int_eq(g_hash_table_size(manifest), 1);
+	ck_assert_msg(g_hash_table_lookup(manifest, "textures/edge/floor01_d.tga") != NULL,
+		"Missing valid entry");
+	ck_assert_msg(g_hash_table_lookup(manifest, "textures/overrun.tga") == NULL,
+		"Parsed an entry from beyond `len` (buffer over-read)");
+
+	Cm_FreeManifest(manifest);
+	Mem_Free(buffer);
+
+} END_TEST
+
 START_TEST(check_Cm_WriteManifest) {
 
 	const char *content1 = "hello";
@@ -212,6 +241,7 @@ int32_t main(int32_t argc, char **argv) {
 		tcase_add_test(tcase, check_Cm_ReadManifest);
 		tcase_add_test(tcase, check_Cm_ReadManifest_empty_lines);
 		tcase_add_test(tcase, check_Cm_ReadManifest_missing_file);
+		tcase_add_test(tcase, check_Cm_ParseManifest_respects_len);
 
 		suite_add_tcase(suite, tcase);
 	}


### PR DESCRIPTION
## Summary

`Cm_ParseManifest()` reads past the end of its input buffer. It passes the
incoming `(const char *)data` straight to `g_strsplit()`, which scans for a
NUL terminator — but the buffer is not guaranteed to be NUL-terminated. In
the installer's update path the manifest comes from `Net_HttpGet()`, which
returns a buffer of exactly `len` bytes with no terminator, so the parser
walks off the end of the allocation into adjacent heap memory.

The over-read produces phantom entries built from whatever heap bytes follow
the buffer. In practice this shows up as spurious `Malformed manifest line:`
warnings (sometimes binary garbage, sometimes stale fragments of a previous
allocation that look like real paths) and bogus entries the installer then
tries to download — e.g. `default/14507%20decals/blood_0.png`, where a real
entry's `size path` got mashed into the `path` field. Those 404, which fails
the update.

No issue filed; happy to open one if preferred.

## Changes

- `src/collision/cm_manifest.c`: copy the input into a NUL-terminated buffer
  of exactly `len` bytes before `g_strsplit()`, so parsing never reads past
  `len` regardless of how the caller obtained the data.
- `src/tests/check_cm_manifest.c`: add `check_Cm_ParseManifest_respects_len`,
  which parses a non-terminated buffer with trailing garbage and asserts that
  nothing beyond `len` is parsed.

## Testing

- [x] Builds without warnings (`make -j$(nproc)`) — clean build from a fresh
  checkout; no warnings from the changed files.
- [x] Tests pass — `check_cm_manifest` is 7/7. The new test fails on the
  current parser (`g_hash_table_size == 2`, parses the trailing garbage entry)
  and passes with the fix. (Ran the target directly; full `make check` is
  blocked by the pre-existing `check_master` link failure on `main`.)
- [ ] Tested in-game — not run; the unit test reproduces the exact failure
  (red→green) without needing a live data server.

## Notes

The fix is at the parser so every caller is covered, but `Net_HttpGet()`
returning a non-terminated buffer is the underlying sharp edge — worth a look
if other call sites treat its output as a C string.
