### PR TITLE
game/shared: clean up AI path position lines; add Minz/Maxz for size_t

### DIFF
--- a/src/client/cl_server.c
+++ b/src/client/cl_server.c
@@ -117,7 +117,7 @@ void Cl_ParseServerInfo(void) {
 
       char player[MAX_TOKEN_CHARS];
       const size_t len = end ? (size_t) (end - line) : q_strlen(line);
-      q_strlcpy(player, line, Mini((int32_t) len + 1, sizeof(player)));
+      q_strlcpy(player, line, Minz(len + 1, sizeof(player)));
 
       if (player[0]) {
         server->clients++;

--- a/src/game/default/g_ai_goal.c
+++ b/src/game/default/g_ai_goal.c
@@ -68,7 +68,7 @@ void G_Ai_SetPathGoal(const g_client_t *cl, ai_goal_t *goal, float priority, Vec
   goal->path.path_index = 0;
 
   const ai_node_id_t node = VectorValue(path, ai_node_id_t, 0);
-  const ai_node_id_t next = VectorValue(path, ai_node_id_t, Mini((int32_t) path->count - 1, 1));
+  const ai_node_id_t next = VectorValue(path, ai_node_id_t, Minz(path->count - 1, 1));
   goal->path.path_position = G_Ai_Node_GetPosition(node);
   goal->path.next_path_position = G_Ai_Node_GetPosition(next);
   goal->path.path_target = path_target;

--- a/src/game/default/g_ai_goal.c
+++ b/src/game/default/g_ai_goal.c
@@ -66,8 +66,11 @@ void G_Ai_SetPathGoal(const g_client_t *cl, ai_goal_t *goal, float priority, Vec
   
   goal->path.path = retain(path);
   goal->path.path_index = 0;
-  goal->path.path_position = G_Ai_Node_GetPosition(VectorValue(path, ai_node_id_t, goal->path.path_index));
-  goal->path.next_path_position = G_Ai_Node_GetPosition(VectorValue(path, ai_node_id_t, Mini(path->count - 1, goal->path.path_index + 1)));
+
+  const ai_node_id_t node = VectorValue(path, ai_node_id_t, 0);
+  const ai_node_id_t next = VectorValue(path, ai_node_id_t, Mini((int32_t) path->count - 1, 1));
+  goal->path.path_position = G_Ai_Node_GetPosition(node);
+  goal->path.next_path_position = G_Ai_Node_GetPosition(next);
   goal->path.path_target = path_target;
 
   if (path_target) {

--- a/src/game/default/g_ai_main.c
+++ b/src/game/default/g_ai_main.c
@@ -928,7 +928,7 @@ static bool G_Ai_AdvancePath(g_client_t *cl, ai_goal_t *goal) {
   const uint32_t index = goal->path.path_index;
 
   const ai_node_id_t node = VectorValue(path, ai_node_id_t, index);
-  const ai_node_id_t next = VectorValue(path, ai_node_id_t, Mini((int32_t) path->count - 1, (int32_t) index + 1));
+  const ai_node_id_t next = VectorValue(path, ai_node_id_t, Minz(path->count - 1, index + 1));
   goal->path.path_position = G_Ai_Node_GetPosition(node);
   goal->path.next_path_position = G_Ai_Node_GetPosition(next);
   goal->distress = 0;

--- a/src/game/default/g_ai_main.c
+++ b/src/game/default/g_ai_main.c
@@ -924,8 +924,13 @@ static bool G_Ai_AdvancePath(g_client_t *cl, ai_goal_t *goal) {
     return false;
   }
 
-  goal->path.path_position = G_Ai_Node_GetPosition(VectorValue(goal->path.path, ai_node_id_t, goal->path.path_index));
-  goal->path.next_path_position = G_Ai_Node_GetPosition(VectorValue(goal->path.path, ai_node_id_t, Mini(goal->path.path->count - 1, goal->path.path_index + 1)));
+  const Vector *path = goal->path.path;
+  const uint32_t index = goal->path.path_index;
+
+  const ai_node_id_t node = VectorValue(path, ai_node_id_t, index);
+  const ai_node_id_t next = VectorValue(path, ai_node_id_t, Mini((int32_t) path->count - 1, (int32_t) index + 1));
+  goal->path.path_position = G_Ai_Node_GetPosition(node);
+  goal->path.next_path_position = G_Ai_Node_GetPosition(next);
   goal->distress = 0;
   goal->distress_extension = false;
   goal->last_distance = FLT_MAX;

--- a/src/game/default/g_ai_node.c
+++ b/src/game/default/g_ai_node.c
@@ -163,7 +163,7 @@ static bool G_Ai_Node_EnsureSpatialIndex(void) {
 
   G_Ai_Node_InvalidateSpatialIndex();
 
-  const uint32_t n = g_ai_nodes->count;
+  const uint32_t n = (uint32_t) g_ai_nodes->count;
   g_ai_nodes_kdtree_positions = malloc(sizeof(vec3_t) * n);
   if (!g_ai_nodes_kdtree_positions) {
     return false;
@@ -1149,7 +1149,7 @@ void G_Ai_InitNodes(void) {
     const ai_node_t *node = AI_NODE(g_ai_nodes, i);
 
     if (node->links) {
-      g_ai_player_roam.file_links += node->links->count;
+      g_ai_player_roam.file_links += (uint32_t) node->links->count;
     }
   }
 }
@@ -1194,7 +1194,7 @@ void G_Ai_NodesReady(void) {
     return;
   }
 
-  const uint32_t added_nodes = g_ai_nodes->count - g_ai_player_roam.file_nodes;
+  const uint32_t added_nodes = (uint32_t) g_ai_nodes->count - g_ai_player_roam.file_nodes;
   uint32_t added_links = 0;
 
   for (uint32_t i = 0; i < g_ai_nodes->count; i++) {

--- a/src/game/default/g_entity.c
+++ b/src/game/default/g_entity.c
@@ -759,8 +759,8 @@ static void G_worldspawn_Music(void) {
     gi.EnumerateFiles("music/*.ogg", G_worldspawn_EnumerateMusic, tracks);
     $(tracks, sort, G_worldspawn_MusicShuffle);
 
-    for (int32_t i = 0; i < (int32_t) Mini(MAX_MUSICS, (int32_t) tracks->count); i++) {
-      gi.SetConfigString(CS_MUSICS + i, (char *) tracks->elements + (size_t) i * MAX_QPATH);
+    for (size_t i = 0; i < Minz(MAX_MUSICS, tracks->count); i++) {
+      gi.SetConfigString(CS_MUSICS + (int32_t) i, (char *) tracks->elements + i * MAX_QPATH);
     }
 
     release(tracks);

--- a/src/shared/vector.h
+++ b/src/shared/vector.h
@@ -337,6 +337,13 @@ static inline uint64_t __attribute__ ((warn_unused_result)) Minui64(uint64_t a, 
 }
 
 /**
+ * @return The minimum of `a` and `b`.
+ */
+static inline size_t __attribute__ ((warn_unused_result)) Minz(size_t a, size_t b) {
+  return a < b ? a : b;
+}
+
+/**
  * @return The maximum of `a` and `b`.
  */
 static inline float __attribute__ ((warn_unused_result)) Maxf(float a, float b) {
@@ -354,6 +361,13 @@ static inline int32_t __attribute__ ((warn_unused_result)) Maxi(int32_t a, int32
  * @return The maximum of `a` and `b`.
  */
 static inline int64_t __attribute__ ((warn_unused_result)) Maxui64(uint64_t a, uint64_t b) {
+  return a > b ? a : b;
+}
+
+/**
+ * @return The maximum of `a` and `b`.
+ */
+static inline size_t __attribute__ ((warn_unused_result)) Maxz(size_t a, size_t b) {
   return a > b ? a : b;
 }
 


### PR DESCRIPTION
## Summary

Two related quality-of-life fixes in the AI pathfinding code. The `G_Ai_Node_GetPosition(VectorValue(...))` call sites had grown to ~200-character lines that were hard to read, and were suppressing compiler precision warnings with potentially lossy `(int32_t)` casts on `size_t` Vector counts. Rather than paper over the casts, we introduce a purpose-built `Minz`/`Maxz` pair for `size_t` comparisons and break the long lines into readable locals.

## Changes

- `src/shared/vector.h`: add `Minz(size_t, size_t)` and `Maxz(size_t, size_t)` alongside the existing `Mini`/`Maxi`/`Minf`/`Maxf`/`Minui64`/`Maxui64` family
- `src/game/default/g_ai_goal.c`, `g_ai_main.c`: extract `node`/`next`/`path`/`index` locals to break up the nested `G_Ai_Node_GetPosition(VectorValue(..., Mini(...)))` chains; replace `Mini((int32_t) ->count, ...)` with `Minz`
- `src/game/default/g_ai_node.c`: add `(uint32_t)` casts on three `size_t -> uint32_t` count assignments that were triggering precision warnings
- `src/game/default/g_entity.c`: replace `Mini(MAX_MUSICS, (int32_t) tracks->count)` with `Minz`; change loop variable to `size_t` to eliminate the paired `(size_t) i` cast in the body

## Testing

- [ ] Builds without warnings (`make -j$(nproc)`)
- [ ] Tests pass (`make check`)
- [ ] Tested in-game on <!-- platform(s) -->

## Notes

`Minz`/`Maxz` follow the existing naming convention (`z` = `size_t` printf specifier). The `r_decal.c` and `r_draw_2d.c` sites that mix `int32_t` overflow counts with `size_t` were intentionally left alone -- those are genuine int32_t arithmetic, not size_t comparisons.