### PR TITLE
Coalesce movement commands under vsync to fix high-FPS jump bug

### DIFF
--- a/src/client/cl_cmd.c
+++ b/src/client/cl_cmd.c
@@ -122,13 +122,13 @@ void Cl_WriteEntityInfoCommand(int16_t number, const cm_entity_t *entity) {
  * @brief Pumps the command cycle, sending the most recently gathered movement to the server.
  * @details Commands must meet a certain duration, in milliseconds, in order to be sent. This
  * prevents saturating the network channel with very small movement commands, which are also
- * problematic for the physics and prediction code.
+ * problematic for the physics and prediction code. This holds regardless of vsync (#866).
  */
 void Cl_SendCommands(void) {
 
   const uint32_t delta = quetoo.ticks - cls.net_chan.last_sent;
 
-  if (delta < 8 && !r_swap_interval->value) {
+  if (delta < 8) {
     return;
   }
 


### PR DESCRIPTION
Fixes #866 (partial/erratic jumps at high FPS with vsync enabled).

## Cause

`Cl_SendCommands` throttles movement commands to a minimum duration (8ms) because, per its own comment, sub-threshold commands are *"problematic for the physics and prediction code."* Vsync was exempt from that throttle (`!r_swap_interval->value`), so at high refresh rates the client issued a movement command **every rendered frame** — ~2.7ms at 360Hz.

A jump sets `velocity.z = PM_SPEED_JUMP` and `PMF_JUMPED`, which suppresses ground-seeking — but only for a single command. With ~2.7ms commands the player rises less than `PM_GROUND_DIST (1.0u)`, so on the next command `Pm_CheckGround` re-grounds and snaps the origin back down, absorbing the jump ("partial jump"). The leftover upward velocity plus the armed trick-jump timer then let a quick re-press stack a full jump ("very high"). Because the trigger is the throttle bypass keying off vsync being enabled at all, framerate is incidental — which is why `r_swap_interval 2` didn't help but disabling vsync did.

## Fix

Apply the existing minimum-duration throttle regardless of vsync, coalescing short frames into a single command exactly as the non-vsync path already does. This restores the >=8ms command guarantee lost when the vsync `SDL_Delay` padding was removed (be2c01d05), without reintroducing blocking. pps under vsync now caps at ~125 (matching non-vsync) instead of tracking refresh.

## Testing

Windows, RTX 5090 @ 360Hz, vsync enabled: jumps full-height and consistent; strafe/ramp/trick jumps and stairs normal; input latency imperceptible. With vsync disabled, behavior unchanged.
