### PR TITLE
#888 Fix large net message packet fragmentation

### DIFF
--- a/src/cgame/default/cg_entity.c
+++ b/src/cgame/default/cg_entity.c
@@ -123,7 +123,7 @@ void Cg_LoadEntities(void) {
       if (!q_strcmp(classname, (*clazz)->classname)) {
 
         cg_entity_t e = {
-          .id = MAX_ENTITIES + cg_entities->count,
+          .id = MAX_ENTITIES + (int32_t) cg_entities->count,
           .clazz = *clazz,
           .def = def
         };

--- a/src/client/cl_server.c
+++ b/src/client/cl_server.c
@@ -116,8 +116,8 @@ void Cl_ParseServerInfo(void) {
       const char *end = q_strchr(line, '\n');
 
       char player[MAX_TOKEN_CHARS];
-      const size_t len = end ? (size_t)(end - line) : q_strlen(line);
-      q_strlcpy(player, line, Mini(len + 1, sizeof(player)));
+      const size_t len = end ? (size_t) (end - line) : q_strlen(line);
+      q_strlcpy(player, line, Mini((int32_t) len + 1, sizeof(player)));
 
       if (player[0]) {
         server->clients++;

--- a/src/client/renderer/r_decal.c
+++ b/src/client/renderer/r_decal.c
@@ -433,7 +433,7 @@ void R_DrawDecals(const r_view_t *view) {
       assert(d->image->texnum);
       glBindTexture(GL_TEXTURE_2D, d->image->texnum);
 
-      glDrawArrays(GL_TRIANGLES, 0, d->triangles->count * 3);
+      glDrawArrays(GL_TRIANGLES, 0, (GLsizei) d->triangles->count * 3);
 
       r_stats.decals += d->triangles->count;
       r_stats.decal_draw_elements++;

--- a/src/client/renderer/r_occlude.c
+++ b/src/client/renderer/r_occlude.c
@@ -312,7 +312,7 @@ void R_DrawOcclusionQueries(const r_view_t *view) {
 
   R_GetError(NULL);
 
-  r_stats.queries_allocated = r_occlusion_queries.allocated->count;
+  r_stats.queries_allocated = (int32_t) r_occlusion_queries.allocated->count;
 }
 
 /**

--- a/src/common/mem_buf.c
+++ b/src/common/mem_buf.c
@@ -21,7 +21,7 @@
 
 #include <signal.h>
 
-#include "mem_buf.h"
+#include "common.h"
 
 /**
  * @brief Initializes a fixed-size memory buffer backed by the given data array.
@@ -38,9 +38,8 @@ void Mem_InitBuffer(mem_buf_t *buf, byte *data, size_t len) {
  * @brief Resets the buffer's write position to zero and clears the overflow flag.
  */
 void Mem_ClearBuffer(mem_buf_t *buf) {
-
   buf->size = 0;
-  buf->overflowed = false;
+  buf->read = 0;
 }
 
 /**
@@ -54,19 +53,7 @@ void *Mem_AllocBuffer(mem_buf_t *buf, size_t len) {
   if (len > buf->max_size - buf->size) {
     const uint32_t delta = (uint32_t) (buf->size + len - buf->max_size);
     fprintf(stderr, "%s: Overflow by %u bytes\n", __func__, delta);
-
-    if (!buf->allow_overflow) {
-      fprintf(stderr, "Overflow without allow_overflow set\n");
-      raise(SIGABRT);
-    }
-
-    if (len > buf->max_size) {
-      fprintf(stderr, "%u is > buffer size %u\n", (uint32_t) len, (uint32_t) buf->max_size);
-      raise(SIGABRT);
-    }
-
-    Mem_ClearBuffer(buf);
-    buf->overflowed = true;
+    return NULL;
   }
 
   data = buf->data + buf->size;
@@ -79,5 +66,11 @@ void *Mem_AllocBuffer(mem_buf_t *buf, size_t len) {
  * @brief Copies `len` bytes from `data` into the next available region of the buffer.
  */
 void Mem_WriteBuffer(mem_buf_t *buf, const void *data, size_t len) {
-  memcpy(Mem_AllocBuffer(buf, len), data, len);
+
+  void *out = Mem_AllocBuffer(buf, len);
+  if (out) {
+    memcpy(out, data, len);
+  } else {
+    Com_Error(ERROR_FATAL, "Buffer overflow writing %zd bytes to %zd sized buffer\n", len, buf->max_size);
+  }
 }

--- a/src/common/mem_buf.c
+++ b/src/common/mem_buf.c
@@ -51,7 +51,7 @@ void *Mem_AllocBuffer(mem_buf_t *buf, size_t len) {
 
   if (len > buf->max_size - buf->size) {
     const uint32_t delta = (uint32_t) (buf->size + len - buf->max_size);
-    Com_Error(ERROR_FATAL, "Buffer overflow writing %zd bytes to %zd sized buffer\n", len, buf->max_size);
+    Com_Error(ERROR_FATAL, "Buffer overflow writing %zu bytes to %zu sized buffer\n", len, buf->max_size);
   }
 
   data = buf->data + buf->size;

--- a/src/common/mem_buf.c
+++ b/src/common/mem_buf.c
@@ -44,16 +44,14 @@ void Mem_ClearBuffer(mem_buf_t *buf) {
 
 /**
  * @brief Advances the write cursor by `len` bytes and returns a pointer to the newly reserved region.
- * @details If `allow_overflow` is set and the buffer would overflow, the buffer is cleared first.
- *   Aborts if the buffer does not have `allow_overflow` set and an overflow would occur.
+ * @details Errors if len exceeds the buffer's remaining capacity.
  */
 void *Mem_AllocBuffer(mem_buf_t *buf, size_t len) {
   void *data;
 
   if (len > buf->max_size - buf->size) {
     const uint32_t delta = (uint32_t) (buf->size + len - buf->max_size);
-    fprintf(stderr, "%s: Overflow by %u bytes\n", __func__, delta);
-    return NULL;
+    Com_Error(ERROR_FATAL, "Buffer overflow writing %zd bytes to %zd sized buffer\n", len, buf->max_size);
   }
 
   data = buf->data + buf->size;
@@ -66,11 +64,5 @@ void *Mem_AllocBuffer(mem_buf_t *buf, size_t len) {
  * @brief Copies `len` bytes from `data` into the next available region of the buffer.
  */
 void Mem_WriteBuffer(mem_buf_t *buf, const void *data, size_t len) {
-
-  void *out = Mem_AllocBuffer(buf, len);
-  if (out) {
-    memcpy(out, data, len);
-  } else {
-    Com_Error(ERROR_FATAL, "Buffer overflow writing %zd bytes to %zd sized buffer\n", len, buf->max_size);
-  }
+  memcpy(Mem_AllocBuffer(buf, len), data, len);
 }

--- a/src/common/mem_buf.h
+++ b/src/common/mem_buf.h
@@ -27,8 +27,6 @@
  * @brief A fixed-sized buffer, used for accumulating e.g. net messages.
  */
 typedef struct {
-  bool allow_overflow; // error if false and overflow occurs
-  bool overflowed; // set to true when a write exceeds max_size
   byte *data;
   size_t max_size; // maximum size before overflow
   size_t size; // current size

--- a/src/game/default/g_ai_node.c
+++ b/src/game/default/g_ai_node.c
@@ -143,7 +143,7 @@ static bool G_Ai_Node_Visible(const vec3_t position, const ai_node_id_t node) {
  */
 uint32_t G_Ai_Node_Count(void) {
 
-  return g_ai_nodes ? g_ai_nodes->count : 0;
+  return g_ai_nodes ? (uint32_t) g_ai_nodes->count : 0;
 }
 
 /**

--- a/src/net/net_chan.c
+++ b/src/net/net_chan.c
@@ -129,7 +129,6 @@ void Netchan_Setup(net_src_t source, net_chan_t *chan, net_addr_t *addr, uint8_t
   chan->outgoing_sequence = 1;
 
   Mem_InitBuffer(&chan->message, chan->message_buffer, sizeof(chan->message_buffer));
-  chan->message.allow_overflow = true;
 }
 
 /**
@@ -156,11 +155,6 @@ static bool Netchan_CheckRetransmit(net_chan_t *chan) {
 void Netchan_Transmit(net_chan_t *chan, byte *data, size_t len) {
   mem_buf_t send;
   byte send_buffer[MAX_MSG_SIZE];
-
-  // check for message overflow
-  if (chan->message.overflowed) {
-    Com_Error(ERROR_DROP, "%s: Overflow\n", Net_NetaddrToString(&chan->remote_address));
-  }
 
   // check for re-transmission of reliable message
   bool send_reliable = Netchan_CheckRetransmit(chan);

--- a/src/net/net_types.h
+++ b/src/net/net_types.h
@@ -47,9 +47,9 @@
 #include "common/common.h"
 
 /**
- * @brief Max length of a single packet. No individual command can exceed
- * this length. However, large server messages can be split into multiple
- * messages and sent in series. See `Sv_SendClientDatagram`.
+ * @brief Max length of a single server message. No individual message can exceed
+ * this length. However, large server messages can be split into multiple packets
+ * and sent in series. See `Sv_SendClientDatagram`.
  */
 #define MAX_MSG_SIZE 16384
 

--- a/src/server/sv_main.c
+++ b/src/server/sv_main.c
@@ -331,7 +331,6 @@ static void Sv_Connect_f(void) {
   Netchan_Setup(NS_UDP_SERVER, &client->net_chan, addr, qport);
 
   Mem_InitBuffer(&client->datagram.buffer, client->datagram.data, sizeof(client->datagram.data));
-  client->datagram.buffer.allow_overflow = true;
 
   client->last_message = quetoo.ticks;
 

--- a/src/server/sv_send.c
+++ b/src/server/sv_send.c
@@ -130,7 +130,6 @@ static void Sv_ClientDatagramMessage(sv_client_t *cl, byte *data, size_t len) {
   // Ensure the datagram buffer is initialized
   if (!cl->datagram.buffer.data) {
     Mem_InitBuffer(&cl->datagram.buffer, cl->datagram.data, sizeof(cl->datagram.data));
-    cl->datagram.buffer.allow_overflow = true;
   }
 
   if (len > MAX_MSG_SIZE_UDP) {
@@ -153,16 +152,6 @@ static void Sv_ClientDatagramMessage(sv_client_t *cl, byte *data, size_t len) {
   $(cl->datagram.messages, appendElement, msg);
 
   Mem_WriteBuffer(&cl->datagram.buffer, data, len);
-
-  if (cl->datagram.buffer.overflowed) {
-    Com_Warn("Client datagram overflow for %s\n", cl->name);
-
-    msg->offset = 0;
-    cl->datagram.buffer.overflowed = false;
-
-    $(cl->datagram.messages, removeAll); release(cl->datagram.messages); cl->datagram.messages = NULL;
-    cl->datagram.messages = NULL;
-  }
 }
 
 /**
@@ -263,7 +252,6 @@ static void Sv_SendClientDatagram(sv_client_t *cl) {
   Sv_BuildClientFrame(cl);
 
   Mem_InitBuffer(&buf, buffer, sizeof(buffer));
-  buf.allow_overflow = true;
 
   // send over all the relevant entity_state_t and the player_state_t
   Sv_WriteClientFrame(cl, &buf);
@@ -391,13 +379,6 @@ void Sv_SendClientPackets(void) {
     }
 
     if (svs.clients[i].gclient->ai) {
-      continue;
-    }
-
-    // if the client's reliable message overflowed, we must drop them
-    if (cl->net_chan.message.overflowed) {
-      Sv_DropClient(cl);
-      Sv_BroadcastPrint(PRINT_MEDIUM, "%s overflowed\n", cl->name);
       continue;
     }
 

--- a/src/server/sv_send.c
+++ b/src/server/sv_send.c
@@ -268,13 +268,6 @@ static void Sv_SendClientDatagram(sv_client_t *cl) {
   // send over all the relevant entity_state_t and the player_state_t
   Sv_WriteClientFrame(cl, &buf);
 
-  // the frame itself (player state and delta entities) must fit into a single message,
-  // since it is parsed as a single command by the client
-  if (buf.overflowed || buf.size > MAX_MSG_SIZE - 16) {
-    Com_Error(ERROR_DROP, "Frame exceeds MAX_MSG_SIZE (%u)\n", (uint32_t) buf.size);
-  }
-
-  // but we can packetize the remaining datagram messages, which are parsed individually
   if (cl->datagram.messages) {
     for (const ListNode *node = cl->datagram.messages->head; node; node = node->next) {
       const sv_client_message_t *msg = (const sv_client_message_t *) node->element;

--- a/src/server/sv_send.c
+++ b/src/server/sv_send.c
@@ -280,7 +280,7 @@ static void Sv_SendClientDatagram(sv_client_t *cl) {
       const sv_client_message_t *msg = (const sv_client_message_t *) node->element;
 
       // if we would overflow the packet, flush it first
-      if (buf.size + msg->len > (MAX_MSG_SIZE - 16)) {
+      if (buf.size + msg->len > (MAX_MSG_SIZE_UDP - 16)) {
         Com_Debug(DEBUG_SERVER, "Fragmenting datagram @ %u bytes\n", (uint32_t) buf.size);
 
         Netchan_Transmit(&cl->net_chan, buf.data, buf.size);


### PR DESCRIPTION
The wrong constant was used in the packet fragmentation conditional in Sv_SendClientDatagram. This PR fixes that, and also simplifies mem_buf_t overflow behavior to just be a hard error everywhere. Previously, a dedicated server would attempt to catch a client overflow and would instead end up in an undefined state (idle, but not killed). Let's make our lives simpler and not bother pretending that we'll recover from mem_buf_t overflows. They are fatal, because we should absolutely never hit them anyway.