### PR TITLE
net: fragment oversized netchan messages for Internet transmission (#888)

### DIFF
--- a/src/client/cl_cmd.c
+++ b/src/client/cl_cmd.c
@@ -138,6 +138,12 @@ void Cl_SendCommands(void) {
 
       if (cls.net_chan.message.size || delta > 1000) {
         Netchan_Transmit(&cls.net_chan, NULL, 0);
+
+        // a large reliable message may have fragmented
+        while (cls.net_chan.unsent_fragments) {
+          Netchan_TransmitNextFragment(&cls.net_chan);
+        }
+
         cl.packet_counter[cl.sample_index]++;
       }
 
@@ -157,6 +163,12 @@ void Cl_SendCommands(void) {
       Cl_WriteMovementCommand(&buf);
 
       Netchan_Transmit(&cls.net_chan, buf.data, buf.size);
+
+      // a large reliable message (e.g. user info) may have fragmented
+      while (cls.net_chan.unsent_fragments) {
+        Netchan_TransmitNextFragment(&cls.net_chan);
+      }
+
       cl.packet_counter[cl.sample_index]++;
 
       Cl_InitMovementCommand();

--- a/src/common/common.h
+++ b/src/common/common.h
@@ -48,7 +48,7 @@
  * of core net messages or serialized data types change. The game and client
  * game maintain `PROTOCOL_MINOR` as well.
  */
-#define PROTOCOL_MAJOR 2027
+#define PROTOCOL_MAJOR 2028
 
 /**
  * @brief The IP address of the master server, where the authoritative list of

--- a/src/net/net_chan.c
+++ b/src/net/net_chan.c
@@ -25,11 +25,14 @@
  *
  * packet header
  * -------------
- * 31  sequence
+ * 30  sequence
+ * 1  is this message a fragment of a larger message
  * 1  does this message contain a reliable payload
  * 31  acknowledge sequence
  * 1  acknowledge receipt of even/odd message
  * 8  qport
+ * [16  fragment offset, if fragmented]
+ * [16  fragment length, if fragmented]
  *
  * The remote connection never knows if it missed a reliable message, the
  * local side detects that it has been dropped by seeing a sequence acknowledge
@@ -148,10 +151,75 @@ static bool Netchan_CheckRetransmit(net_chan_t *chan) {
 }
 
 /**
+ * @brief Sends the next fragment of the outgoing message currently being
+ * fragmented. The caller drains all fragments by looping on `unsent_fragments`.
+ *
+ * Every fragment of a message carries the same sequence number; the sequence
+ * is only advanced once the final fragment has been sent. A message that is an
+ * exact multiple of `FRAGMENT_SIZE` is terminated by a final, empty fragment so
+ * that the receiver can tell the message is complete.
+ */
+void Netchan_TransmitNextFragment(net_chan_t *chan) {
+  mem_buf_t send;
+  byte send_buffer[MAX_MSG_SIZE];
+
+  Mem_InitBuffer(&send, send_buffer, sizeof(send_buffer));
+
+  const uint32_t w1 = (chan->outgoing_sequence & SEQUENCE_MASK) |
+                      ((uint32_t) chan->unsent_reliable << 31) | FRAGMENT_BIT;
+  const uint32_t w2 = (chan->incoming_sequence & SEQUENCE_MASK) | ((uint32_t) chan->reliable_incoming << 31);
+
+  Net_WriteLong(&send, w1);
+  Net_WriteLong(&send, w2);
+
+  // send the qport if we are a client
+  if (chan->source == NS_UDP_CLIENT) {
+    Net_WriteByte(&send, chan->qport);
+  }
+
+  size_t fragment_length = chan->unsent_length - chan->unsent_fragment_start;
+  if (fragment_length > FRAGMENT_SIZE) {
+    fragment_length = FRAGMENT_SIZE;
+  }
+
+  Net_WriteShort(&send, (int32_t) chan->unsent_fragment_start);
+  Net_WriteShort(&send, (int32_t) fragment_length);
+  Net_WriteData(&send, chan->unsent_buffer + chan->unsent_fragment_start, fragment_length);
+
+  // send the datagram
+  Net_SendDatagram(chan->source, &chan->remote_address, send.data, send.size);
+  chan->last_sent = quetoo.ticks;
+
+  if (net_show_packets->value) {
+    Com_Print("Send %u bytes : s=%i ack=%i rack=%i (fragment %u)\n", (uint32_t) send.size,
+              chan->outgoing_sequence, chan->incoming_sequence, chan->reliable_incoming,
+              (uint32_t) chan->unsent_fragment_start);
+  }
+
+  chan->unsent_fragment_start += fragment_length;
+
+  // a message that exactly fills a fragment still needs a final, empty fragment
+  // so the receiver knows there are no more; only then is the message complete
+  if (chan->unsent_fragment_start == chan->unsent_length && fragment_length != FRAGMENT_SIZE) {
+    chan->outgoing_sequence++;
+    if (chan->unsent_reliable) {
+      chan->reliable_outgoing = chan->outgoing_sequence;
+    }
+    chan->unsent_fragments = false;
+  }
+}
+
+/**
  * @brief Tries to send an unreliable message to a connection, and handles the
  * transmission / retransmission of the reliable messages.
  *
  * A 0 size will still generate a packet and deal with the reliable messages.
+ *
+ * Messages larger than `FRAGMENT_SIZE` are split into multiple sub-MTU
+ * fragments, drained by the caller via `Netchan_TransmitNextFragment`, and
+ * reassembled by the receiver in `Netchan_Process`. This keeps large server
+ * frames (e.g. many entities) deliverable over real UDP without relying on IP
+ * fragmentation.
  */
 void Netchan_Transmit(net_chan_t *chan, byte *data, size_t len) {
   mem_buf_t send;
@@ -174,11 +242,38 @@ void Netchan_Transmit(net_chan_t *chan, byte *data, size_t len) {
     send_reliable = true;
   }
 
-  // write the packet header
+  // assemble the reliable and unreliable parts into a single payload; the
+  // reliable message is always placed first
+  size_t payload_size = 0;
+
+  if (send_reliable) {
+    memcpy(chan->unsent_buffer, chan->reliable_buffer, chan->reliable_size);
+    payload_size = chan->reliable_size;
+  }
+
+  if (payload_size + len <= sizeof(chan->unsent_buffer)) {
+    memcpy(chan->unsent_buffer + payload_size, data, len);
+    payload_size += len;
+  } else {
+    Com_Warn("Netchan_Transmit: dumped unreliable\n");
+  }
+
+  // large messages are fragmented and drained by the caller
+  if (payload_size > FRAGMENT_SIZE) {
+    chan->unsent_fragments = true;
+    chan->unsent_reliable = send_reliable;
+    chan->unsent_fragment_start = 0;
+    chan->unsent_length = payload_size;
+
+    Netchan_TransmitNextFragment(chan);
+    return;
+  }
+
+  // otherwise, write the entire message as a single packet
   Mem_InitBuffer(&send, send_buffer, sizeof(send_buffer));
 
-  const uint32_t w1 = (chan->outgoing_sequence & ~(1u << 31)) | ((uint32_t) send_reliable << 31);
-  const uint32_t w2 = (chan->incoming_sequence & ~(1u << 31)) | ((uint32_t) chan->reliable_incoming << 31);
+  const uint32_t w1 = (chan->outgoing_sequence & SEQUENCE_MASK) | ((uint32_t) send_reliable << 31);
+  const uint32_t w2 = (chan->incoming_sequence & SEQUENCE_MASK) | ((uint32_t) chan->reliable_incoming << 31);
 
   chan->outgoing_sequence++;
   chan->last_sent = quetoo.ticks;
@@ -191,18 +286,11 @@ void Netchan_Transmit(net_chan_t *chan, byte *data, size_t len) {
     Net_WriteByte(&send, chan->qport);
   }
 
-  // copy the reliable message to the packet first
   if (send_reliable) {
-    Mem_WriteBuffer(&send, chan->reliable_buffer, chan->reliable_size);
     chan->reliable_outgoing = chan->outgoing_sequence;
   }
 
-  // add the unreliable part if space is available
-  if (send.max_size - send.size >= len) {
-    Mem_WriteBuffer(&send, data, len);
-  } else {
-    Com_Warn("Netchan_Transmit: dumped unreliable\n");
-  }
+  Net_WriteData(&send, chan->unsent_buffer, payload_size);
 
   // send the datagram
   Net_SendDatagram(chan->source, &chan->remote_address, send.data, send.size);
@@ -237,19 +325,29 @@ bool Netchan_Process(net_chan_t *chan, mem_buf_t *msg) {
     Net_ReadByte(msg);
   }
 
-  reliable_message = sequence >> 31u;
+  const bool fragmented = (sequence & FRAGMENT_BIT) != 0;
+
+  reliable_message = (sequence & RELIABLE_BIT) ? 1 : 0;
   reliable_ack = sequence_ack >> 31u;
 
-  sequence &= ~(1u << 31);
+  sequence &= SEQUENCE_MASK;
   sequence_ack &= ~(1u << 31);
+
+  // read the fragment header, if present
+  uint32_t fragment_offset = 0, fragment_length = 0;
+  if (fragmented) {
+    fragment_offset = Net_ReadShort(msg) & 0xffff;
+    fragment_length = Net_ReadShort(msg) & 0xffff;
+  }
 
   if (net_show_packets->value) {
     if (reliable_message)
-      Com_Print("Recv %u bytes: s=%i reliable=%i ack=%i rack=%i\n", (uint32_t) msg->size,
-                sequence, chan->reliable_incoming ^ 1, sequence_ack, reliable_ack);
+      Com_Print("Recv %u bytes: s=%i reliable=%i ack=%i rack=%i%s\n", (uint32_t) msg->size,
+                sequence, chan->reliable_incoming ^ 1, sequence_ack, reliable_ack,
+                fragmented ? " (fragment)" : "");
     else
-      Com_Print("Recv %u bytes : s=%i ack=%i rack=%i\n", (uint32_t) msg->size, sequence,
-                sequence_ack, reliable_ack);
+      Com_Print("Recv %u bytes : s=%i ack=%i rack=%i%s\n", (uint32_t) msg->size, sequence,
+                sequence_ack, reliable_ack, fragmented ? " (fragment)" : "");
   }
 
   // discard stale or duplicated packets
@@ -258,6 +356,40 @@ bool Netchan_Process(net_chan_t *chan, mem_buf_t *msg) {
       Com_Print("%s:Out of order packet %i at %i\n",
                 Net_NetaddrToString(&chan->remote_address), sequence, chan->incoming_sequence);
     return false;
+  }
+
+  // reassemble fragmented messages, deferring processing until the message is
+  // complete; fragments must arrive in order and contiguously
+  if (fragmented) {
+
+    if (chan->fragment_sequence != sequence) { // a new fragmented message
+      chan->fragment_sequence = sequence;
+      chan->fragment_size = 0;
+    }
+
+    if (fragment_offset != chan->fragment_size ||
+        chan->fragment_size + fragment_length > sizeof(chan->fragment_buffer)) {
+      if (net_show_drop->value)
+        Com_Print("%s:Dropped fragmented message at %i\n",
+                  Net_NetaddrToString(&chan->remote_address), sequence);
+      chan->fragment_sequence = 0;
+      return false;
+    }
+
+    Net_ReadData(msg, chan->fragment_buffer + chan->fragment_size, fragment_length);
+    chan->fragment_size += fragment_length;
+
+    // a full-size fragment means more are still coming
+    if (fragment_length == FRAGMENT_SIZE) {
+      return false;
+    }
+
+    // the message is complete; present it to the caller as the payload
+    memcpy(msg->data, chan->fragment_buffer, chan->fragment_size);
+    msg->size = chan->fragment_size;
+    msg->read = 0;
+
+    chan->fragment_sequence = 0;
   }
 
   // dropped packets don't keep the message from being used

--- a/src/net/net_chan.h
+++ b/src/net/net_chan.h
@@ -29,6 +29,7 @@ extern mem_buf_t net_message;
 
 void Netchan_Setup(net_src_t source, net_chan_t *chan, net_addr_t *addr, uint8_t qport);
 void Netchan_Transmit(net_chan_t *chan, byte *data, size_t len);
+void Netchan_TransmitNextFragment(net_chan_t *chan);
 void Netchan_OutOfBand(int32_t sock, const net_addr_t *addr, const void *data, size_t len);
 void Netchan_OutOfBandPrint(int32_t sock, const net_addr_t *addr, const char *format, ...) __attribute__((format(printf,
         3, 4)));

--- a/src/net/net_types.h
+++ b/src/net/net_types.h
@@ -58,6 +58,23 @@
  */
 #define MAX_MSG_SIZE_UDP 1450
 
+/**
+ * @brief The high bit of the sequence number flags a reliable payload (Q2 style).
+ * The next bit flags a fragmented message (Q3 style); see `Netchan_Transmit`.
+ * The remaining 30 bits are the actual sequence number.
+ */
+#define RELIABLE_BIT (1u << 31)
+#define FRAGMENT_BIT (1u << 30)
+#define SEQUENCE_MASK (~(RELIABLE_BIT | FRAGMENT_BIT))
+
+/**
+ * @brief Messages larger than this are split into multiple fragments, each fit
+ * for Internet (sub-MTU) transmission, and reassembled by the receiver. A
+ * message that is an exact multiple of this size is terminated by a final,
+ * empty fragment.
+ */
+#define FRAGMENT_SIZE 1300
+
 // A typedef for net_sockaddr, to reduce "struct" everywhere and silence Windows warning.
 typedef struct sockaddr_in net_sockaddr;
 
@@ -112,4 +129,16 @@ typedef struct {
   // message is copied to this buffer when it is first transfered
   size_t reliable_size;
   byte reliable_buffer[MAX_MSG_SIZE - 10]; // un-acked reliable message
+
+  // outgoing fragmented messages are drained across Netchan_TransmitNextFragment calls
+  bool unsent_fragments; // true while a fragmented message is being sent
+  bool unsent_reliable; // whether the in-flight fragmented message carries reliable data
+  size_t unsent_fragment_start; // offset of the next fragment to send
+  size_t unsent_length; // total length of the message being fragmented
+  byte unsent_buffer[MAX_MSG_SIZE];
+
+  // incoming fragmented messages are reassembled here before processing
+  uint32_t fragment_sequence; // sequence of the message currently being reassembled
+  size_t fragment_size; // bytes reassembled so far
+  byte fragment_buffer[MAX_MSG_SIZE];
 } net_chan_t;

--- a/src/server/sv_send.c
+++ b/src/server/sv_send.c
@@ -269,9 +269,12 @@ static void Sv_SendClientDatagram(sv_client_t *cl) {
   Sv_WriteClientFrame(cl, &buf);
 
   // the frame itself (player state and delta entities) must fit into a single message,
-  // since it is parsed as a single command by the client
-  if (buf.overflowed || buf.size > MAX_MSG_SIZE - 16) {
-    Com_Error(ERROR_DROP, "Frame exceeds MAX_MSG_SIZE (%u)\n", (uint32_t) buf.size);
+  // since it is parsed as a single command by the client. The netchan fragments
+  // oversized messages for transmission, so only a frame that exhausts the message
+  // buffer entirely is unrecoverable; skip it rather than crashing the server.
+  if (buf.overflowed) {
+    Com_Warn("Frame overflow for %s; skipping frame\n", cl->name);
+    return;
   }
 
   // but we can packetize the remaining datagram messages, which are parsed individually
@@ -285,6 +288,11 @@ static void Sv_SendClientDatagram(sv_client_t *cl) {
 
         Netchan_Transmit(&cl->net_chan, buf.data, buf.size);
 
+        // drain any pending fragments before reusing the netchan
+        while (cl->net_chan.unsent_fragments) {
+          Netchan_TransmitNextFragment(&cl->net_chan);
+        }
+
         Mem_ClearBuffer(&buf);
       }
 
@@ -294,6 +302,11 @@ static void Sv_SendClientDatagram(sv_client_t *cl) {
 
   // send the pending packet, which may include reliable messages
   Netchan_Transmit(&cl->net_chan, buf.data, buf.size);
+
+  // drain any pending fragments from the final frame
+  while (cl->net_chan.unsent_fragments) {
+    Netchan_TransmitNextFragment(&cl->net_chan);
+  }
 }
 
 /**
@@ -414,6 +427,11 @@ void Sv_SendClientPackets(void) {
 
       if ((size = Sv_GetDemoMessage(buffer))) {
         Netchan_Transmit(&cl->net_chan, buffer, size);
+
+        // drain any pending fragments
+        while (cl->net_chan.unsent_fragments) {
+          Netchan_TransmitNextFragment(&cl->net_chan);
+        }
       } else {
         break;    // recording is done, so we're done
       }
@@ -432,6 +450,11 @@ void Sv_SendClientPackets(void) {
 
     } else if (cl->net_chan.message.size) { // update reliable
       Netchan_Transmit(&cl->net_chan, NULL, 0);
+
+      // a large reliable message (e.g. config strings) may have fragmented
+      while (cl->net_chan.unsent_fragments) {
+        Netchan_TransmitNextFragment(&cl->net_chan);
+      }
     } else if (quetoo.ticks - cl->net_chan.last_sent > 1000) { // or just don't timeout
       Netchan_Transmit(&cl->net_chan, NULL, 0);
     }


### PR DESCRIPTION
## Summary

On dedicated Internet servers with high entity counts (e.g. RailWolf's 24+ bot "botopia" server), `Sv_SendClientDatagram()` builds a single frame (player state + all delta entities) that exceeds the UDP MTU. The frame was sent as one datagram relying on IP-layer fragmentation — any dropped IP fragment loses the whole frame — and a frame exceeding `MAX_MSG_SIZE` crashed the dedicated server outright via `Com_Error(ERROR_DROP)`. Listen servers never hit this because the loopback path is not MTU-bound.

This adds Q3-style application-layer message fragmentation to the netchan, as outlined in the issue. Messages larger than the MTU are split into sub-MTU fragments and reassembled by the receiver; this is transparent to all game logic (no entity culling or gameplay changes).

Fixes #888

## Changes

- **`net_chan.c` — `Netchan_Transmit()` / new `Netchan_TransmitNextFragment()`**: a message that exceeds `FRAGMENT_SIZE` (1300 b) is staged in the netchan and sent one fragment per packet; callers drain via `Netchan_TransmitNextFragment()` while `unsent_fragments` is set. Every fragment carries the same sequence number tagged with `FRAGMENT_BIT`, plus a 16-bit offset/length header; the sequence advances only after the final fragment. A message that is an exact multiple of `FRAGMENT_SIZE` is terminated by a final, empty fragment.
- **`net_chan.c` — `Netchan_Process()`**: reassembles in-order fragments per channel, deferring delivery (and reliable acknowledgement) until the message is complete.
- **Bit layout**: `FRAGMENT_BIT` is sequence bit 30; bit 31 remains the reliable flag (Q2 style), leaving a 30-bit sequence (`SEQUENCE_MASK`). This resolves the bit-31 conflict noted in the issue.
- **`net_types.h`**: `FRAGMENT_BIT` / `FRAGMENT_SIZE` / `SEQUENCE_MASK` constants and per-channel outgoing/incoming fragment state on `net_chan_t`.
- **`sv_send.c` / `cl_cmd.c`**: drain pending fragments after each transmit that can produce a large message (frame path, loading-client reliable flush, demo path, client command path).
- **`sv_send.c`**: `Sv_SendClientDatagram()` no longer crashes the whole server on frame overflow — oversized frames are fragmented for transmission, and a frame that exhausts the message buffer is skipped with a warning.
- **`PROTOCOL_MAJOR`** bumped to 2028 (core packet-header change; requires coordinated client + server update).

## Testing

- [x] Builds without warnings (`make -j$(nproc)`) — built clean in a Debian 12 container against current `jdolan/Objectively` + `jdolan/ObjectivelyMVC` HEAD; the changed files compile clean under `-Wall -Wextra`.
- [x] Tests pass (`make check`) — 19/19 PASS, including `check_net_message` (netcode delta round-trip).
- [ ] Tested in-game — not yet exercised on a live dedicated server under load; would appreciate a test on a high-bot server.

## Notes

- One deliberate deviation from the implementation sketch in the issue: rather than fully removing the `ERROR_DROP` in `Sv_SendClientDatagram()`, I demoted it to a non-fatal warning + skip. Fragmentation lifts the *MTU* limit but not the 16 KB message-buffer ceiling, so a guard is still warranted — but it must never take down the whole server (the reported symptom).
- Backwards-incompatible at the netchan layer only when fragmentation actually triggers; the `PROTOCOL_MAJOR` bump gates mismatched builds at connect.
