### PR TITLE
Fix missing if-block in Cl_ParseServerInfo ping smoothing

### DIFF
--- a/src/client/cl_server.c
+++ b/src/client/cl_server.c
@@ -133,6 +133,7 @@ void Cl_ParseServerInfo(void) {
 
     // smooth across refreshes so the displayed ping converges instead of
     // bouncing on each request's one-shot round-trip measurement
+    if (server->ping_smoothed == 0) {
       server->ping_smoothed = sample;
     } else {
       server->ping_smoothed = (server->ping_smoothed * 3 + sample) / 4;


### PR DESCRIPTION
## Summary

The ping-smoothing logic introduced in #877/#883 was merged with a missing `if (server->ping_smoothed == 0) {` opening brace. This left `sample` declared in dead code, produced a dangling `else`, and caused a build failure on `main`.

## Fix

Restore the missing `if` condition around the first branch of the smoothing logic:

```c
if (server->ping_smoothed == 0) {
    server->ping_smoothed = sample;
} else {
    server->ping_smoothed = (server->ping_smoothed * 3 + sample) / 4;
}
```

Fixes the CI failure at https://github.com/jdolan/quetoo/actions/runs/27918121448.