### PR TITLE
Fix single-track music playlist not repeating

### DIFF
--- a/src/client/sound/s_music.c
+++ b/src/client/sound/s_music.c
@@ -405,7 +405,7 @@ void S_RenderMusic(const s_stage_t *stage) {
 
   SDL_UnlockMutex(s_music_state.mutex);
 
-  if (S_MusicGain() && state != AL_PLAYING) {
+  if (S_MusicGain() && (state == AL_STOPPED || state == AL_INITIAL)) {
     S_NextTrack_f();
   }
 

--- a/src/client/sound/s_music.c
+++ b/src/client/sound/s_music.c
@@ -420,10 +420,9 @@ void S_RenderMusic(const s_stage_t *stage) {
 void S_NextTrack_f(void) {
 
   if (S_MusicGain()) {
-    s_music_t *current = S_CurrentMusic();
     s_music_t *music = S_NextMusic();
 
-    if (music && music != current) {
+    if (music) {
       S_PlayMusic(music);
     } else {
       Com_Debug(DEBUG_SOUND, "No music available\n");

--- a/src/client/sound/s_music.c
+++ b/src/client/sound/s_music.c
@@ -420,10 +420,15 @@ void S_RenderMusic(const s_stage_t *stage) {
 void S_NextTrack_f(void) {
 
   if (S_MusicGain()) {
+    s_music_t *current = S_CurrentMusic();
     s_music_t *music = S_NextMusic();
 
     if (music) {
-      S_PlayMusic(music);
+      if (music == s_music_state.default_music && current == s_music_state.default_music) {
+        Com_Debug(DEBUG_SOUND, "Default music already playing\n");
+      } else {
+        S_PlayMusic(music);
+      }
     } else {
       Com_Debug(DEBUG_SOUND, "No music available\n");
     }


### PR DESCRIPTION
When the `music` field in `maps.lst` specifies a single track, `S_NextMusic()` wraps around to that same track. The original `!= current` guard prevented replay, causing silence after the track finished.

Replace the blanket `!= current` guard with a narrower check: skip restart only when both next and current are the **default (menu) music**, preserving the existing behavior of not restarting the menu track on every `Cl_ClearState` call. Any map-specified track will restart as expected.

Fixes #884