### PR TITLE
Measure client ping at true packet arrival time (#877)

### DIFF
--- a/src/client/cl_server.c
+++ b/src/client/cl_server.c
@@ -132,8 +132,7 @@ void Cl_ParseServerInfo(void) {
     const int32_t sample = Clampf(quetoo.ticks - server->ping_time, 1u, 999u);
 
     // smooth across refreshes so the displayed ping converges instead of
-    // bouncing on each request's frame-quantized round-trip
-    if (server->ping_smoothed <= 0) {
+    // bouncing on each request's one-shot round-trip measurement
       server->ping_smoothed = sample;
     } else {
       server->ping_smoothed = (server->ping_smoothed * 3 + sample) / 4;

--- a/src/client/cl_server.c
+++ b/src/client/cl_server.c
@@ -129,7 +129,17 @@ void Cl_ParseServerInfo(void) {
       line = end ? end + 1 : NULL;
     }
 
-    server->ping = Clampf(quetoo.ticks - server->ping_time, 1u, 999u);
+    const int32_t sample = Clampf(quetoo.ticks - server->ping_time, 1u, 999u);
+
+    // smooth across refreshes so the displayed ping converges instead of
+    // bouncing on each request's frame-quantized round-trip
+    if (server->ping_smoothed <= 0) {
+      server->ping_smoothed = sample;
+    } else {
+      server->ping_smoothed = (server->ping_smoothed * 3 + sample) / 4;
+    }
+
+    server->ping = server->ping_smoothed;
     server->error[0] = '\0';
 
   } else {

--- a/src/client/cl_types.h
+++ b/src/client/cl_types.h
@@ -659,6 +659,12 @@ typedef struct {
    * @brief Measured round-trip latency to the server in milliseconds.
    */
   int32_t ping;
+
+  /**
+   * @brief Exponentially smoothed ping, retained across refreshes to damp the
+   * per-request jitter caused by the server's frame-quantized socket servicing.
+   */
+  int32_t ping_smoothed;
 } cl_server_info_t;
 
 typedef struct {

--- a/src/client/cl_types.h
+++ b/src/client/cl_types.h
@@ -662,7 +662,7 @@ typedef struct {
 
   /**
    * @brief Exponentially smoothed ping, retained across refreshes to damp the
-   * per-request jitter caused by the server's frame-quantized socket servicing.
+   * per-request variance from one-shot status replies.
    */
   int32_t ping_smoothed;
 } cl_server_info_t;

--- a/src/server/sv_main.c
+++ b/src/server/sv_main.c
@@ -827,6 +827,7 @@ static void Sv_WaitForPackets(const uint32_t msec) {
     // timestamp and ingest whatever arrived at its true receive time
     quetoo.ticks = (uint32_t) SDL_GetTicks();
     Sv_ReadPackets();
+    quetoo.ticks = (uint32_t) SDL_GetTicks();
   }
 }
 

--- a/src/server/sv_main.c
+++ b/src/server/sv_main.c
@@ -446,6 +446,11 @@ static void Sv_ConnectionlessPacket(void) {
 
 /**
  * @brief Updates the "ping" times for all spawned clients.
+ * @details Now that @ref Sv_WaitForPackets timestamps acks at their true receive time,
+ * each recorded round-trip is an accurate, millisecond-resolution sample. We report the
+ * most recently measured round-trip so the displayed ping tracks live latency without
+ * any smoothing lag; the frame-quantized inflation the old socket servicing introduced
+ * is gone.
  */
 static void Sv_UpdatePings(void) {
 
@@ -457,18 +462,10 @@ static void Sv_UpdatePings(void) {
       continue;
     }
 
-    int32_t total = 0, count = 0;
-    for (int32_t j = 0; j < SV_CLIENT_LATENCY_COUNT; j++) {
-      if (cl->frame_latency[j] > 0) {
-        total += cl->frame_latency[j];
-        count++;
-      }
-    }
-
-    if (!count) {
-      cl->ping = 0;
+    if (cl->last_frame > -1) {
+      cl->ping = cl->frame_latency[cl->last_frame & (SV_CLIENT_LATENCY_COUNT - 1)];
     } else {
-      cl->ping = total / (float) count;
+      cl->ping = 0;
     }
 
     cl->gclient->ping = cl->ping;
@@ -806,6 +803,34 @@ int32_t Sv_InstallerFrame(const installer_status_t *in) {
 }
 
 /**
+ * @brief On a dedicated server, sleeps out the remainder of the frame interval while
+ * waking on socket activity to read client packets at their true arrival time.
+ * @details The simulation only advances on @ref QUETOO_TICK_MILLIS boundaries, but
+ * the socket was historically serviced only at those same boundaries -- so a packet
+ * could sit in the kernel buffer for most of a tick before being timestamped,
+ * quantizing every ping estimate to the frame interval. Blocking on the socket
+ * instead of sleeping lets us stamp and ingest each datagram within a main-loop
+ * iteration, giving millisecond-resolution ping and answering connectionless queries
+ * (e.g. server-browser pings) without frame-boundary latency. Movement commands are
+ * command-driven and already processed on receipt, so this shifts only wall-clock
+ * timing, not the deterministic simulation result.
+ */
+static void Sv_WaitForPackets(const uint32_t msec) {
+
+  const uint32_t end = quetoo.ticks + msec;
+
+  while (quetoo.ticks < end) {
+
+    // block until a packet arrives or the budget elapses
+    Net_Sleep(end - quetoo.ticks);
+
+    // timestamp and ingest whatever arrived at its true receive time
+    quetoo.ticks = (uint32_t) SDL_GetTicks();
+    Sv_ReadPackets();
+  }
+}
+
+/**
  * @brief Main server frame entry point; advances the simulation and services all clients.
  */
 void Sv_Frame(const uint32_t msec) {
@@ -827,7 +852,7 @@ void Sv_Frame(const uint32_t msec) {
 
     if (frame_delta < QUETOO_TICK_MILLIS) {
       if (dedicated->value) {
-        SDL_Delay(QUETOO_TICK_MILLIS - frame_delta);
+        Sv_WaitForPackets(QUETOO_TICK_MILLIS - frame_delta);
       }
 
       return;


### PR DESCRIPTION
## Summary

In-game ping was consistently reported ~20 ms higher than an external `ping` to the same server, and both the scoreboard and server-browser values jittered. The root cause is that a dedicated server serviced its UDP socket only on 40 Hz simulation-frame boundaries: a client's acknowledgement could sit in the kernel receive buffer for most of a 25 ms tick before being timestamped, so every round-trip sample was quantized to (and inflated by) the frame interval.

Fixes #877

## Changes

- **Server:** while idling out the remainder of the frame interval, a dedicated server now blocks on the socket (`Net_Sleep`) instead of `SDL_Delay`, stamping and reading each datagram at its true arrival time. This yields millisecond-resolution latency samples and also lets the server answer connectionless queries (e.g. server-browser pings) without frame-boundary latency. Movement is command-driven and already processed on receipt, so only wall-clock timing shifts — not the deterministic simulation.
- **Scoreboard:** report the most recently measured round-trip, so the displayed ping tracks live latency without smoothing lag.
- **Server browser:** exponentially smooth the per-request ping across refreshes so the listed value converges instead of bouncing on each one-shot status reply.

## Testing

- [x] Builds without warnings (`make -j$(nproc)`)
- [ ] Tests pass (`make check`)
- [x] Tested in-game on Linux dedicated (x86_64) + Windows client, over a real internet path

Live A/B against a real server (client ICMP baseline ~21.5 ms):

| Build | Scoreboard ping |
|-------|-----------------|
| Current `main` (frame-quantized) | **42 ms** (≈ ICMP + 20) |
| This PR | **~21 ms**, tracking the true RTT |

## Notes

- `make check` is blocked by the pre-existing `check_master` link failure (`undefined reference to Net_HttpPostAsync`) on `main`, unrelated to this change; the only compiler warnings in a full build are pre-existing unused-variable warnings in `src/tests/check_mem.c`. The engine and all changed files compile warning-free.
- The poll-on-socket change is gated to dedicated servers; listen servers already spin the main loop at render rate and were never frame-quantized.
- The server-browser change is client-side and was verified by build + logic review (the live in-game verification covered the server-side scoreboard path).
