### PR TITLE
Fix update dialog not firing in MainViewController

### DIFF
--- a/Quetoo.xcodeproj/xcshareddata/xcschemes/quetoo-all.xcscheme
+++ b/Quetoo.xcodeproj/xcshareddata/xcschemes/quetoo-all.xcscheme
@@ -96,8 +96,8 @@
             isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
-            argument = "+set version 9956"
-            isEnabled = "YES">
+            argument = "+set version -1"
+            isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
             argument = "+set r_window_width 1920 +set r_window_height 1080"

--- a/Quetoo.xcodeproj/xcshareddata/xcschemes/quetoo-all.xcscheme
+++ b/Quetoo.xcodeproj/xcshareddata/xcschemes/quetoo-all.xcscheme
@@ -96,8 +96,8 @@
             isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
-            argument = "+set version -1"
-            isEnabled = "NO">
+            argument = "+set version 9956"
+            isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument
             argument = "+set r_window_width 1920 +set r_window_height 1080"

--- a/src/cgame/default/cg_editor.c
+++ b/src/cgame/default/cg_editor.c
@@ -261,8 +261,7 @@ static void Cg_InitEditorEntity(int16_t number) {
   if (number < cgi.Bsp()->num_entities) {
     edit->brushes = cgi.EntityBrushes(cgi.Bsp()->entities[number]);
     if (!edit->brushes->count) {
-      release(edit->brushes);
-      edit->brushes = NULL;
+      edit->brushes = release(edit->brushes);
     }
   }
 
@@ -306,9 +305,7 @@ static void Cg_FreeEditorEntity(int16_t number) {
 
   cgi.FreeEntity(edit->def);
 
-  if (edit->brushes) {
-    release(edit->brushes);
-  }
+  release(edit->brushes);
 
   if (edit->misc.clazz && edit->misc.data) {
     if (edit->misc.clazz->Free) {

--- a/src/cgame/default/cg_entity.c
+++ b/src/cgame/default/cg_entity.c
@@ -156,7 +156,7 @@ void Cg_LoadEntities(void) {
           e.next_think += interval * Randomf();
         }
 
-        $(cg_entities, addElement, &e);
+        $(cg_entities, add, &e);
       }
     }
   }

--- a/src/cgame/default/cg_flare.c
+++ b/src/cgame/default/cg_flare.c
@@ -240,7 +240,7 @@ void Cg_LoadFlares(void) {
       }
 
       cg_flare_t *flare = Cg_LoadFlare(face, stage);
-      $(cg_flares, addElement, &flare);
+      $(cg_flares, add, &flare);
     }
   }
 

--- a/src/cgame/default/cg_flare.c
+++ b/src/cgame/default/cg_flare.c
@@ -189,7 +189,7 @@ static void Cg_MergeFlares(void) {
           Cg_FacesShareVertex(a->face, b->face)) {
         a->bounds = Box3_Union(a->bounds, b->bounds);
 
-        $(cg_flares, removeElementAtIndex, j);
+        $(cg_flares, removeAt, j);
         cgi.Free(b);
 
         j--;

--- a/src/cgame/default/cg_light.c
+++ b/src/cgame/default/cg_light.c
@@ -67,7 +67,7 @@ static cg_light_t *Cg_AllocLight(const cg_light_t *in) {
 
   light->time = cgi.client->unclamped_time;
 
-  $(cg_lights.allocated, prependElement, light);
+  $(cg_lights.allocated, prepend, light);
   return light;
 }
 
@@ -80,7 +80,7 @@ static void Cg_FreeLight(cg_light_t *light) {
   assert(node);
 
   $(cg_lights.allocated, removeNode, node);
-  $(cg_lights.free, prependElement, light);
+  $(cg_lights.free, prepend, light);
 }
 
 /**

--- a/src/cgame/default/cg_light.c
+++ b/src/cgame/default/cg_light.c
@@ -247,18 +247,12 @@ void Cg_InitLights(void) {
 void Cg_FreeLights(void) {
 
   if (cg_lights.allocated) {
-    cg_lights.allocated->destroy = (ListDestroyFunc) cgi.Free;
-    $(cg_lights.allocated, removeAll);
-    release(cg_lights.allocated);
+    cg_lights.allocated->destroy = cgi.Free;
+    cg_lights.allocated = release(cg_lights.allocated);
   }
-
-  cg_lights.allocated = NULL;
 
   if (cg_lights.free) {
-    cg_lights.free->destroy = (ListDestroyFunc) cgi.Free;
-    $(cg_lights.free, removeAll);
-    release(cg_lights.free);
+    cg_lights.free->destroy = cgi.Free;
+    cg_lights.free = release(cg_lights.free);
   }
-
-  cg_lights.free = NULL;
 }

--- a/src/cgame/default/cg_local.h
+++ b/src/cgame/default/cg_local.h
@@ -23,6 +23,9 @@
 
 #define __CG_LOCAL_H__
 
+#include <Objectively/PointerArray.h>
+#include <Objectively/Vector.h>
+
 #define Cg_Debug(...) ({ if (cgi.DebugMask() & DEBUG_CGAME) { cgi.Debug(DEBUG_CGAME, __func__, __VA_ARGS__); } })
 #define Cg_Error(...) cgi.Error(__func__, __VA_ARGS__)
 #define Cg_Warn(...) cgi.Warn(__func__, __VA_ARGS__)
@@ -53,4 +56,3 @@
 #include "cg_ui.h"
 #include "cg_view.h"
 #include "cg_weapon.h"
-#include <Objectively/Vector.h>

--- a/src/cgame/default/cg_main.c
+++ b/src/cgame/default/cg_main.c
@@ -215,7 +215,7 @@ static void Cg_ParseTeamInfo(const char *s) {
   q_strlcpy(buf, s, sizeof(buf));
   char *save = NULL;
   for (char *tok = q_strtok_r(buf, "\\", &save); tok; tok = q_strtok_r(NULL, "\\", &save)) {
-    $(info, addPointer, q_strdup(tok));
+    $(info, add, q_strdup(tok));
   }
 
   const size_t count = info->count;
@@ -228,13 +228,13 @@ static void Cg_ParseTeamInfo(const char *s) {
   cg_team_info_t *team = cg_state.teams;
   for (size_t i = 0; i < count; i += 4, team++) {
 
-    team->id = atoi((char *) $(info, pointerAtIndex, i + 0));
+    team->id = atoi((char *) $(info, get, i + 0));
 
-    q_strlcpy(team->name, (char *) $(info, pointerAtIndex, i + 1), sizeof(team->name));
+    q_strlcpy(team->name, (char *) $(info, get, i + 1), sizeof(team->name));
 
-    team->hue = atoi((char *) $(info, pointerAtIndex, i + 2));
+    team->hue = atoi((char *) $(info, get, i + 2));
 
-    if (!Color_Parse((char *) $(info, pointerAtIndex, i + 3), &team->color)) {
+    if (!Color_Parse((char *) $(info, get, i + 3), &team->color)) {
       team->color = color_white;
     }
   }

--- a/src/cgame/default/cg_main.c
+++ b/src/cgame/default/cg_main.c
@@ -209,14 +209,13 @@ static void Cg_Shutdown(void) {
  */
 static void Cg_ParseTeamInfo(const char *s) {
 
-  Vector *info = $(alloc(Vector), initWithSize, sizeof(char *));
+  PointerArray *info = $(alloc(PointerArray), initWithDestroy, free);
 
   char buf[MAX_STRING_CHARS];
   q_strlcpy(buf, s, sizeof(buf));
   char *save = NULL;
   for (char *tok = q_strtok_r(buf, "\\", &save); tok; tok = q_strtok_r(NULL, "\\", &save)) {
-    char *dup = q_strdup(tok);
-    $(info, addElement, &dup);
+    $(info, addPointer, q_strdup(tok));
   }
 
   const size_t count = info->count;
@@ -229,18 +228,17 @@ static void Cg_ParseTeamInfo(const char *s) {
   cg_team_info_t *team = cg_state.teams;
   for (size_t i = 0; i < count; i += 4, team++) {
 
-    team->id = atoi(VectorValue(info, char *, i + 0));
+    team->id = atoi((char *) $(info, pointerAtIndex, i + 0));
 
-    q_strlcpy(team->name, VectorValue(info, char *, i + 1), sizeof(team->name));
+    q_strlcpy(team->name, (char *) $(info, pointerAtIndex, i + 1), sizeof(team->name));
 
-    team->hue = atoi(VectorValue(info, char *, i + 2));
+    team->hue = atoi((char *) $(info, pointerAtIndex, i + 2));
 
-    if (!Color_Parse(VectorValue(info, char *, i + 3), &team->color)) {
+    if (!Color_Parse((char *) $(info, pointerAtIndex, i + 3), &team->color)) {
       team->color = color_white;
     }
   }
 
-  for (size_t i = 0; i < count; i++) { free(VectorValue(info, char *, i)); }
   release(info);
 }
 

--- a/src/cgame/default/cg_main.c
+++ b/src/cgame/default/cg_main.c
@@ -222,7 +222,6 @@ static void Cg_ParseTeamInfo(const char *s) {
   const size_t count = info->count;
 
   if (count != lengthof(cg_state.teams) * 4) {
-    for (size_t i = 0; i < count; i++) { free(VectorValue(info, char *, i)); }
     release(info);
     Cg_Error("Invalid team data: %s\n", s);
   }

--- a/src/cgame/default/cg_ui.c
+++ b/src/cgame/default/cg_ui.c
@@ -66,18 +66,13 @@ void Cg_ShutdownUi(void) {
   cgi.PopAllViewControllers();
   cgi.PopViewController();
 
-  update_available = false;
-
-  release(updateViewController);
-  updateViewController = NULL;
-
-  release(mainViewController);
-  mainViewController = NULL;
-
   $(cgi.Theme(), removeStylesheet, stylesheet);
 
-  release(stylesheet);
-  stylesheet = NULL;
+  update_available = false;
+
+  updateViewController = release(updateViewController);
+  mainViewController = release(mainViewController);
+  stylesheet = release(stylesheet);
 }
 
 /**

--- a/src/cgame/default/cg_ui.c
+++ b/src/cgame/default/cg_ui.c
@@ -28,6 +28,7 @@
 static MainViewController *mainViewController;
 static UpdateViewController *updateViewController;
 static Stylesheet *stylesheet;
+static bool update_available;
 
 /**
  * @brief Initializes the user interface.
@@ -49,12 +50,23 @@ void Cg_InitUi(void) {
 }
 
 /**
+ * @brief Returns true if a binary update was detected during startup, clearing the flag.
+ */
+bool Cg_IsUpdateAvailable(void) {
+  const bool avail = update_available;
+  update_available = false;
+  return avail;
+}
+
+/**
  * @brief Shuts down the user interface.
  */
 void Cg_ShutdownUi(void) {
 
   cgi.PopAllViewControllers();
   cgi.PopViewController();
+
+  update_available = false;
 
   release(updateViewController);
   updateViewController = NULL;
@@ -109,6 +121,14 @@ int32_t Cg_UpdateInstaller(const installer_status_t *in) {
   }
 
   $(updateViewController, setStatus, in);
+
+  if (in->state == INSTALLER_UPDATE_AVAILABLE) {
+    update_available = true;
+    cgi.PopViewController();
+    release(updateViewController);
+    updateViewController = NULL;
+    return 1;
+  }
 
   if (in->state == INSTALLER_DONE || in->state == INSTALLER_ERROR) {
     static uint64_t done_at = 0;

--- a/src/cgame/default/cg_ui.c
+++ b/src/cgame/default/cg_ui.c
@@ -28,7 +28,6 @@
 static MainViewController *mainViewController;
 static UpdateViewController *updateViewController;
 static Stylesheet *stylesheet;
-static bool update_available;
 
 /**
  * @brief Initializes the user interface.
@@ -50,15 +49,6 @@ void Cg_InitUi(void) {
 }
 
 /**
- * @brief Returns true if a binary update was detected during startup, clearing the flag.
- */
-bool Cg_IsUpdateAvailable(void) {
-  const bool avail = update_available;
-  update_available = false;
-  return avail;
-}
-
-/**
  * @brief Shuts down the user interface.
  */
 void Cg_ShutdownUi(void) {
@@ -67,8 +57,6 @@ void Cg_ShutdownUi(void) {
   cgi.PopViewController();
 
   $(cgi.Theme(), removeStylesheet, stylesheet);
-
-  update_available = false;
 
   updateViewController = release(updateViewController);
   mainViewController = release(mainViewController);
@@ -118,7 +106,7 @@ int32_t Cg_UpdateInstaller(const installer_status_t *in) {
   $(updateViewController, setStatus, in);
 
   if (in->state == INSTALLER_UPDATE_AVAILABLE) {
-    update_available = true;
+    mainViewController->updateAvailable = true;
     cgi.PopViewController();
     release(updateViewController);
     updateViewController = NULL;

--- a/src/cgame/default/cg_ui.h
+++ b/src/cgame/default/cg_ui.h
@@ -26,7 +26,6 @@
 void Cg_InitUi(void);
 void Cg_ShutdownUi(void);
 void Cg_ClearUi(void);
-bool Cg_IsUpdateAvailable(void);
 void Cg_UpdateLoading(const cl_loading_t loading);
 int32_t Cg_UpdateInstaller(const installer_status_t *status);
 

--- a/src/cgame/default/cg_ui.h
+++ b/src/cgame/default/cg_ui.h
@@ -26,6 +26,7 @@
 void Cg_InitUi(void);
 void Cg_ShutdownUi(void);
 void Cg_ClearUi(void);
+bool Cg_IsUpdateAvailable(void);
 void Cg_UpdateLoading(const cl_loading_t loading);
 int32_t Cg_UpdateInstaller(const installer_status_t *status);
 

--- a/src/cgame/default/ui/home/HomeViewController.c
+++ b/src/cgame/default/ui/home/HomeViewController.c
@@ -23,20 +23,10 @@
 
 #include "HomeViewController.h"
 
-#include "DialogViewController.h"
 #include "LeaderboardViewController.h"
 #include "StatsViewController.h"
 
 #define _Class _HomeViewController
-
-#pragma mark - Delegates
-
-/**
- * @brief Dialog::okFunction for opening the releases page.
- */
-static void openReleasesPage(ident data) {
-  SDL_OpenURL(QUETOO_RELEASES_URL);
-}
 
 #pragma mark - Object
 
@@ -87,27 +77,6 @@ static void loadView(ViewController *self) {
 }
 
 /**
- * @see ViewController::viewWillAppear(ViewController *)
- */
-static void viewWillAppear(ViewController *self) {
-
-  super(ViewController, self, viewWillAppear);
-
-  if (Cg_IsUpdateAvailable()) {
-    const Dialog dialog = {
-      .message = "A new version of Quetoo is available. Download now?",
-      .ok = "Yes",
-      .cancel = "No",
-      .okFunction = openReleasesPage
-    };
-
-    ViewController *viewController = (ViewController *) $(alloc(DialogViewController), initWithDialog, &dialog);
-    $(self, addChildViewController, viewController);
-    release(viewController);
-  }
-}
-
-/**
  * @see Class::initialize(Class *)
  */
 static void initialize(Class *clazz) {
@@ -115,7 +84,6 @@ static void initialize(Class *clazz) {
   ((ObjectInterface *) clazz->interface)->dealloc = dealloc;
 
   ((ViewControllerInterface *) clazz->interface)->loadView = loadView;
-  ((ViewControllerInterface *) clazz->interface)->viewWillAppear = viewWillAppear;
 }
 
 /**

--- a/src/cgame/default/ui/home/HomeViewController.c
+++ b/src/cgame/default/ui/home/HomeViewController.c
@@ -23,10 +23,20 @@
 
 #include "HomeViewController.h"
 
+#include "DialogViewController.h"
 #include "LeaderboardViewController.h"
 #include "StatsViewController.h"
 
 #define _Class _HomeViewController
+
+#pragma mark - Delegates
+
+/**
+ * @brief Dialog::okFunction for opening the releases page.
+ */
+static void openReleasesPage(ident data) {
+  SDL_OpenURL(QUETOO_RELEASES_URL);
+}
 
 #pragma mark - Object
 
@@ -77,6 +87,27 @@ static void loadView(ViewController *self) {
 }
 
 /**
+ * @see ViewController::viewWillAppear(ViewController *)
+ */
+static void viewWillAppear(ViewController *self) {
+
+  super(ViewController, self, viewWillAppear);
+
+  if (Cg_IsUpdateAvailable()) {
+    const Dialog dialog = {
+      .message = "A new version of Quetoo is available. Download now?",
+      .ok = "Yes",
+      .cancel = "No",
+      .okFunction = openReleasesPage
+    };
+
+    ViewController *viewController = (ViewController *) $(alloc(DialogViewController), initWithDialog, &dialog);
+    $(self, addChildViewController, viewController);
+    release(viewController);
+  }
+}
+
+/**
  * @see Class::initialize(Class *)
  */
 static void initialize(Class *clazz) {
@@ -84,6 +115,7 @@ static void initialize(Class *clazz) {
   ((ObjectInterface *) clazz->interface)->dealloc = dealloc;
 
   ((ViewControllerInterface *) clazz->interface)->loadView = loadView;
+  ((ViewControllerInterface *) clazz->interface)->viewWillAppear = viewWillAppear;
 }
 
 /**

--- a/src/cgame/default/ui/main/MainViewController.c
+++ b/src/cgame/default/ui/main/MainViewController.c
@@ -64,6 +64,13 @@ static void didClickNavigateViewController(Button *button) {
 }
 
 /**
+ * @brief Opens the releases page.
+ */
+static void openReleasesPage(ident data) {
+  SDL_OpenURL(QUETOO_RELEASES_URL);
+}
+
+/**
  * @brief Quit the game.
  */
 static void quit(ident data) {
@@ -210,6 +217,21 @@ static void viewWillAppear(ViewController *self) {
     if (team == TEAM_NONE) {
       $(this, navigateToViewController, _TeamsViewController());
     }
+  }
+
+  if (this->updateAvailable) {
+    this->updateAvailable = false;
+
+    const Dialog dialog = {
+      .message = "A new version of Quetoo is available. Download now?",
+      .ok = "Yes",
+      .cancel = "No",
+      .okFunction = openReleasesPage
+    };
+
+    ViewController *viewController = (ViewController *) $(alloc(DialogViewController), initWithDialog, &dialog);
+    $(self, addChildViewController, viewController);
+    release(viewController);
   }
 }
 

--- a/src/cgame/default/ui/main/MainViewController.c
+++ b/src/cgame/default/ui/main/MainViewController.c
@@ -231,7 +231,6 @@ static void viewWillAppear(ViewController *self) {
 
     ViewController *viewController = (ViewController *) $(alloc(DialogViewController), initWithDialog, &dialog);
     $(self, addChildViewController, viewController);
-    release(viewController);
   }
 }
 

--- a/src/cgame/default/ui/main/MainViewController.h
+++ b/src/cgame/default/ui/main/MainViewController.h
@@ -63,6 +63,11 @@ struct MainViewController {
    * @brief The NavigationViewController.
    */
   NavigationViewController *navigationViewController;
+
+  /**
+   * @brief Set when an update is available, to present the update dialog on next appearance.
+   */
+  bool updateAvailable;
 };
 
 /**

--- a/src/cgame/default/ui/main/UpdateViewController.c
+++ b/src/cgame/default/ui/main/UpdateViewController.c
@@ -81,15 +81,15 @@ static void fetchHeroImages(void *data) {
 	release(list_data);
 
 	if (urls->count > 1) {
-		for (uint32_t i = (uint32_t) urls->count - 1; i > 0; i--) {
-			const uint32_t j = (uint32_t) rand() % (i + 1);
+		for (size_t i = urls->count - 1; i > 0; i--) {
+			const size_t j = Randomu() % (i + 1);
 			void *tmp = urls->elements[i];
 			urls->elements[i] = urls->elements[j];
 			urls->elements[j] = tmp;
 		}
 	}
 
-	for (uint32_t i = 0; i < urls->count; i++) {
+	for (size_t i = 0; i < urls->count; i++) {
 		image_data = NULL;
 		const char *url_str = urls->elements[i];
 		if ($(cgi.restClient, get, url_str, &image_data) == 200 && image_data) {

--- a/src/cgame/default/ui/main/UpdateViewController.c
+++ b/src/cgame/default/ui/main/UpdateViewController.c
@@ -23,7 +23,6 @@
 
 #include <SDL3_image/SDL_image.h>
 
-#include "DialogViewController.h"
 #include "UpdateViewController.h"
 
 #define _Class _UpdateViewController
@@ -208,17 +207,9 @@ static void setStatus(UpdateViewController *self, const installer_status_t *in) 
       $(self->progressBar, setLabelFormat, "Checking for binary updates\u2026");
       $(self->progressBar, setValue, 0.0);
       break;
-    case INSTALLER_UPDATE_AVAILABLE: {
-      const Dialog dialog = {
-        .message = "A new version of Quetoo is available. Download now?",
-        .ok = "Yes",
-        .cancel = "No",
-        .okFunction = openReleasesPage
-      };
-
-      ViewController *viewController = (ViewController *) $(alloc(DialogViewController), initWithDialog, &dialog);
-      $((ViewController *) self, addChildViewController, viewController);
-    }
+    case INSTALLER_UPDATE_AVAILABLE:
+      $(self->progressBar, setLabelFormat, "Update available.");
+      $(self->progressBar, setValue, 100.0);
       break;
 		case INSTALLER_COMPARING:
 			$(self->progressBar, setLabelFormat, "Comparing data files\u2026");

--- a/src/cgame/default/ui/main/UpdateViewController.c
+++ b/src/cgame/default/ui/main/UpdateViewController.c
@@ -23,6 +23,8 @@
 
 #include <SDL3_image/SDL_image.h>
 
+#include <Objectively/PointerArray.h>
+
 #include "UpdateViewController.h"
 
 #define _Class _UpdateViewController
@@ -68,7 +70,7 @@ static void fetchHeroImages(void *data) {
 			continue;
 		}
 
-		$(urls, addPointer, q_strdup(url));
+		$(urls, add, q_strdup(url));
 		p = s + q_strlen(suffix);
 	}
 

--- a/src/cgame/default/ui/main/UpdateViewController.c
+++ b/src/cgame/default/ui/main/UpdateViewController.c
@@ -80,11 +80,13 @@ static void fetchHeroImages(void *data) {
 
 	release(list_data);
 
-	for (uint32_t i = (uint32_t) urls->count - 1; i > 0; i--) {
-		const uint32_t j = (uint32_t) rand() % (i + 1);
-		void *tmp = urls->elements[i];
-		urls->elements[i] = urls->elements[j];
-		urls->elements[j] = tmp;
+	if (urls->count > 1) {
+		for (uint32_t i = (uint32_t) urls->count - 1; i > 0; i--) {
+			const uint32_t j = (uint32_t) rand() % (i + 1);
+			void *tmp = urls->elements[i];
+			urls->elements[i] = urls->elements[j];
+			urls->elements[j] = tmp;
+		}
 	}
 
 	for (uint32_t i = 0; i < urls->count; i++) {

--- a/src/cgame/default/ui/main/UpdateViewController.c
+++ b/src/cgame/default/ui/main/UpdateViewController.c
@@ -22,7 +22,6 @@
 #include "cg_local.h"
 
 #include <SDL3_image/SDL_image.h>
-
 #include <Objectively/PointerArray.h>
 
 #include "UpdateViewController.h"

--- a/src/cgame/default/ui/main/UpdateViewController.c
+++ b/src/cgame/default/ui/main/UpdateViewController.c
@@ -50,7 +50,7 @@ static void fetchHeroImages(void *data) {
 	static const char prefix[] = "<Key>hero-images/";
 	static const char suffix[] = "</Key>";
 
-	Vector *urls = $(alloc(Vector), initWithSize, sizeof(char *));
+	PointerArray *urls = $(alloc(PointerArray), initWithDestroy, free);
 
 	char *p = (char *) list_data->bytes;
 	while ((p = q_strstr(p, prefix)) != NULL) {
@@ -68,8 +68,7 @@ static void fetchHeroImages(void *data) {
 			continue;
 		}
 
-		char *dup = q_strdup(url);
-		$(urls, addElement, &dup);
+		$(urls, addPointer, q_strdup(url));
 		p = s + q_strlen(suffix);
 	}
 
@@ -77,14 +76,14 @@ static void fetchHeroImages(void *data) {
 
 	for (uint32_t i = (uint32_t) urls->count - 1; i > 0; i--) {
 		const uint32_t j = (uint32_t) rand() % (i + 1);
-		char *tmp = VectorValue(urls, char *, i);
-		VectorValue(urls, char *, i) = VectorValue(urls, char *, j);
-		VectorValue(urls, char *, j) = tmp;
+		void *tmp = urls->elements[i];
+		urls->elements[i] = urls->elements[j];
+		urls->elements[j] = tmp;
 	}
 
 	for (uint32_t i = 0; i < urls->count; i++) {
 		image_data = NULL;
-		char *url_str = VectorValue(urls, char *, i);
+		const char *url_str = urls->elements[i];
 		if ($(cgi.restClient, get, url_str, &image_data) == 200 && image_data) {
 			Image *image = NULL;
 
@@ -111,10 +110,7 @@ static void fetchHeroImages(void *data) {
 		release(image_data);
 	}
 
-	for (uint32_t i = 0; i < urls->count; i++) {
-		free(VectorValue(urls, char *, i));
-	}
-	release(urls);
+	urls = release(urls);
 }
 
 #pragma mark - Object

--- a/src/cgame/default/ui/main/UpdateViewController.c
+++ b/src/cgame/default/ui/main/UpdateViewController.c
@@ -61,6 +61,11 @@ static void fetchHeroImages(void *data) {
 		assert(s);
 		*s = '\0';
 
+		if (*p == '\0') {
+			p = s + q_strlen(suffix);
+			continue;
+		}
+
 		char url[MAX_STRING_CHARS];
 		const int url_len = q_snprintf(url, sizeof(url), "%s%s", QUETOO_HERO_BASE_URL, p);
 		if (url_len < 0 || (size_t) url_len >= sizeof(url)) {

--- a/src/cgame/default/ui/main/UpdateViewController.c
+++ b/src/cgame/default/ui/main/UpdateViewController.c
@@ -33,13 +33,6 @@
 #pragma mark - Delegates
 
 /**
- * @brief Dialog::okFunction for opening the releases page.
- */
-static void openReleasesPage(ident data) {
-  SDL_OpenURL(QUETOO_RELEASES_URL);
-}
-
-/**
  * @brief `ThreadRunFunc` that pre-fetches all hero images synchronously.
  */
 static void fetchHeroImages(void *data) {

--- a/src/cgame/default/ui/play/CreateServerViewController.c
+++ b/src/cgame/default/ui/play/CreateServerViewController.c
@@ -19,8 +19,6 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
  */
 
-#include <Objectively/Pointer.h>
-
 #include "cg_local.h"
 
 #include "CreateServerViewController.h"
@@ -59,7 +57,7 @@ static void createServer(Button *button) {
 
   CreateServerViewController *this = button->delegate.self;
 
-  Array *selectedMaps = $(this->mapList, selectedMaps);
+  PointerArray *selectedMaps = $(this->mapList, selectedMaps);
   if (selectedMaps->count) {
 
     file_t *file = cgi.OpenFileWrite(MAP_LIST_UI);
@@ -70,8 +68,7 @@ static void createServer(Button *button) {
 
       for (size_t i = 0; i < selectedMaps->count; i++) {
 
-        const Pointer *value = $(selectedMaps, objectAtIndex, i);
-        const MapListItemInfo *info = (MapListItemInfo *) value->pointer;
+        const MapListItemInfo *info = (MapListItemInfo *) $(selectedMaps, pointerAtIndex, i);
 
         char name[MAX_QPATH];
         StripExtension(Basename(info->mapname), name);

--- a/src/cgame/default/ui/play/CreateServerViewController.c
+++ b/src/cgame/default/ui/play/CreateServerViewController.c
@@ -67,8 +67,7 @@ static void createServer(Button *button) {
       assert(string);
 
       for (size_t i = 0; i < selectedMaps->count; i++) {
-
-        const MapListItemInfo *info = (MapListItemInfo *) $(selectedMaps, pointerAtIndex, i);
+        const MapListItemInfo *info = (MapListItemInfo *) $(selectedMaps, get, i);
 
         char name[MAX_QPATH];
         StripExtension(Basename(info->mapname), name);

--- a/src/cgame/default/ui/play/CreateServerViewController.c
+++ b/src/cgame/default/ui/play/CreateServerViewController.c
@@ -19,7 +19,7 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
  */
 
-#include <Objectively/Value.h>
+#include <Objectively/Pointer.h>
 
 #include "cg_local.h"
 
@@ -70,8 +70,8 @@ static void createServer(Button *button) {
 
       for (size_t i = 0; i < selectedMaps->count; i++) {
 
-        const Value *value = $(selectedMaps, objectAtIndex, i);
-        const MapListItemInfo *info = (MapListItemInfo *) value->value;
+        const Pointer *value = $(selectedMaps, objectAtIndex, i);
+        const MapListItemInfo *info = (MapListItemInfo *) value->pointer;
 
         char name[MAX_QPATH];
         StripExtension(Basename(info->mapname), name);

--- a/src/cgame/default/ui/play/JoinServerViewController.c
+++ b/src/cgame/default/ui/play/JoinServerViewController.c
@@ -468,7 +468,7 @@ static void reloadServers(JoinServerViewController *self) {
   const List *servers = cgi.Servers();
   for (const ListNode *node = servers ? servers->head : NULL; node; node = node->next) {
     cl_server_info_t *server = node->element;
-    $(self->servers, appendElement, server);
+    $(self->servers, append, server);
   }
 
   for (ListNode *node = self->servers->head; node; ) {

--- a/src/cgame/default/ui/play/MapListCollectionItemView.c
+++ b/src/cgame/default/ui/play/MapListCollectionItemView.c
@@ -43,11 +43,11 @@ static MapListCollectionItemView *initWithFrame(MapListCollectionItemView *self,
 }
 
 /**
- * @fn void MapListCollectionItemView::setMapListItemInfo(MapListCollectionItemView *self, MapListItemInfo *info);
+ * @fn void MapListCollectionItemView::setMapListItemInfo(MapListCollectionItemView *self, const MapListItemInfo *info);
  *
  * @memberof MapListCollectionItemView
  */
-static void setMapListItemInfo(MapListCollectionItemView *self, MapListItemInfo *info) {
+static void setMapListItemInfo(MapListCollectionItemView *self, const MapListItemInfo *info) {
 
   CollectionItemView *item = (CollectionItemView *) self;
 

--- a/src/cgame/default/ui/play/MapListCollectionItemView.h
+++ b/src/cgame/default/ui/play/MapListCollectionItemView.h
@@ -78,12 +78,12 @@ struct MapListCollectionItemViewInterface {
   MapListCollectionItemView *(*initWithFrame)(MapListCollectionItemView *self, const SDL_Rect *frame);
 
   /**
-   * @fn void MapListCollectionItemView::setMapListItemInfo(MapListCollectionItemView *self, MapListItemInfo *info);
+   * @fn void MapListCollectionItemView::setMapListItemInfo(MapListCollectionItemView *self, const MapListItemInfo *info);
    * @brief Sets the information for this item.
    * @param info The MapListItemInfo.
    * @memberof MapListCollectionItemView
    */
-  void (*setMapListItemInfo)(MapListCollectionItemView *self, MapListItemInfo *info);
+  void (*setMapListItemInfo)(MapListCollectionItemView *self, const MapListItemInfo *info);
 };
 
 /**

--- a/src/cgame/default/ui/play/MapListCollectionView.c
+++ b/src/cgame/default/ui/play/MapListCollectionView.c
@@ -19,7 +19,7 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
  */
 
-#include <Objectively/Value.h>
+#include <Objectively/Pointer.h>
 
 #include "cg_local.h"
 
@@ -62,12 +62,12 @@ static CollectionItemView *itemForObjectAtIndexPath(const CollectionView *collec
   const MapListCollectionView *this = (const MapListCollectionView *) collectionView;
   const size_t index = $(indexPath, indexAtPosition, 0);
 
-  Value *value = $((Array *) this->maps, objectAtIndex, index);
+  Pointer *value = $((Array *) this->maps, objectAtIndex, index);
 
   MapListCollectionItemView *item = $(alloc(MapListCollectionItemView), initWithFrame, NULL);
   assert(item);
 
-  $(item, setMapListItemInfo, value->value);
+  $(item, setMapListItemInfo, value->pointer);
 
   return (CollectionItemView *) item;
 }
@@ -79,8 +79,8 @@ static CollectionItemView *itemForObjectAtIndexPath(const CollectionView *collec
  */
 static Order sortMaps(const ident a, const ident b) {
 
-  const MapListItemInfo *c = ((const Value *) a)->value;
-  const MapListItemInfo *d = ((const Value *) b)->value;
+  const MapListItemInfo *c = ((const Pointer *) a)->pointer;
+  const MapListItemInfo *d = ((const Pointer *) b)->pointer;
 
   const char *e = !q_strncmp(c->message, "The ", 4) ? c->message + 4 : c->message;
   const char *f = !q_strncmp(d->message, "The ", 4) ? d->message + 4 : d->message;
@@ -98,8 +98,8 @@ static void enumerateMaps(const char *path, void *data) {
   const Array *maps = (Array *) this->maps;
   for (size_t i = 0; i < maps->count; i++) {
 
-    const Value *value = $(maps, objectAtIndex, i);
-    const MapListItemInfo *info = value->value;
+    const Pointer *value = $(maps, objectAtIndex, i);
+    const MapListItemInfo *info = value->pointer;
 
     if (q_strcmp(info->mapname, path) == 0) {
       return;
@@ -193,7 +193,7 @@ static void enumerateMaps(const char *path, void *data) {
 
       release(mapshots);
 
-      Value *value = $(alloc(Value), initWithValue, info);
+      Pointer *value = ptr(info, NULL);
 
       synchronized(this->lock, {
         $(this->maps, addObject, value);
@@ -301,7 +301,7 @@ static Array *selectedMaps(const MapListCollectionView *self) {
   for (size_t i = 0; i < selection->count; i++) {
     const IndexPath *indexPath = $(selection, objectAtIndex, i);
 
-    Value *value = this->dataSource.objectForItemAtIndexPath(this, indexPath);
+    Pointer *value = this->dataSource.objectForItemAtIndexPath(this, indexPath);
     $(selectedMaps, addObject, value);
   }
 

--- a/src/cgame/default/ui/play/MapListCollectionView.c
+++ b/src/cgame/default/ui/play/MapListCollectionView.c
@@ -19,7 +19,7 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
  */
 
-#include <Objectively/Pointer.h>
+#include <Objectively/PointerArray.h>
 
 #include "cg_local.h"
 
@@ -27,6 +27,17 @@
 #include "MapListCollectionItemView.h"
 
 #define _Class _MapListCollectionView
+
+/**
+ * @brief PointerArray destroy function for MapListItemInfo.
+ */
+static void freeMapListItemInfo(void *p) {
+  MapListItemInfo *info = p;
+  if (info->mapshot) {
+    SDL_DestroySurface(info->mapshot);
+  }
+  free(info);
+}
 
 #pragma mark CollectionViewDataSource
 
@@ -37,7 +48,7 @@ static size_t numberOfItems(const CollectionView *collectionView) {
 
   const MapListCollectionView *this = (const MapListCollectionView *) collectionView;
 
-  return ((Array *) this->maps)->count;
+  return this->maps->count;
 }
 
 /**
@@ -49,7 +60,7 @@ static ident objectForItemAtIndexPath(const CollectionView *collectionView, cons
 
   const size_t index = $(indexPath, indexAtPosition, 0);
 
-  return $((Array *) this->maps, objectAtIndex, index);
+  return $(this->maps, pointerAtIndex, $(indexPath, indexAtPosition, 0));
 }
 
 #pragma mark - CollectionViewDelegate
@@ -62,12 +73,12 @@ static CollectionItemView *itemForObjectAtIndexPath(const CollectionView *collec
   const MapListCollectionView *this = (const MapListCollectionView *) collectionView;
   const size_t index = $(indexPath, indexAtPosition, 0);
 
-  Pointer *value = $((Array *) this->maps, objectAtIndex, index);
+  const MapListItemInfo *info = $(this->maps, pointerAtIndex, index);
 
   MapListCollectionItemView *item = $(alloc(MapListCollectionItemView), initWithFrame, NULL);
   assert(item);
 
-  $(item, setMapListItemInfo, value->pointer);
+  $(item, setMapListItemInfo, info);
 
   return (CollectionItemView *) item;
 }
@@ -79,8 +90,8 @@ static CollectionItemView *itemForObjectAtIndexPath(const CollectionView *collec
  */
 static Order sortMaps(const ident a, const ident b) {
 
-  const MapListItemInfo *c = ((const Pointer *) a)->pointer;
-  const MapListItemInfo *d = ((const Pointer *) b)->pointer;
+  const MapListItemInfo *c = a;
+  const MapListItemInfo *d = b;
 
   const char *e = !q_strncmp(c->message, "The ", 4) ? c->message + 4 : c->message;
   const char *f = !q_strncmp(d->message, "The ", 4) ? d->message + 4 : d->message;
@@ -95,12 +106,8 @@ static void enumerateMaps(const char *path, void *data) {
 
   MapListCollectionView *this = (MapListCollectionView *) data;
 
-  const Array *maps = (Array *) this->maps;
-  for (size_t i = 0; i < maps->count; i++) {
-
-    const Pointer *value = $(maps, objectAtIndex, i);
-    const MapListItemInfo *info = value->pointer;
-
+  for (size_t i = 0; i < this->maps->count; i++) {
+    const MapListItemInfo *info = $(this->maps, pointerAtIndex, i);
     if (q_strcmp(info->mapname, path) == 0) {
       return;
     }
@@ -193,10 +200,8 @@ static void enumerateMaps(const char *path, void *data) {
 
       release(mapshots);
 
-      Pointer *value = ptr(info, NULL);
-
       synchronized(this->lock, {
-        $(this->maps, addObject, value);
+        $(this->maps, addPointer, info);
         $(this->maps, sort, sortMaps);
       });
     }
@@ -248,10 +253,9 @@ static void layoutIfNeeded(View *self) {
 
   synchronized(this->lock, {
 
-    const Array *maps = (Array *) this->maps;
     const Array *items = (Array *) this->collectionView.items;
 
-    if (maps->count != items->count) {
+    if (this->maps->count != items->count) {
       $((CollectionView *) this, reloadData);
     }
 
@@ -272,7 +276,7 @@ static MapListCollectionView *initWithFrame(MapListCollectionView *self, const S
     self->lock = $(alloc(Lock), init);
     assert(self->lock);
 
-    self->maps = $$(Array, array);
+    self->maps = $(alloc(PointerArray), initWithDestroy, freeMapListItemInfo);
     assert(self->maps);
 
     cgi.Thread(__func__, loadMaps, self, THREAD_NO_WAIT);
@@ -288,26 +292,24 @@ static MapListCollectionView *initWithFrame(MapListCollectionView *self, const S
 }
 
 /**
- * @fn Array *MapListCollectionView::selectedMaps(const MapListCollectionView *self)
+ * @fn PointerArray *MapListCollectionView::selectedMaps(const MapListCollectionView *self)
  * @memberof MapListCollectionView
  */
-static Array *selectedMaps(const MapListCollectionView *self) {
+static PointerArray *selectedMaps(const MapListCollectionView *self) {
 
   const CollectionView *this = (const CollectionView *) self;
 
-  Array *selectedMaps = $$(Array, array);
+  PointerArray *selected = $(alloc(PointerArray), init);
 
   Array *selection = $(this, selectionIndexPaths);
   for (size_t i = 0; i < selection->count; i++) {
     const IndexPath *indexPath = $(selection, objectAtIndex, i);
-
-    Pointer *value = this->dataSource.objectForItemAtIndexPath(this, indexPath);
-    $(selectedMaps, addObject, value);
+    $(selected, addPointer, this->dataSource.objectForItemAtIndexPath(this, indexPath));
   }
 
   release(selection);
 
-  return (Array *) selectedMaps;
+  return selected;
 }
 
 #pragma mark - Class lifecycle

--- a/src/cgame/default/ui/play/MapListCollectionView.c
+++ b/src/cgame/default/ui/play/MapListCollectionView.c
@@ -191,11 +191,7 @@ static void enumerateMaps(const char *path, void *data) {
         }
       }
 
-      if (mapshots) {
-        mapshots->destroy = (ListDestroyFunc) free;
-        $(mapshots, removeAll);
-        release(mapshots);
-      }
+      release(mapshots);
 
       Value *value = $(alloc(Value), initWithValue, info);
 

--- a/src/cgame/default/ui/play/MapListCollectionView.c
+++ b/src/cgame/default/ui/play/MapListCollectionView.c
@@ -60,7 +60,7 @@ static ident objectForItemAtIndexPath(const CollectionView *collectionView, cons
 
   const size_t index = $(indexPath, indexAtPosition, 0);
 
-  return $(this->maps, pointerAtIndex, $(indexPath, indexAtPosition, 0));
+  return $(this->maps, get, index);
 }
 
 #pragma mark - CollectionViewDelegate
@@ -73,7 +73,7 @@ static CollectionItemView *itemForObjectAtIndexPath(const CollectionView *collec
   const MapListCollectionView *this = (const MapListCollectionView *) collectionView;
   const size_t index = $(indexPath, indexAtPosition, 0);
 
-  const MapListItemInfo *info = $(this->maps, pointerAtIndex, index);
+  const MapListItemInfo *info = $(this->maps, get, index);
 
   MapListCollectionItemView *item = $(alloc(MapListCollectionItemView), initWithFrame, NULL);
   assert(item);
@@ -107,7 +107,7 @@ static void enumerateMaps(const char *path, void *data) {
   MapListCollectionView *this = (MapListCollectionView *) data;
 
   for (size_t i = 0; i < this->maps->count; i++) {
-    const MapListItemInfo *info = $(this->maps, pointerAtIndex, i);
+    const MapListItemInfo *info = $(this->maps, get, i);
     if (q_strcmp(info->mapname, path) == 0) {
       return;
     }
@@ -201,7 +201,7 @@ static void enumerateMaps(const char *path, void *data) {
       release(mapshots);
 
       synchronized(this->lock, {
-        $(this->maps, addPointer, info);
+        $(this->maps, add, info);
         $(this->maps, sort, sortMaps);
       });
     }
@@ -304,7 +304,7 @@ static PointerArray *selectedMaps(const MapListCollectionView *self) {
   Array *selection = $(this, selectionIndexPaths);
   for (size_t i = 0; i < selection->count; i++) {
     const IndexPath *indexPath = $(selection, objectAtIndex, i);
-    $(selected, addPointer, this->dataSource.objectForItemAtIndexPath(this, indexPath));
+    $(selected, add, this->dataSource.objectForItemAtIndexPath(this, indexPath));
   }
 
   release(selection);

--- a/src/cgame/default/ui/play/MapListCollectionView.h
+++ b/src/cgame/default/ui/play/MapListCollectionView.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include <Objectively/Lock.h>
+#include <Objectively/PointerArray.h>
 
 #include <ObjectivelyMVC/CollectionView.h>
 
@@ -59,7 +60,7 @@ struct MapListCollectionView {
   /**
    * @brief Available maps.
    */
-  Array *maps;
+  PointerArray *maps;
 };
 
 /**
@@ -82,11 +83,11 @@ struct MapListCollectionViewInterface {
   MapListCollectionView *(*initWithFrame)(MapListCollectionView *self, const SDL_Rect *frame);
 
   /**
-   * @fn Array *MapListCollectionView::selectedMaps(const MapListCollectionView *self)
-   * @return An Array of selected MapListItemInfo Values.
+   * @fn PointerArray *MapListCollectionView::selectedMaps(const MapListCollectionView *self)
+   * @return A PointerArray of selected MapListItemInfo pointers.
    * @memberof MapListCollectionView
    */
-  Array *(*selectedMaps)(const MapListCollectionView *self);
+  PointerArray *(*selectedMaps)(const MapListCollectionView *self);
 };
 
 /**

--- a/src/client/cl_media.c
+++ b/src/client/cl_media.c
@@ -97,7 +97,7 @@ static void Cl_Mapshots_enumerate(const char *path, void *data) {
   const size_t len = q_strlen(path);
   if ((len >= 4 && !q_strcmp(path + len - 4, ".jpg")) ||
       (len >= 4 && !q_strcmp(path + len - 4, ".png"))) {
-    $(list, appendElement, q_strdup(path));
+    $(list, append, q_strdup(path));
   }
 }
 

--- a/src/client/cl_media.c
+++ b/src/client/cl_media.c
@@ -110,7 +110,7 @@ List *Cl_Mapshots(const char *mapname) {
   StripExtension(mapname, map);
 
   List *list = $(alloc(List), init);
-  list->destroy = (ListDestroyFunc) free;
+  list->destroy = free;
   Fs_Enumerate(va("mapshots/%s/*", Basename(map)), Cl_Mapshots_enumerate, (void *) list);
 
   return list;
@@ -287,7 +287,6 @@ void Cl_LoadMedia(void) {
     cls.loading.mapshot[0] = '\0';
   }
 
-  $(mapshots, removeAll);
   release(mapshots);
 
   Cl_UpdatePrediction();

--- a/src/client/cl_parse.c
+++ b/src/client/cl_parse.c
@@ -96,8 +96,7 @@ void Cl_CheckOrDownloadFile(const char *filename) {
 
   SDL_SetAtomicInt(&cl_download.complete, 0);
   cl_download.status = 0;
-  release(cl_download.data);
-  cl_download.data = NULL;
+  cl_download.data = release(cl_download.data);
 
   $($$(RESTClient, sharedInstance), getAsync, url, Cl_DownloadComplete, NULL);
 
@@ -115,15 +114,13 @@ void Cl_CheckOrDownloadFile(const char *filename) {
 
   if (cl_download.status != 200 || !cl_download.data) {
     Com_Warn("Failed to download %s (HTTP %d)\n", filename, cl_download.status);
-    release(cl_download.data);
-    cl_download.data = NULL;
+    cl_download.data = release(cl_download.data);
     return;
   }
 
   if (cl_download.data->length > MAX_DOWNLOAD_SIZE) {
     Com_Warn("Download %s exceeds maximum size (%zu bytes)\n", filename, cl_download.data->length);
-    release(cl_download.data);
-    cl_download.data = NULL;
+    cl_download.data = release(cl_download.data);
     return;
   }
 
@@ -135,8 +132,7 @@ void Cl_CheckOrDownloadFile(const char *filename) {
   file_t *file = Fs_OpenWrite(tempname);
   if (!file) {
     Com_Warn("Failed to open %s for writing\n", tempname);
-    release(cl_download.data);
-    cl_download.data = NULL;
+    cl_download.data = release(cl_download.data);
     return;
   }
 
@@ -145,8 +141,7 @@ void Cl_CheckOrDownloadFile(const char *filename) {
 
   const size_t downloaded_length = cl_download.data->length;
 
-  release(cl_download.data);
-  cl_download.data = NULL;
+  cl_download.data = release(cl_download.data);
 
   if (Fs_Rename(tempname, filename)) {
     Com_Print("Downloaded %s (%zu bytes)\n", filename, downloaded_length);

--- a/src/client/cl_predict.c
+++ b/src/client/cl_predict.c
@@ -240,7 +240,7 @@ void Cl_PredictMovement(void) {
 
   while (++ack <= last) {
     cl_cmd_t *cmd = &cl.cmds[ack & CMD_MASK];
-    $(cmds, addElement, &cmd);
+    $(cmds, add, &cmd);
   }
 
   if (cmds->count) {

--- a/src/client/cl_server.c
+++ b/src/client/cl_server.c
@@ -41,7 +41,7 @@ static cl_server_info_t *Cl_AddServer(const net_addr_t *addr) {
     cls.servers->destroy = Mem_Free;
   }
 
-  $(cls.servers, prependElement, s);
+  $(cls.servers, prepend, s);
 
   return s;
 }

--- a/src/client/cl_server.c
+++ b/src/client/cl_server.c
@@ -36,7 +36,12 @@ static cl_server_info_t *Cl_AddServer(const net_addr_t *addr) {
   s->addr = *addr;
   q_strlcpy(s->hostname, Net_NetaddrToString(&s->addr), sizeof(s->hostname));
 
-  if (!cls.servers) { cls.servers = $(alloc(List), init); cls.servers->destroy = (ListDestroyFunc) Mem_Free; } $(cls.servers, prependElement, s);
+  if (!cls.servers) {
+    cls.servers = $(alloc(List), init);
+    cls.servers->destroy = Mem_Free;
+  }
+
+  $(cls.servers, prependElement, s);
 
   return s;
 }
@@ -64,10 +69,7 @@ static cl_server_info_t *Cl_ServerForNetaddr(const net_addr_t *addr) {
  * @brief Frees the list of known servers and clears the pointer.
  */
 void Cl_FreeServers(void) {
-
-  if (cls.servers) { $(cls.servers, removeAll); release(cls.servers); }
-
-  cls.servers = NULL;
+  cls.servers = release(cls.servers);
 }
 
 /**

--- a/src/client/renderer/r_bsp_model.c
+++ b/src/client/renderer/r_bsp_model.c
@@ -745,12 +745,9 @@ static void R_FreeBspModel(r_media_t *self) {
   r_bsp_block_t *block = bsp->blocks;
   for (int32_t i = 0; i < bsp->num_blocks; i++, block++) {
 
-    if (block->decals.triangles) {
-      release(block->decals.triangles);
-    }
+    release(block->decals.triangles);
 
     glDeleteBuffers(1, &block->decals.vertex_buffer);
-
     glDeleteVertexArrays(1, &block->decals.vertex_array);
 
     R_FreeOcclusionQuery(block->query);

--- a/src/client/renderer/r_decal.c
+++ b/src/client/renderer/r_decal.c
@@ -160,7 +160,7 @@ static void R_ClipDecalToFace(const r_view_t *view,
   if (overflow > 0) {
     const int32_t remove_count = Mini(overflow, (int32_t) decals->triangles->count);
     for (int32_t i = 0; i < remove_count; i++) {
-      $(decals->triangles, removeElementAtIndex, 0);
+      $(decals->triangles, removeAt, 0);
     }
   }
   

--- a/src/client/renderer/r_decal.c
+++ b/src/client/renderer/r_decal.c
@@ -189,7 +189,7 @@ static void R_ClipDecalToFace(const r_view_t *view,
     }
     
     decals->image = (r_image_t *) decal->image;
-    $(decals->triangles, addElement, &triangle);
+    $(decals->triangles, add, &triangle);
   }
 
   decals->dirty = true;

--- a/src/client/renderer/r_media.c
+++ b/src/client/renderer/r_media.c
@@ -40,7 +40,7 @@ typedef struct {
 static void R_EnumerateMedia_collect(const HashTable *table, ident key, ident value, ident data) {
   R_EnumerateMedia_ctx_t *ctx = data;
   r_media_t *media = value;
-  $(ctx->media, addElement, &media);
+  $(ctx->media, add, &media);
 }
 
 /**
@@ -92,7 +92,7 @@ r_media_t *R_RegisterDependency(r_media_t *dependent, r_media_t *dependency) {
   }
 
   if ($(dependent->dependencies, nodeForElement, dependency) == NULL) {
-    $(dependent->dependencies, prependElement, dependency);
+    $(dependent->dependencies, prepend, dependency);
   }
 
   return R_RegisterMedia(dependency);
@@ -206,7 +206,7 @@ static void R_FreeMedia_collect(const HashTable *table, ident key, ident value, 
   r_media_t *media = value;
 
   if (R_FreeMedia_(media, ctx->data)) {
-    $(ctx->media, addElement, &media);
+    $(ctx->media, add, &media);
   }
 }
 

--- a/src/client/renderer/r_media.c
+++ b/src/client/renderer/r_media.c
@@ -191,10 +191,7 @@ static bool R_FreeMedia_(r_media_t *media, void *data) {
     media->Free(media);
   }
 
-  if (media->dependencies) {
-    release(media->dependencies);
-    media->dependencies = NULL;
-  }
+  media->dependencies = release(media->dependencies);
 
   return true;
 }
@@ -294,7 +291,7 @@ void R_InitMedia(void) {
   memset(&r_media_state, 0, sizeof(r_media_state));
 
   r_media_state.media = $(alloc(HashTable), init, (HashTableHashFunc) R_MediaHash, (HashTableEqualFunc) R_MediaEqual);
-  r_media_state.media->destroyValue = (HashTableDestroyFunc) Mem_Free;
+  r_media_state.media->destroyValue = Mem_Free;
 
   R_BeginLoading();
 }
@@ -305,6 +302,6 @@ void R_InitMedia(void) {
 void R_ShutdownMedia(void) {
 
   R_FreeMediaEntries((void *) 1);
-  release(r_media_state.media);
-  r_media_state.media = NULL;
+
+  r_media_state.media = release(r_media_state.media);
 }

--- a/src/client/renderer/r_mesh_model_obj.c
+++ b/src/client/renderer/r_mesh_model_obj.c
@@ -108,22 +108,22 @@ static void R_LoadObjModel(r_model_t *mod, void *buffer) {
         // swap ordering to match Quetoo
         vec = Vec3(vec.x, vec.z, vec.y);
         mod->bounds = Box3_Append(mod->bounds, vec);
-        $(obj.v, addElement, &vec);
+        $(obj.v, add, &vec);
       }
     } else if (q_strncmp("vt ", line, q_strlen("vt ")) == 0) {
       if (Parse_QuickPrimitive(line + q_strlen("vt "), PARSER_NO_COMMENTS, PARSE_DEFAULT, PARSE_FLOAT, &vec, 2) == 2) {
         vec.y = -vec.y;
-        $(obj.vt, addElement, &vec);
+        $(obj.vt, add, &vec);
       }
     } else if (q_strncmp("vn ", line, q_strlen("vn ")) == 0) {
       if (Parse_QuickPrimitive(line + q_strlen("vn "), PARSER_NO_COMMENTS, PARSE_DEFAULT, PARSE_FLOAT, &vec, 3) == 3) {
         // swap ordering to match Quetoo
         vec = Vec3_Normalize(Vec3(vec.x, vec.z, vec.y));
-        $(obj.vn, addElement, &vec);
+        $(obj.vn, add, &vec);
       }
     } else if (q_strncmp("usemtl ", line, q_strlen("usemtl ")) == 0) {
       if (group.f->count) {
-        $(obj.g, addElement, &group);
+        $(obj.g, add, &group);
       } else {
         release(group.f);
       }
@@ -131,7 +131,7 @@ static void R_LoadObjModel(r_model_t *mod, void *buffer) {
       group.f = $(alloc(Vector), initWithSize, sizeof(r_obj_face_t));
     } else if (q_strncmp("g ", line, q_strlen("g ")) == 0) {
       if (group.f->count) {
-        $(obj.g, addElement, &group);
+        $(obj.g, add, &group);
       } else {
         release(group.f);
       }
@@ -163,12 +163,12 @@ static void R_LoadObjModel(r_model_t *mod, void *buffer) {
         }
       }
 
-      $(group.f, addElement, &face);
+      $(group.f, add, &face);
     }
   }
 
   if (group.f->count) {
-    $(obj.g, addElement, &group);
+    $(obj.g, add, &group);
   } else {
     release(group.f);
   }

--- a/src/client/renderer/r_model.c
+++ b/src/client/renderer/r_model.c
@@ -65,7 +65,7 @@ r_model_t *R_LoadModel(const char *name) {
       static HashTable *warned;
       if (!warned) {
         warned = $(alloc(HashTable), init, HashTableHashStr, HashTableEqualStr);
-        warned->destroyKey = (HashTableDestroyFunc) free;
+        warned->destroyKey = free;
       }
       if ($(warned, get, (void *) key) == NULL) {
         char *warned_key = q_strdup(key);

--- a/src/client/renderer/r_occlude.c
+++ b/src/client/renderer/r_occlude.c
@@ -316,6 +316,18 @@ void R_DrawOcclusionQueries(const r_view_t *view) {
 }
 
 /**
+ * @brief GDestroyNotify for deleting occlusion queries.
+ */
+static void R_ShutdownOcclusionQuery(void * data) {
+
+  r_occlusion_query_t *query = data;
+
+  glDeleteQueries(1, &query->name);
+
+  Mem_Free(query);
+}
+
+/**
  * @brief Initializes occlusion query state, allocating GPU buffers for bounding box rendering.
  */
 void R_InitOcclusionQueries(void) {
@@ -359,18 +371,6 @@ void R_InitOcclusionQueries(void) {
 }
 
 /**
- * @brief GDestroyNotify for deleting occlusion queries.
- */
-static void R_ShutdownOcclusionQuery(void * data) {
-
-  r_occlusion_query_t *query = data;
-
-  glDeleteQueries(1, &query->name);
-
-  Mem_Free(query);
-}
-
-/**
  * @brief Shuts down occlusion query state, freeing all GPU resources and allocated queries.
  */
 void R_ShutdownOcclusionQueries(void) {
@@ -380,15 +380,9 @@ void R_ShutdownOcclusionQueries(void) {
 
   glDeleteVertexArrays(1, &r_occlusion_queries.vertex_array);
 
-  if (r_occlusion_queries.allocated) {
-    r_occlusion_queries.allocated->destroy = (ListDestroyFunc) R_ShutdownOcclusionQuery;
-    $(r_occlusion_queries.allocated, removeAll);
-    release(r_occlusion_queries.allocated);
-  }
+  r_occlusion_queries.allocated->destroy = R_ShutdownOcclusionQuery;
+  r_occlusion_queries.allocated = release(r_occlusion_queries.allocated);
 
-  if (r_occlusion_queries.free) {
-    r_occlusion_queries.free->destroy = (ListDestroyFunc) R_ShutdownOcclusionQuery;
-    $(r_occlusion_queries.free, removeAll);
-    release(r_occlusion_queries.free);
-  }
+  r_occlusion_queries.free->destroy = R_ShutdownOcclusionQuery;
+  r_occlusion_queries.free = release(r_occlusion_queries.free);
 }

--- a/src/client/renderer/r_occlude.c
+++ b/src/client/renderer/r_occlude.c
@@ -147,7 +147,7 @@ r_occlusion_query_t *R_AllocOcclusionQuery(const box3_t bounds) {
 
   r_occlusion_queries.dirty = true;
 
-  $(r_occlusion_queries.allocated, prependElement, query);
+  $(r_occlusion_queries.allocated, prepend, query);
   return query;
 }
 
@@ -164,7 +164,7 @@ void R_FreeOcclusionQuery(r_occlusion_query_t *query) {
   if (node) {
     $(r_occlusion_queries.allocated, removeNode, node);
   }
-  $(r_occlusion_queries.free, prependElement, query);
+  $(r_occlusion_queries.free, prepend, query);
 
   r_occlusion_queries.dirty = true;
 }

--- a/src/client/sound/s_media.c
+++ b/src/client/sound/s_media.c
@@ -43,7 +43,7 @@ void S_LoadClientModelSamples(const char *model) {
     s_media_t *media = $(s_media_state.media, get, node->element);
 
     if (media && media->name[0] == '*') {
-      $(sounds, addElement, &media);
+      $(sounds, add, &media);
     }
   }
 
@@ -90,7 +90,7 @@ void S_RegisterDependency(s_media_t *dependent, s_media_t *dependency) {
         if (!dependent->dependencies) {
           dependent->dependencies = $(alloc(List), init);
         }
-        $(dependent->dependencies, appendElement, dependency);
+        $(dependent->dependencies, append, dependency);
 
         S_RegisterMedia(dependency);
       }
@@ -117,11 +117,11 @@ static void S_RegisterMedia_InsertSortedKey(const char *name) {
   // find insertion point (insert before first node where name <= existing)
   for (ListNode *n = s_media_state.keys->head; n; n = n->next) {
     if (q_strcmp(name, (const char *) n->element) <= 0) {
-      $(s_media_state.keys, insertElementAfter, n->prev, (void *) name);
+      $(s_media_state.keys, insertAfter, n->prev, (void *) name);
       return;
     }
   }
-  $(s_media_state.keys, appendElement, (void *) name);
+  $(s_media_state.keys, append, (void *) name);
 }
 
 /**
@@ -243,7 +243,7 @@ static void S_EndLoading_Collect(const HashTable *table, ident k, ident v, ident
   s_media_t *media = (s_media_t *) v;
   Vector *vec = (Vector *) data;
   if (!(media->seed == s_media_state.seed || (media->Retain && media->Retain(media)))) {
-    $(vec, addElement, &media);
+    $(vec, add, &media);
   }
 }
 
@@ -327,7 +327,7 @@ static void S_ShutdownMedia_Collect(const HashTable *table, ident k, ident v, id
   (void) table; (void) k;
   Vector *vec = (Vector *) data;
   s_media_t *media = (s_media_t *) v;
-  $(vec, addElement, &media);
+  $(vec, add, &media);
 }
 
 /**

--- a/src/client/sound/s_media.c
+++ b/src/client/sound/s_media.c
@@ -220,10 +220,7 @@ static bool S_FreeMedia_(const char *key, s_media_t *media, bool force) {
     media->Free(media);
   }
 
-  if (media->dependencies) {
-    release(media->dependencies);
-    media->dependencies = NULL;
-  }
+  media->dependencies = release(media->dependencies);
 
   // remove key from sorted keys list
   if (s_media_state.keys) {

--- a/src/client/sound/s_music.c
+++ b/src/client/sound/s_music.c
@@ -114,10 +114,7 @@ static bool S_LoadMusicFile(const char *name, SF_INFO *info, SNDFILE **snd, file
  */
 void S_ClearPlaylist(void) {
 
-  if (s_music_state.playlist) {
-    release(s_music_state.playlist);
-    s_music_state.playlist = NULL;
-  }
+    s_music_state.playlist = release(s_music_state.playlist);
 }
 
 /**

--- a/src/client/sound/s_music.c
+++ b/src/client/sound/s_music.c
@@ -173,7 +173,7 @@ s_music_t *S_LoadMusic(const char *name) {
     if (!s_music_state.playlist) {
       s_music_state.playlist = $(alloc(List), init);
     }
-    $(s_music_state.playlist, appendElement, music);
+    $(s_music_state.playlist, append, music);
   }
 
   return music;

--- a/src/collision/cm_entity.c
+++ b/src/collision/cm_entity.c
@@ -186,7 +186,7 @@ cm_entity_t *Cm_SortEntity(cm_entity_t *entity) {
   Vector *pairs = $(alloc(Vector), initWithSize, sizeof(cm_entity_t *));
 
   for (cm_entity_t *e = entity; e; e = e->next) {
-    $(pairs, addElement, &e);
+    $(pairs, add, &e);
   }
 
   $(pairs, sort, Cm_SortEntity_cmp);
@@ -268,7 +268,7 @@ List *Cm_LoadEntities(const char *entity_string) {
 
       assert(entity);
 
-      $(entities, appendElement, entity);
+      $(entities, append, entity);
     }
   }
 
@@ -378,7 +378,7 @@ Vector *Cm_EntityBrushes(const cm_entity_t *entity) {
   for (int32_t i = 0; i < Cm_Bsp()->num_brushes; i++, brush++) {
 
     if (brush->entity == entity) {
-      $(brushes, addElement, &brush);
+      $(brushes, add, &brush);
     }
   }
 

--- a/src/collision/cm_manifest.c
+++ b/src/collision/cm_manifest.c
@@ -44,7 +44,7 @@ static void Cm_Md5Hex(const void *data, size_t len, char *hex, size_t hex_size) 
  */
 HashTable *Cm_AllocManifest(void) {
 	HashTable *manifest = $(alloc(HashTable), init, HashTableHashStr, HashTableEqualStr);
-	manifest->destroyValue = (HashTableDestroyFunc) Mem_Free;
+	manifest->destroyValue = Mem_Free;
 	return manifest;
 }
 

--- a/src/common/atlas.c
+++ b/src/common/atlas.c
@@ -102,7 +102,7 @@ atlas_node_t *Atlas_Insert(atlas_t *atlas, ...) {
     va_end(args);
     assert(node->surfaces[0]);
 
-    $(atlas->nodes, addElement, &node);
+    $(atlas->nodes, add, &node);
   }
 
   return node;

--- a/src/common/cmd.c
+++ b/src/common/cmd.c
@@ -20,7 +20,7 @@
  */
 
 #include <Objectively/HashTable.h>
-#include <Objectively/Vector.h>
+#include <Objectively/PointerArray.h>
 
 #include "console.h"
 #include "filesystem.h"
@@ -294,20 +294,19 @@ cmd_t *Cmd_Get(const char *name) {
 }
 
 static Order Cmd_Enumerate_comparator(const ident a, const ident b) {
-  const int32_t cmp = q_strcasecmp((*(const cmd_t *const *) a)->name, (*(const cmd_t *const *) b)->name);
+  const int32_t cmp = q_strcasecmp(((const cmd_t *) a)->name, ((const cmd_t *) b)->name);
   return cmp < 0 ? OrderAscending : cmp > 0 ? OrderDescending : OrderSame;
 }
 
 typedef struct {
-  Vector *cmds;
+  PointerArray *cmds;
 } Cmd_Enumerate_ctx_t;
 
 static void Cmd_Enumerate_collect(const HashTable *table, ident key, ident value, ident data) {
   Cmd_Enumerate_ctx_t *ctx = data;
   const List *list = value;
   for (const ListNode *node = list->head; node; node = node->next) {
-    cmd_t *cmd = node->element;
-    $(ctx->cmds, addElement, &cmd);
+    $(ctx->cmds, addPointer, node->element);
   }
 }
 
@@ -316,15 +315,14 @@ static void Cmd_Enumerate_collect(const HashTable *table, ident key, ident value
  */
 void Cmd_Enumerate(Cmd_Enumerator func, void *data) {
   Cmd_Enumerate_ctx_t ctx = {
-    .cmds = $(alloc(Vector), initWithSize, sizeof(cmd_t *)),
+    .cmds = $(alloc(PointerArray), init),
   };
 
   $(cmd_state.commands, enumerate, Cmd_Enumerate_collect, &ctx);
   $(ctx.cmds, sort, Cmd_Enumerate_comparator);
 
   for (size_t i = 0; i < ctx.cmds->count; i++) {
-    cmd_t *cmd = VectorValue(ctx.cmds, cmd_t *, i);
-    func(cmd, data);
+    func((cmd_t *) $(ctx.cmds, pointerAtIndex, i), data);
   }
 
   release(ctx.cmds);
@@ -624,17 +622,16 @@ static void Cmd_Alias_f(void) {
 }
 
 typedef struct {
-  Vector *strs;
+  PointerArray *strs;
 } Cmd_List_ctx_t;
 
 static void Cmd_List_f_enumerate(cmd_t *cmd, void *data) {
   Cmd_List_ctx_t *ctx = data;
-  char *str = q_strdup(Cmd_Stringify(cmd));
-  $(ctx->strs, addElement, &str);
+  $(ctx->strs, addPointer, q_strdup(Cmd_Stringify(cmd)));
 }
 
 static Order Cmd_List_sortfn(const ident a, const ident b) {
-  const int32_t cmp = q_strcolorcmp(*(const char *const *) a, *(const char *const *) b);
+  const int32_t cmp = q_strcolorcmp((const char *) a, (const char *) b);
   return cmp < 0 ? OrderAscending : cmp > 0 ? OrderDescending : OrderSame;
 }
 
@@ -643,16 +640,14 @@ static Order Cmd_List_sortfn(const ident a, const ident b) {
  */
 static void Cmd_List_f(void) {
   Cmd_List_ctx_t ctx = {
-    .strs = $(alloc(Vector), initWithSize, sizeof(char *)),
+    .strs = $(alloc(PointerArray), initWithDestroy, free),
   };
 
   Cmd_Enumerate(Cmd_List_f_enumerate, &ctx);
   $(ctx.strs, sort, Cmd_List_sortfn);
 
   for (size_t i = 0; i < ctx.strs->count; i++) {
-    char *str = VectorValue(ctx.strs, char *, i);
-    Com_Print("%s\n", str);
-    free(str);
+    Com_Print("%s\n", (char *) $(ctx.strs, pointerAtIndex, i));
   }
 
   release(ctx.strs);
@@ -715,12 +710,11 @@ static void Cmd_Wait_f(void) {
 }
 
 typedef struct {
-  Vector *lists;
+  PointerArray *lists;
 } Cmd_Shutdown_ctx_t;
 
 static void Cmd_Shutdown_collect(const HashTable *table, ident key, ident value, ident data) {
-  Vector *lists = data;
-  $(lists, addElement, &value);
+  $(((PointerArray *) data), addPointer, value);
 }
 
 /**
@@ -773,13 +767,13 @@ void Cmd_Init(void) {
 void Cmd_Shutdown(void) {
 
   Cmd_Shutdown_ctx_t ctx = {
-    .lists = $(alloc(Vector), initWithSize, sizeof(ident)),
+    .lists = $(alloc(PointerArray), init),
   };
 
   $(cmd_state.commands, enumerate, Cmd_Shutdown_collect, ctx.lists);
 
   for (size_t i = 0; i < ctx.lists->count; i++) {
-    release(VectorValue(ctx.lists, List *, i));
+    release((List *) $(ctx.lists, pointerAtIndex, i));
   }
 
   release(ctx.lists);

--- a/src/common/cmd.c
+++ b/src/common/cmd.c
@@ -362,7 +362,7 @@ cmd_t *Cmd_Add(const char *name, CmdExecuteFunc function, uint32_t flags,
 
   if (!list) {
     list = $(alloc(List), init);
-    list->destroy = (ListDestroyFunc) Mem_Free;
+    list->destroy = Mem_Free;
     $(cmd_state.commands, set, key, list);
   }
 
@@ -403,7 +403,7 @@ static cmd_t *Cmd_Alias(const char *name, const char *commands) {
 
   if (!list) {
     list = $(alloc(List), init);
-    list->destroy = (ListDestroyFunc) Mem_Free;
+    list->destroy = Mem_Free;
     $(cmd_state.commands, set, key, list);
   }
 
@@ -425,7 +425,7 @@ static List *Cmd_RemovePtr_(cmd_t *cmd) {
   }
 
   // Disable destroy so we control when cmd is freed
-  ListDestroyFunc saved = list->destroy;
+  Consumer saved = list->destroy;
   list->destroy = NULL;
   $(list, removeNode, node);
   list->destroy = saved;
@@ -779,14 +779,12 @@ void Cmd_Shutdown(void) {
   $(cmd_state.commands, enumerate, Cmd_Shutdown_collect, ctx.lists);
 
   for (size_t i = 0; i < ctx.lists->count; i++) {
-    List *list = VectorValue(ctx.lists, List *, i);
-    $(list, removeAll);
-    release(list);
+    release(VectorValue(ctx.lists, List *, i));
   }
 
   release(ctx.lists);
-  release(cmd_state.commands);
-  cmd_state.commands = NULL;
+
+  cmd_state.commands = release(cmd_state.commands);
 }
 
 /*

--- a/src/common/cmd.c
+++ b/src/common/cmd.c
@@ -306,7 +306,7 @@ static void Cmd_Enumerate_collect(const HashTable *table, ident key, ident value
   Cmd_Enumerate_ctx_t *ctx = data;
   const List *list = value;
   for (const ListNode *node = list->head; node; node = node->next) {
-    $(ctx->cmds, addPointer, node->element);
+    $(ctx->cmds, add, node->element);
   }
 }
 
@@ -322,7 +322,7 @@ void Cmd_Enumerate(Cmd_Enumerator func, void *data) {
   $(ctx.cmds, sort, Cmd_Enumerate_comparator);
 
   for (size_t i = 0; i < ctx.cmds->count; i++) {
-    func((cmd_t *) $(ctx.cmds, pointerAtIndex, i), data);
+    func((cmd_t *) $(ctx.cmds, get, i), data);
   }
 
   release(ctx.cmds);
@@ -364,7 +364,7 @@ cmd_t *Cmd_Add(const char *name, CmdExecuteFunc function, uint32_t flags,
     $(cmd_state.commands, set, key, list);
   }
 
-  $(list, prependElement, cmd);
+  $(list, prepend, cmd);
   return cmd;
 }
 
@@ -405,7 +405,7 @@ static cmd_t *Cmd_Alias(const char *name, const char *commands) {
     $(cmd_state.commands, set, key, list);
   }
 
-  $(list, prependElement, cmd);
+  $(list, prepend, cmd);
   return cmd;
 }
 
@@ -460,7 +460,7 @@ static void Cmd_RemoveAll_collect(const HashTable *table, ident key, ident value
   for (const ListNode *node = list->head; node; node = node->next) {
     cmd_t *cmd = node->element;
     if (cmd->flags & ctx->flags) {
-      $(ctx->cmds, appendElement, cmd);
+      $(ctx->cmds, append, cmd);
     }
   }
 }
@@ -627,7 +627,7 @@ typedef struct {
 
 static void Cmd_List_f_enumerate(cmd_t *cmd, void *data) {
   Cmd_List_ctx_t *ctx = data;
-  $(ctx->strs, addPointer, q_strdup(Cmd_Stringify(cmd)));
+  $(ctx->strs, add, q_strdup(Cmd_Stringify(cmd)));
 }
 
 static Order Cmd_List_sortfn(const ident a, const ident b) {
@@ -647,7 +647,7 @@ static void Cmd_List_f(void) {
   $(ctx.strs, sort, Cmd_List_sortfn);
 
   for (size_t i = 0; i < ctx.strs->count; i++) {
-    Com_Print("%s\n", (char *) $(ctx.strs, pointerAtIndex, i));
+    Com_Print("%s\n", (char *) $(ctx.strs, get, i));
   }
 
   release(ctx.strs);
@@ -714,7 +714,7 @@ typedef struct {
 } Cmd_Shutdown_ctx_t;
 
 static void Cmd_Shutdown_collect(const HashTable *table, ident key, ident value, ident data) {
-  $(((PointerArray *) data), addPointer, value);
+  $(((PointerArray *) data), add, value);
 }
 
 /**
@@ -773,7 +773,7 @@ void Cmd_Shutdown(void) {
   $(cmd_state.commands, enumerate, Cmd_Shutdown_collect, ctx.lists);
 
   for (size_t i = 0; i < ctx.lists->count; i++) {
-    release((List *) $(ctx.lists, pointerAtIndex, i));
+    release((List *) $(ctx.lists, get, i));
   }
 
   release(ctx.lists);

--- a/src/common/console.c
+++ b/src/common/console.c
@@ -686,7 +686,7 @@ bool Con_CompleteInput(console_t *console) {
   // print matches
   Con_PrintMatches(console, matches);
 
-  matches->destroy = (ListDestroyFunc) Mem_Free;
+  matches->destroy = Mem_Free;
   release(matches);
 
   return true;
@@ -762,7 +762,7 @@ void Con_Init(void) {
   memset(&console_state, 0, sizeof(console_state));
 
   console_state.strings = $(alloc(List), init);
-  console_state.strings->destroy = (ListDestroyFunc) Con_FreeString;
+  console_state.strings->destroy = (Consumer) Con_FreeString;
 
   console_state.consoles = $(alloc(List), init);
 
@@ -782,11 +782,8 @@ void Con_Shutdown(void) {
 
   Con_FreeStrings();
 
-  release(console_state.strings);
-  console_state.strings = NULL;
-
-  release(console_state.consoles);
-  console_state.consoles = NULL;
+  console_state.strings = release(console_state.strings);
+  console_state.consoles = release(console_state.consoles);
 
   SDL_DestroyMutex(console_state.lock);
   console_state.lock = NULL;

--- a/src/common/console.c
+++ b/src/common/console.c
@@ -164,7 +164,7 @@ void Con_Append(int32_t level, const char *string) {
 
   SDL_LockMutex(console_state.lock);
 
-  $(console_state.strings, appendElement, str);
+  $(console_state.strings, append, str);
   console_state.size += str->size;
 
   while (console_state.size > CON_MAX_SIZE) {
@@ -432,7 +432,7 @@ void Con_AutocompleteMatch(List *matches, const char *name, const char *descript
     }
   }
 
-  $(matches, insertElementAfter, insert_after, match);
+  $(matches, insertAfter, insert_after, match);
 }
 
 /**
@@ -733,7 +733,7 @@ void Con_AddConsole(const console_t *console) {
 
   SDL_LockMutex(console_state.lock);
 
-  $(console_state.consoles, appendElement, (void *) console);
+  $(console_state.consoles, append, (void *) console);
 
   SDL_UnlockMutex(console_state.lock);
 }

--- a/src/common/cvar.c
+++ b/src/common/cvar.c
@@ -286,7 +286,7 @@ cvar_t *Cvar_Add(const char *name, const char *value, uint32_t flags, const char
 
   if (!list) {
     list = $(alloc(List), init);
-    list->destroy = (ListDestroyFunc) Mem_Free;
+    list->destroy = Mem_Free;
     $(cvar_vars, set, key, list);
   }
 
@@ -753,6 +753,7 @@ static void Cvar_Shutdown_collect(const HashTable *table, ident key, ident value
  * @brief Frees all cvar lists in the hash table.
  */
 static void Cvar_FreeAll(void) {
+
   Cvar_Shutdown_ctx_t ctx = {
     .lists = $(alloc(Vector), initWithSize, sizeof(ident)),
   };
@@ -760,9 +761,7 @@ static void Cvar_FreeAll(void) {
   $(cvar_vars, enumerate, Cvar_Shutdown_collect, ctx.lists);
 
   for (size_t i = 0; i < ctx.lists->count; i++) {
-    List *list = VectorValue(ctx.lists, List *, i);
-    $(list, removeAll);
-    release(list);
+    release(VectorValue(ctx.lists, List *, i));
   }
 
   release(ctx.lists);

--- a/src/common/cvar.c
+++ b/src/common/cvar.c
@@ -179,7 +179,7 @@ static void Cvar_Enumerate_collect(const HashTable *table, ident key, ident valu
   Cvar_Enumerate_ctx_t *ctx = data;
   const List *list = value;
   for (const ListNode *node = list->head; node; node = node->next) {
-    $(ctx->vars, addPointer, node->element);
+    $(ctx->vars, add, node->element);
   }
 }
 
@@ -195,7 +195,7 @@ void Cvar_Enumerate(Cvar_Enumerator func, void *data) {
   $(ctx.vars, sort, Cvar_Enumerate_comparator);
 
   for (size_t i = 0; i < ctx.vars->count; i++) {
-    func((cvar_t *) $(ctx.vars, pointerAtIndex, i), data);
+    func((cvar_t *) $(ctx.vars, get, i), data);
   }
 
   release(ctx.vars);
@@ -288,7 +288,7 @@ cvar_t *Cvar_Add(const char *name, const char *value, uint32_t flags, const char
     $(cvar_vars, set, key, list);
   }
 
-  $(list, prependElement, var);
+  $(list, prepend, var);
   return var;
 }
 
@@ -644,7 +644,7 @@ typedef struct {
 
 static void Cvar_List_f_enumerate(cvar_t *var, void *data) {
   Cvar_List_ctx_t *ctx = data;
-  $(ctx->strs, addPointer, q_strdup(Cvar_Stringify(var)));
+  $(ctx->strs, add, q_strdup(Cvar_Stringify(var)));
 }
 
 static Order Cvar_List_sortfn(const ident a, const ident b) {
@@ -664,7 +664,7 @@ static void Cvar_List_f(void) {
   $(ctx.strs, sort, Cvar_List_sortfn);
 
   for (size_t i = 0; i < ctx.strs->count; i++) {
-    Com_Print("%s\n", (char *) $(ctx.strs, pointerAtIndex, i));
+    Com_Print("%s\n", (char *) $(ctx.strs, get, i));
   }
 
   release(ctx.strs);
@@ -740,7 +740,7 @@ typedef struct {
 } Cvar_Shutdown_ctx_t;
 
 static void Cvar_Shutdown_collect(const HashTable *table, ident key, ident value, ident data) {
-  $(((PointerArray *) data), addPointer, value);
+  $(((PointerArray *) data), add, value);
 }
 
 /**
@@ -755,7 +755,7 @@ static void Cvar_FreeAll(void) {
   $(cvar_vars, enumerate, Cvar_Shutdown_collect, ctx.lists);
 
   for (size_t i = 0; i < ctx.lists->count; i++) {
-    release((List *) $(ctx.lists, pointerAtIndex, i));
+    release((List *) $(ctx.lists, get, i));
   }
 
   release(ctx.lists);

--- a/src/common/cvar.c
+++ b/src/common/cvar.c
@@ -20,7 +20,7 @@
  */
 
 #include <Objectively/HashTable.h>
-#include <Objectively/Vector.h>
+#include <Objectively/PointerArray.h>
 
 #include "console.h"
 #include "filesystem.h"
@@ -167,20 +167,19 @@ static const char *Cvar_Stringify(const cvar_t *var) {
 }
 
 static Order Cvar_Enumerate_comparator(const ident a, const ident b) {
-  const int32_t cmp = q_strcasecmp((*(const cvar_t *const *) a)->name, (*(const cvar_t *const *) b)->name);
+  const int32_t cmp = q_strcasecmp(((const cvar_t *) a)->name, ((const cvar_t *) b)->name);
   return cmp < 0 ? OrderAscending : cmp > 0 ? OrderDescending : OrderSame;
 }
 
 typedef struct {
-  Vector *vars;
+  PointerArray *vars;
 } Cvar_Enumerate_ctx_t;
 
 static void Cvar_Enumerate_collect(const HashTable *table, ident key, ident value, ident data) {
   Cvar_Enumerate_ctx_t *ctx = data;
   const List *list = value;
   for (const ListNode *node = list->head; node; node = node->next) {
-    cvar_t *var = node->element;
-    $(ctx->vars, addElement, &var);
+    $(ctx->vars, addPointer, node->element);
   }
 }
 
@@ -189,15 +188,14 @@ static void Cvar_Enumerate_collect(const HashTable *table, ident key, ident valu
  */
 void Cvar_Enumerate(Cvar_Enumerator func, void *data) {
   Cvar_Enumerate_ctx_t ctx = {
-    .vars = $(alloc(Vector), initWithSize, sizeof(cvar_t *)),
+    .vars = $(alloc(PointerArray), init),
   };
 
   $(cvar_vars, enumerate, Cvar_Enumerate_collect, &ctx);
   $(ctx.vars, sort, Cvar_Enumerate_comparator);
 
   for (size_t i = 0; i < ctx.vars->count; i++) {
-    cvar_t *var = VectorValue(ctx.vars, cvar_t *, i);
-    func(var, data);
+    func((cvar_t *) $(ctx.vars, pointerAtIndex, i), data);
   }
 
   release(ctx.vars);
@@ -641,17 +639,16 @@ static void Cvar_Toggle_f(void) {
 }
 
 typedef struct {
-  Vector *strs;
+  PointerArray *strs;
 } Cvar_List_ctx_t;
 
 static void Cvar_List_f_enumerate(cvar_t *var, void *data) {
   Cvar_List_ctx_t *ctx = data;
-  char *str = q_strdup(Cvar_Stringify(var));
-  $(ctx->strs, addElement, &str);
+  $(ctx->strs, addPointer, q_strdup(Cvar_Stringify(var)));
 }
 
 static Order Cvar_List_sortfn(const ident a, const ident b) {
-  const int32_t cmp = q_strcolorcmp(*(const char *const *) a, *(const char *const *) b);
+  const int32_t cmp = q_strcolorcmp((const char *) a, (const char *) b);
   return cmp < 0 ? OrderAscending : cmp > 0 ? OrderDescending : OrderSame;
 }
 
@@ -660,16 +657,14 @@ static Order Cvar_List_sortfn(const ident a, const ident b) {
  */
 static void Cvar_List_f(void) {
   Cvar_List_ctx_t ctx = {
-    .strs = $(alloc(Vector), initWithSize, sizeof(char *)),
+    .strs = $(alloc(PointerArray), initWithDestroy, free),
   };
 
   Cvar_Enumerate(Cvar_List_f_enumerate, &ctx);
   $(ctx.strs, sort, Cvar_List_sortfn);
 
   for (size_t i = 0; i < ctx.strs->count; i++) {
-    char *str = VectorValue(ctx.strs, char *, i);
-    Com_Print("%s\n", str);
-    free(str);
+    Com_Print("%s\n", (char *) $(ctx.strs, pointerAtIndex, i));
   }
 
   release(ctx.strs);
@@ -741,12 +736,11 @@ void Cvar_WriteAll(file_t *f) {
 }
 
 typedef struct {
-  Vector *lists;
+  PointerArray *lists;
 } Cvar_Shutdown_ctx_t;
 
 static void Cvar_Shutdown_collect(const HashTable *table, ident key, ident value, ident data) {
-  Vector *lists = data;
-  $(lists, addElement, &value);
+  $(((PointerArray *) data), addPointer, value);
 }
 
 /**
@@ -755,13 +749,13 @@ static void Cvar_Shutdown_collect(const HashTable *table, ident key, ident value
 static void Cvar_FreeAll(void) {
 
   Cvar_Shutdown_ctx_t ctx = {
-    .lists = $(alloc(Vector), initWithSize, sizeof(ident)),
+    .lists = $(alloc(PointerArray), init),
   };
 
   $(cvar_vars, enumerate, Cvar_Shutdown_collect, ctx.lists);
 
   for (size_t i = 0; i < ctx.lists->count; i++) {
-    release(VectorValue(ctx.lists, List *, i));
+    release((List *) $(ctx.lists, pointerAtIndex, i));
   }
 
   release(ctx.lists);

--- a/src/common/filesystem.c
+++ b/src/common/filesystem.c
@@ -347,7 +347,7 @@ int64_t Fs_Load(const char *filename, void **buffer) {
           Com_Error(ERROR_DROP, "%s: %s\n", filename, Fs_LastError());
         }
 
-        $(list, appendElement, chunk);
+        $(list, append, chunk);
         len += chunk->len;
       }
 

--- a/src/common/filesystem.c
+++ b/src/common/filesystem.c
@@ -329,7 +329,7 @@ int64_t Fs_Load(const char *filename, void **buffer) {
     } else {
 
       List *list = $(alloc(List), init);
-      list->destroy = (ListDestroyFunc) Mem_Free;
+      list->destroy = Mem_Free;
       len = 0;
 
       typedef struct {
@@ -820,7 +820,7 @@ void Fs_Init(const uint32_t flags) {
   fs_state.base_search_paths = PHYSFS_getSearchPath();
 
   fs_state.loaded_files = $(alloc(HashTable), init, HashTableHashDirect, HashTableEqualDirect);
-  fs_state.loaded_files->destroyValue = (HashTableDestroyFunc) Mem_Free;
+  fs_state.loaded_files->destroyValue = Mem_Free;
 }
 
 /**

--- a/src/common/installer.c
+++ b/src/common/installer.c
@@ -405,7 +405,7 @@ void Installer_Init(Installer_FrameFunction frame) {
 #endif
 
   memset(&installer, 0, sizeof(installer));
-  installer.status.state = INSTALLER_COMPARING;
+  installer.status.state = INSTALLER_CHECKING;
 
   installer.mutex = SDL_CreateMutex();
   assert(installer.mutex);

--- a/src/common/mem.c
+++ b/src/common/mem.c
@@ -469,7 +469,7 @@ Vector *Mem_Stats(void) {
   Vector *stat_array = $(alloc(Vector), initWithSize, sizeof(mem_stat_t));
 
   mem_stat_t total = { .tag = -1, .size = mem_state.size, .count = 0 };
-  $(stat_array, addElement, &total);
+  $(stat_array, add, &total);
 
   for (const mem_block_t *b = mem_state.head; b; b = b->next_block) {
     mem_stat_t *stats = NULL;
@@ -488,7 +488,7 @@ Vector *Mem_Stats(void) {
         .size = Mem_CalculateBlockSize(b),
         .count = 1
       };
-      $(stat_array, addElement, &entry);
+      $(stat_array, add, &entry);
     } else {
       stats->size += Mem_CalculateBlockSize(b);
       stats->count++;

--- a/src/game/default/g_ai_main.c
+++ b/src/game/default/g_ai_main.c
@@ -319,7 +319,7 @@ static uint32_t G_Ai_FindItems(g_client_t *cl, pm_cmd_t *cmd) {
       weight *= 3.f;
     }
 
-    $(items_visible, addElement, &(ai_item_pick_t) {
+    $(items_visible, add, &(ai_item_pick_t) {
       .entity = ent,
       .item = item,
       .weight = weight
@@ -1635,7 +1635,7 @@ static uint32_t G_Ai_LongRange(g_client_t *cl, pm_cmd_t *cmd) {
     weight = Randomf() * weight;
 
     // add!!
-    $(goal_possibilities, addElement, &(ai_item_pick_t) {
+    $(goal_possibilities, add, &(ai_item_pick_t) {
       .weight = weight,
       .entity = ent
     });
@@ -1952,7 +1952,7 @@ static void G_Ai_TestPath_f(void) {
 
       for (uint32_t i = 1; i < path->count; i++) {
         ai_node_id_t node = VectorValue(path, ai_node_id_t, i);
-        $(path_to_start, addElement, &node);
+        $(path_to_start, add, &node);
       }
       G_Ai_SetPathGoal(cl, &cl->ai->move_target, 1.0, path_to_start, NULL);
       release(path_to_start);

--- a/src/game/default/g_ai_node.c
+++ b/src/game/default/g_ai_node.c
@@ -30,17 +30,17 @@
 /**
  * @brief Cached spatial acceleration structures for the navigation graph.
  *
- * The kd-tree accelerates G_Ai_Node_FindClosest queries (O(log n) average vs.
+ * The kd-tree accelerates `G_Ai_Node_FindClosest` queries (O(log n) average vs.
  * the previous O(n) linear scan), and is rebuilt lazily after any mutation
  * of the global node array.
  */
 static struct gridkdtree_s *g_ai_nodes_kdtree = NULL;
 static vec3_t *g_ai_nodes_kdtree_positions = NULL;
-static uint32_t g_ai_nodes_kdtree_count = 0;
+static size_t g_ai_nodes_kdtree_count = 0;
 
 /**
  * @brief Invalidates the cached kd-tree. Must be called whenever the
- * underlying g_ai_nodes array is mutated (add/remove/move/reload).
+ * underlying `g_ai_nodes` array is mutated (add/remove/move/reload).
  */
 static void G_Ai_Node_InvalidateSpatialIndex(void) {
   if (g_ai_nodes_kdtree) {
@@ -142,7 +142,6 @@ static bool G_Ai_Node_Visible(const vec3_t position, const ai_node_id_t node) {
  * @brief Returns the total number of navigation nodes currently loaded.
  */
 uint32_t G_Ai_Node_Count(void) {
-
   return g_ai_nodes ? (uint32_t) g_ai_nodes->count : 0;
 }
 
@@ -163,13 +162,13 @@ static bool G_Ai_Node_EnsureSpatialIndex(void) {
 
   G_Ai_Node_InvalidateSpatialIndex();
 
-  const uint32_t n = (uint32_t) g_ai_nodes->count;
+  const size_t n = g_ai_nodes->count;
   g_ai_nodes_kdtree_positions = malloc(sizeof(vec3_t) * n);
   if (!g_ai_nodes_kdtree_positions) {
     return false;
   }
 
-  for (uint32_t i = 0; i < n; i++) {
+  for (size_t i = 0; i < n; i++) {
     g_ai_nodes_kdtree_positions[i] = AI_NODE(g_ai_nodes, i)->position;
   }
 
@@ -236,7 +235,7 @@ ai_node_id_t G_Ai_Node_FindClosest(const vec3_t position, const float max_distan
   }
 
   // Fallback: linear scan (kd-tree build failed).
-  for (uint32_t i = 0; i < g_ai_nodes->count; i++) {
+  for (size_t i = 0; i < g_ai_nodes->count; i++) {
     const ai_node_t *node = AI_NODE(g_ai_nodes, i);
 
     vec3_t dir = Vec3_Subtract(position, node->position);
@@ -245,7 +244,9 @@ ai_node_id_t G_Ai_Node_FindClosest(const vec3_t position, const float max_distan
     }
     const float dist = Vec3_LengthSquared(dir);
 
-    if (dist < dist_squared && (closest == AI_NODE_INVALID || dist < closest_dist) && (!only_visible || G_Ai_Node_Visible(position, i))) {
+    if (dist < dist_squared
+        && (closest == AI_NODE_INVALID || dist < closest_dist)
+        && (!only_visible || G_Ai_Node_Visible(position, i))) {
       closest = i;
       closest_dist = dist;
     }
@@ -287,7 +288,7 @@ bool G_Ai_Node_IsLinked(const ai_node_id_t a, const ai_node_id_t b) {
   const ai_node_t *node_a = AI_NODE(g_ai_nodes, a);
 
   if (node_a->links) {
-    for (uint32_t i = 0; i < node_a->links->count; i++) {
+    for (size_t i = 0; i < node_a->links->count; i++) {
       const ai_link_t *link = AI_LINK(node_a->links, i);
 
       if (link->id == b) {
@@ -359,7 +360,7 @@ static void G_Ai_Node_Unlink(const ai_node_id_t a, const ai_node_id_t b) {
     ai_node_t *node_a = AI_NODE(g_ai_nodes, a);
 
     if (node_a->links) {
-      for (uint32_t i = 0; i < node_a->links->count; i++) {
+      for (size_t i = 0; i < node_a->links->count; i++) {
         const ai_link_t *link = AI_LINK(node_a->links, i);
 
         if (link->id == b) {
@@ -379,7 +380,7 @@ static void G_Ai_Node_Unlink(const ai_node_id_t a, const ai_node_id_t b) {
     ai_node_t *node_b = AI_NODE(g_ai_nodes, b);
   
     if (node_b->links) {
-      for (uint32_t i = 0; i < node_b->links->count; i++) {
+      for (size_t i = 0; i < node_b->links->count; i++) {
         const ai_link_t *link = AI_LINK(node_b->links, i);
 
         if (link->id == a) {
@@ -406,7 +407,7 @@ static void G_Ai_Node_UnlinkAll(const ai_node_id_t id) {
     return;
   }
 
-  for (uint32_t i = node->links->count - 1; ; i--) {
+  for (size_t i = node->links->count - 1; ; i--) {
     G_Ai_Node_Unlink(id, AI_LINK(node->links, i)->id);
     
     if (i == 0 || !node->links) {
@@ -421,14 +422,14 @@ static void G_Ai_Node_UnlinkAll(const ai_node_id_t id) {
 */
 static void G_Ai_Node_Adjust(const ai_node_id_t id) {
 
-  for (uint32_t i = 0; i < g_ai_nodes->count; i++) {
+  for (size_t i = 0; i < g_ai_nodes->count; i++) {
     const ai_node_t *node = AI_NODE(g_ai_nodes, i);
 
     if (!node->links) {
       continue;
     }
 
-    for (uint32_t l = 0; l < node->links->count; l++) {
+    for (size_t l = 0; l < node->links->count; l++) {
       ai_link_t *link = AI_LINK(node->links, l);
 
       if (link->id >= id) {
@@ -487,14 +488,14 @@ vec3_t G_Ai_Node_GetPosition(const ai_node_id_t node) {
  */
 static void G_Ai_Node_UpdateCosts(const ai_node_id_t id) {
 
-  for (uint32_t i = 0; i < g_ai_nodes->count; i++) {
+  for (size_t i = 0; i < g_ai_nodes->count; i++) {
     const ai_node_t *node = AI_NODE(g_ai_nodes, i);
 
     if (!node->links || !node->links->count) {
       continue;
     }
 
-    for (uint32_t l = 0; l < node->links->count; l++) {
+    for (size_t l = 0; l < node->links->count; l++) {
       ai_link_t *link = AI_LINK(node->links, l);
 
       if (id == i || link->id == id) {
@@ -915,7 +916,7 @@ static bool G_Ai_NodeInPath(Vector *path, ai_node_id_t node) {
     return false;
   }
 
-  for (uint32_t i = 0; i < path->count; i++) {
+  for (size_t i = 0; i < path->count; i++) {
     if (AI_NODE_ID(path, i) == node) {
       return true;
     }
@@ -984,7 +985,7 @@ void G_Ai_Node_Render(void) {
 
     if (node->links) {
 
-      for (uint32_t l = 0; l < node->links->count; l++) {
+      for (size_t l = 0; l < node->links->count; l++) {
         const ai_link_t *link = AI_LINK(node->links, l);
         ai_unique_link_t ulink;
         int32_t bit;
@@ -1029,7 +1030,7 @@ void G_Ai_Node_Render(void) {
     }
   }
 
-  for (uint32_t i = 0; i < unique_links->count; i++) {
+  for (size_t i = 0; i < unique_links->count; i++) {
     const ai_render_link_t *render_link = VectorElement(unique_links, ai_render_link_t, i);
     G_Ai_Node_RenderLink(render_link->link, render_link->bits);
   }
@@ -1104,16 +1105,16 @@ void G_Ai_InitNodes(void) {
 
   g_ai_nodes = $(alloc(Vector), initWithSize, sizeof(ai_node_t));
 
-  for (uint32_t i = 0; i < num_nodes; i++) {
+  for (size_t i = 0; i < num_nodes; i++) {
     ai_node_t node = { 0 };
     $(g_ai_nodes, addElement, &node);
   }
 
   G_Ai_Node_InvalidateSpatialIndex();
 
-  uint32_t total_links = 0;
+  size_t total_links = 0;
 
-  for (uint32_t i = 0; i < g_ai_nodes->count; i++) {
+  for (size_t i = 0; i < g_ai_nodes->count; i++) {
     ai_node_t *node = AI_NODE(g_ai_nodes, i);
 
     gi.ReadFile(file, &node->position, sizeof(node->position), 1);
@@ -1125,7 +1126,7 @@ void G_Ai_InitNodes(void) {
     if (num_links) {
       node->links = $(alloc(Vector), initWithSize, sizeof(ai_link_t));
 
-      for (uint32_t l = 0; l < num_links; l++) {
+      for (size_t l = 0; l < num_links; l++) {
         ai_link_t link = { 0 };
         $(node->links, addElement, &link);
       }
@@ -1140,12 +1141,12 @@ void G_Ai_InitNodes(void) {
   }
 
   gi.CloseFile(file);
-  gi.Print("  Loaded %u nodes with %u total links.\n", num_nodes, total_links);
+  gi.Print("  Loaded %u nodes with %zu total links.\n", num_nodes, total_links);
 
   g_ai_player_roam.file_nodes = num_nodes;
   g_ai_player_roam.file_links = 0;
 
-  for (uint32_t i = 0; i < g_ai_nodes->count; i++) {
+  for (size_t i = 0; i < g_ai_nodes->count; i++) {
     const ai_node_t *node = AI_NODE(g_ai_nodes, i);
 
     if (node->links) {
@@ -1175,11 +1176,11 @@ static void G_Ai_CheckNodes(void) {
     });
   }
 
-  for (uint32_t i = 0; i < g_ai_nodes->count; i++) {
+  for (size_t i = 0; i < g_ai_nodes->count; i++) {
     const ai_node_t *node = AI_NODE(g_ai_nodes, i);
     
     if (gi.PointContents(node->position) & CONTENTS_MASK_SOLID) {
-      gi.Warn("Node %i @ %s is inside of solid\n", i, vtos(node->position));
+      gi.Warn("Node %zu @ %s is inside of solid\n", i, vtos(node->position));
     }
   }
 }
@@ -1194,10 +1195,10 @@ void G_Ai_NodesReady(void) {
     return;
   }
 
-  const uint32_t added_nodes = (uint32_t) g_ai_nodes->count - g_ai_player_roam.file_nodes;
-  uint32_t added_links = 0;
+  const size_t added_nodes = g_ai_nodes->count - g_ai_player_roam.file_nodes;
+  size_t added_links = 0;
 
-  for (uint32_t i = 0; i < g_ai_nodes->count; i++) {
+  for (size_t i = 0; i < g_ai_nodes->count; i++) {
     const ai_node_t *node = AI_NODE(g_ai_nodes, i);
 
     if (node->links) {
@@ -1206,7 +1207,7 @@ void G_Ai_NodesReady(void) {
   }
 
   added_links -= g_ai_player_roam.file_links;
-  gi.Print("  Game loaded %u additional nodes with %u new links.\n", added_nodes, added_links);
+  gi.Print("  Game loaded %u additional nodes with %zu new links.\n", added_nodes, added_links);
 
   G_ForEachEntity(ent, {
     if (ent->classname && q_strcmp(ent->classname, "func_plat") == 0) {
@@ -1254,7 +1255,7 @@ void G_Ai_SaveNodes(void) {
   const uint32_t num_nodes = (uint32_t) g_ai_nodes->count;
   gi.WriteFile(file, &num_nodes, sizeof(num_nodes), 1);
 
-  for (uint32_t i = 0; i < g_ai_nodes->count; i++) {
+  for (size_t i = 0; i < g_ai_nodes->count; i++) {
     const ai_node_t *node = AI_NODE(g_ai_nodes, i);
 
     gi.WriteFile(file, &node->position, sizeof(node->position), 1);
@@ -1293,10 +1294,7 @@ void G_Ai_DeleteNodes(void) {
     $(g_ai_nodes, removeAllElements);
   }
 
-  if (g_ai_platforms) {
-    release(g_ai_platforms);
-    g_ai_platforms = NULL;
-  }
+  g_ai_platforms = release(g_ai_platforms);
 
   G_Ai_Node_InvalidateSpatialIndex();
   G_Ai_Node_FreePathPool();
@@ -1308,7 +1306,7 @@ void G_Ai_DeleteNodes(void) {
 void G_Ai_ShutdownNodes(void) {
 
   if (g_ai_nodes) {
-    for (uint32_t i = 0; i < g_ai_nodes->count; i++) {
+    for (size_t i = 0; i < g_ai_nodes->count; i++) {
       ai_node_t *node = AI_NODE(g_ai_nodes, i);
 
       if (node->links) {
@@ -1316,14 +1314,10 @@ void G_Ai_ShutdownNodes(void) {
       }
     }
 
-    release(g_ai_nodes);
-    g_ai_nodes = NULL;
+    g_ai_nodes = release(g_ai_nodes);
   }
 
-  if (g_ai_platforms) {
-    release(g_ai_platforms);
-    g_ai_platforms = NULL;
-  }
+  g_ai_platforms = release(g_ai_platforms);
 
   G_Ai_Node_InvalidateSpatialIndex();
   G_Ai_Node_FreePathPool();
@@ -1526,7 +1520,7 @@ Vector *G_Ai_Node_FindPath(const g_client_t *cl, const ai_node_id_t start, const
     const int32_t node_contents = gi.PointContents(node->position);
     const bool from_hazard = (node_contents & (CONTENTS_LAVA | CONTENTS_SLIME)) != 0;
 
-    for (uint32_t i = 0; i < node->links->count; i++) {
+    for (size_t i = 0; i < node->links->count; i++) {
       const ai_link_t *link = AI_LINK(node->links, i);
       ai_node_t *link_node = AI_NODE(g_ai_nodes, link->id);
       const float drop = node->position.z - link_node->position.z;
@@ -1536,7 +1530,7 @@ Vector *G_Ai_Node_FindPath(const g_client_t *cl, const ai_node_id_t start, const
       // Check platform accessibility using the pre-collected list.
       if (g_ai_platforms) {
         bool blocked = false;
-        for (uint32_t p = 0; p < g_ai_platforms->count; p++) {
+        for (size_t p = 0; p < g_ai_platforms->count; p++) {
           const g_entity_t *plat = AI_PLATFORM(g_ai_platforms, p);
           if (link_node->position.x < plat->abs_bounds.mins.x || link_node->position.x > plat->abs_bounds.maxs.x ||
               link_node->position.y < plat->abs_bounds.mins.y || link_node->position.y > plat->abs_bounds.maxs.y) {
@@ -1641,7 +1635,7 @@ Vector *G_Ai_Node_FindPath(const g_client_t *cl, const ai_node_id_t start, const
       }
 
       if (length) {
-        for (uint32_t i = 0; i < return_path->count - 1; i++) {
+        for (size_t i = 0; i < return_path->count - 1; i++) {
           const ai_node_id_t a = AI_NODE_ID(return_path, i);
           const ai_node_id_t b = AI_NODE_ID(return_path, i + 1);
 
@@ -1726,7 +1720,7 @@ bool G_Ai_DropItemLikeNode(g_entity_t *ent) {
   // to the item as well
   if (src_links) {
 
-    for (uint32_t i = 0; i < src_links->count; i++) {
+    for (size_t i = 0; i < src_links->count; i++) {
       const ai_link_t *link = AI_LINK(src_links, i);
 
       // not bidirectional

--- a/src/game/default/g_ai_node.c
+++ b/src/game/default/g_ai_node.c
@@ -272,7 +272,7 @@ ai_node_id_t G_Ai_Node_Create(const vec3_t position) {
   ai_node_t node = (ai_node_t) {
     .position = position
   };
-  $(g_ai_nodes, addElement, &node);
+  $(g_ai_nodes, add, &node);
 
   G_Ai_Node_InvalidateSpatialIndex();
 
@@ -331,7 +331,7 @@ void G_Ai_Node_Link(const ai_node_id_t a, const ai_node_id_t b, const float cost
     .id = b,
     .cost = cost
   };
-  $(node_a->links, addElement, &link);
+  $(node_a->links, add, &link);
 
   G_Ai_Debug("Connected %d -> %d\n", a, b);
 }
@@ -1024,7 +1024,7 @@ void G_Ai_Node_Render(void) {
             .link = ulink,
             .bits = bit
           };
-          $(unique_links, addElement, &render_link);
+          $(unique_links, add, &render_link);
         }
       }
     }
@@ -1107,7 +1107,7 @@ void G_Ai_InitNodes(void) {
 
   for (size_t i = 0; i < num_nodes; i++) {
     ai_node_t node = { 0 };
-    $(g_ai_nodes, addElement, &node);
+    $(g_ai_nodes, add, &node);
   }
 
   G_Ai_Node_InvalidateSpatialIndex();
@@ -1128,7 +1128,7 @@ void G_Ai_InitNodes(void) {
 
       for (size_t l = 0; l < num_links; l++) {
         ai_link_t link = { 0 };
-        $(node->links, addElement, &link);
+        $(node->links, add, &link);
       }
 
       gi.ReadFile(file, node->links->elements, sizeof(ai_link_t), num_links);
@@ -1214,7 +1214,7 @@ void G_Ai_NodesReady(void) {
       if (!g_ai_platforms) {
         g_ai_platforms = $(alloc(Vector), initWithSize, sizeof(g_entity_t *));
       }
-      $(g_ai_platforms, addElement, &ent);
+      $(g_ai_platforms, add, &ent);
     }
   });
 
@@ -1291,7 +1291,7 @@ void G_Ai_DeleteNodes(void) {
       }
     }
 
-    $(g_ai_nodes, removeAllElements);
+    $(g_ai_nodes, removeAll);
   }
 
   g_ai_platforms = release(g_ai_platforms);
@@ -1619,7 +1619,7 @@ Vector *G_Ai_Node_FindPath(const g_client_t *cl, const ai_node_id_t start, const
     G_Ai_Debug("Found path from %u -> %u with %u nodes visited\n", start, end, visited);
 
     return_path = $(alloc(Vector), initWithSize, sizeof(ai_node_id_t));
-    $(return_path, insertElementAtIndex, (void *) &end, 0);
+    $(return_path, insert, (void *) &end, 0);
 
     if (start != end) {
       ai_node_id_t from = end;
@@ -1627,7 +1627,7 @@ Vector *G_Ai_Node_FindPath(const g_client_t *cl, const ai_node_id_t start, const
       for (;;) {
         const ai_node_t *from_node = AI_NODE(g_ai_nodes, from);
         from = from_node->came_from;
-        $(return_path, insertElementAtIndex, &from, 0);
+        $(return_path, insert, &from, 0);
 
         if (from == start) {
           break;

--- a/src/game/default/g_ai_node.c
+++ b/src/game/default/g_ai_node.c
@@ -1207,7 +1207,7 @@ void G_Ai_NodesReady(void) {
   }
 
   added_links -= g_ai_player_roam.file_links;
-  gi.Print("  Game loaded %u additional nodes with %zu new links.\n", added_nodes, added_links);
+  gi.Print("  Game loaded %zu additional nodes with %zu new links.\n", added_nodes, added_links);
 
   G_ForEachEntity(ent, {
     if (ent->classname && q_strcmp(ent->classname, "func_plat") == 0) {

--- a/src/game/default/g_ai_node.c
+++ b/src/game/default/g_ai_node.c
@@ -364,7 +364,7 @@ static void G_Ai_Node_Unlink(const ai_node_id_t a, const ai_node_id_t b) {
         const ai_link_t *link = AI_LINK(node_a->links, i);
 
         if (link->id == b) {
-          $(node_a->links, removeElementAtIndex, i);
+          $(node_a->links, removeAt, i);
 
           if (!node_a->links->count) {
             release(node_a->links);
@@ -384,7 +384,7 @@ static void G_Ai_Node_Unlink(const ai_node_id_t a, const ai_node_id_t b) {
         const ai_link_t *link = AI_LINK(node_b->links, i);
 
         if (link->id == a) {
-          $(node_b->links, removeElementAtIndex, i);
+          $(node_b->links, removeAt, i);
 
           if (!node_b->links->count) {
             release(node_b->links);
@@ -450,7 +450,7 @@ void G_Ai_Node_Destroy(const ai_node_id_t id) {
   }
 
   G_Ai_Node_UnlinkAll(id);
-  $(g_ai_nodes, removeElementAtIndex, id);
+  $(g_ai_nodes, removeAt, id);
 
   G_Ai_Node_InvalidateSpatialIndex();
 

--- a/src/game/default/g_combat.c
+++ b/src/game/default/g_combat.c
@@ -454,7 +454,7 @@ void G_Damage(const g_damage_t *dmg) {
           q_strlcpy(frag.weapon, G_WeaponNameForMod(mod), sizeof(frag.weapon));
 
           if (frag.attacker_guid[0] && frag.target_guid[0]) {
-            $(g_level.frags, addElement, &frag);
+            $(g_level.frags, add, &frag);
           }
         }
       }

--- a/src/game/default/g_entity.c
+++ b/src/game/default/g_entity.c
@@ -500,7 +500,7 @@ static void G_CreateTeamSpawnPoints(Vector **dm_spawns, Vector **team_red_spawns
     Vector *_from = *from;
     g_entity_t *point = VectorValue(_from, g_entity_t *, 0);
 
-    $(*from, removeElementAtIndex, 0);
+    $(*from, removeAt, 0);
     if (!*to) { *to = $(alloc(Vector), initWithSize, sizeof(g_entity_t *)); }
     $(*to, add, &point);
 

--- a/src/game/default/g_entity.c
+++ b/src/game/default/g_entity.c
@@ -451,10 +451,10 @@ static void G_CreateTeamSpawnPoints(Vector **dm_spawns, Vector **team_red_spawns
 
     if (dist_to_red < dist_to_blue) {
       if (!*team_red_spawns) { *team_red_spawns = $(alloc(Vector), initWithSize, sizeof(g_entity_t *)); }
-      $(*team_red_spawns, addElement, &p);
+      $(*team_red_spawns, add, &p);
     } else {
       if (!*team_blue_spawns) { *team_blue_spawns = $(alloc(Vector), initWithSize, sizeof(g_entity_t *)); }
-      $(*team_blue_spawns, addElement, &p);
+      $(*team_blue_spawns, add, &p);
     }
   }
 
@@ -490,7 +490,7 @@ static void G_CreateTeamSpawnPoints(Vector **dm_spawns, Vector **team_red_spawns
     Vector *_from = *from;
     g_entity_t *point = VectorValue(_from, g_entity_t *, 0);
     if (!*to) { *to = $(alloc(Vector), initWithSize, sizeof(g_entity_t *)); }
-    $(*to, addElement, &point);
+    $(*to, add, &point);
   }
 
   int32_t num_move = diff - 1;
@@ -502,7 +502,7 @@ static void G_CreateTeamSpawnPoints(Vector **dm_spawns, Vector **team_red_spawns
 
     $(*from, removeElementAtIndex, 0);
     if (!*to) { *to = $(alloc(Vector), initWithSize, sizeof(g_entity_t *)); }
-    $(*to, addElement, &point);
+    $(*to, add, &point);
 
     num_move--;
   }
@@ -519,7 +519,7 @@ static void G_InitSpawnPoints(void) {
 
   while ((spot = G_Find(spot, EOFS(classname), "info_player_deathmatch")) != NULL) {
     if (!dm_spawns) { dm_spawns = $(alloc(Vector), initWithSize, sizeof(g_entity_t *)); }
-    $(dm_spawns, addElement, &spot);
+    $(dm_spawns, add, &spot);
   }
 
   if (!dm_spawns) {
@@ -527,7 +527,7 @@ static void G_InitSpawnPoints(void) {
 
     while ((spot = G_Find(spot, EOFS(classname), "info_player_start")) != NULL) {
       if (!dm_spawns) { dm_spawns = $(alloc(Vector), initWithSize, sizeof(g_entity_t *)); }
-      $(dm_spawns, addElement, &spot);
+      $(dm_spawns, add, &spot);
     }
   }
   
@@ -546,7 +546,7 @@ static void G_InitSpawnPoints(void) {
   while ((spot = G_Find(spot, EOFS(classname), "info_player_team_any")) != NULL) {
     for (int32_t t = 0; t < MAX_TEAMS; t++) {
       if (!team_spawns[t]) { team_spawns[t] = $(alloc(Vector), initWithSize, sizeof(g_entity_t *)); }
-      $(team_spawns[t], addElement, &spot);
+      $(team_spawns[t], add, &spot);
     }
   }
 
@@ -556,7 +556,7 @@ static void G_InitSpawnPoints(void) {
 
     while ((spot = G_Find(spot, EOFS(classname), team->spawn)) != NULL) {
       if (!team_spawns[t]) { team_spawns[t] = $(alloc(Vector), initWithSize, sizeof(g_entity_t *)); }
-      $(team_spawns[t], addElement, &spot);
+      $(team_spawns[t], add, &spot);
     }
 
     team->spawn_points.count = team_spawns[t] ? (int32_t) team_spawns[t]->count : 0;
@@ -571,7 +571,7 @@ static void G_InitSpawnPoints(void) {
       for (uint32_t i = 0; i < team_spawns[t]->count; i++) {
         g_entity_t *p = VectorValue(team_spawns[t], g_entity_t *, i);
         if (!dm_spawns) { dm_spawns = $(alloc(Vector), initWithSize, sizeof(g_entity_t *)); }
-        $(dm_spawns, addElement, &p);
+        $(dm_spawns, add, &p);
       }
     }
     
@@ -745,7 +745,7 @@ static void G_worldspawn_EnumerateMusic(const char *path, void *data) {
   if (q_strcmp(name, "gtdstudio-explore") == 0) {
     return;
   }
-  $(tracks, addElement, name);
+  $(tracks, add, name);
 }
 
 /**

--- a/src/game/default/g_item.c
+++ b/src/game/default/g_item.c
@@ -748,7 +748,7 @@ static bool G_PickupFlag(g_client_t *cl, g_entity_t *ent) {
           q_strlcpy(capture.team,        other_team->name,          sizeof(capture.team));
 
           if (capture.player_guid[0]) {
-            $(g_level.captures, addElement, &capture);
+            $(g_level.captures, add, &capture);
           }
         }
 

--- a/src/game/default/g_main.c
+++ b/src/game/default/g_main.c
@@ -479,11 +479,8 @@ static void G_PostStats(void) {
   gi.PostStats((g_frag_t *) g_level.frags->elements, (int32_t) g_level.frags->count,
                (g_capture_t *) g_level.captures->elements, (int32_t) g_level.captures->count);
 
-  release(g_level.frags);
-  g_level.frags = NULL;
-
-  release(g_level.captures);
-  g_level.captures = NULL;
+  g_level.frags = release(g_level.frags);
+  g_level.captures = release(g_level.captures);
 }
 
 /**

--- a/src/master/main.c
+++ b/src/master/main.c
@@ -351,7 +351,7 @@ static void Ms_AddServer(struct sockaddr_in *from) {
   if (!ms_servers) {
     ms_servers = $(alloc(List), init);
   }
-  $(ms_servers, appendElement, server);
+  $(ms_servers, append, server);
   Com_Print("Server %s registered\n", stos(server));
 
   // send an acknowledgment

--- a/src/quemap/face.c
+++ b/src/quemap/face.c
@@ -175,7 +175,7 @@ static void AddVertexToWeldingSpatialHash(const vec3_t v, const int32_t index) {
 
   if (!WeldingBucketContainsIndex(array, index)) {
     int32_t element = index;
-    $(array, addElement, &element);
+    $(array, add, &element);
   }
 }
 
@@ -410,7 +410,7 @@ static void BuildPhongMaps(const bsp_model_t *mod) {
         $(phong_vertex_faces, set, key_copy, arr);
       }
       const bsp_face_t *face = f;
-      $(arr, addElement, &face);
+      $(arr, add, &face);
     }
   }
 

--- a/src/quemap/face.c
+++ b/src/quemap/face.c
@@ -131,12 +131,12 @@ static bool WeldingSpatialHashEqualFunc(const ident a_, const ident b_) {
 void ClearWeldingSpatialHash(void) {
 
   if (welding_spatial_hash) {
-    release(welding_spatial_hash);
+    welding_spatial_hash = release(welding_spatial_hash);
   }
 
   welding_spatial_hash = $(alloc(HashTable), init, WeldingSpatialHashFunc, WeldingSpatialHashEqualFunc);
-  welding_spatial_hash->destroyKey = (HashTableDestroyFunc) Mem_Free;
-  welding_spatial_hash->destroyValue = (HashTableDestroyFunc) WeldingSpatialHashValueDestroyFunc;
+  welding_spatial_hash->destroyKey = Mem_Free;
+  welding_spatial_hash->destroyValue = WeldingSpatialHashValueDestroyFunc;
 }
 
 /**
@@ -391,7 +391,7 @@ static void ReleaseObject(ident object) {
 static void BuildPhongMaps(const bsp_model_t *mod) {
 
   phong_vertex_faces = $(alloc(HashTable), init, WeldingSpatialHashFunc, WeldingSpatialHashEqualFunc);
-  phong_vertex_faces->destroyKey = (HashTableDestroyFunc) Mem_Free;
+  phong_vertex_faces->destroyKey = Mem_Free;
   phong_vertex_faces->destroyValue = ReleaseObject;
 
   const bsp_face_t *f = &bsp_file.faces[mod->first_face];
@@ -424,10 +424,8 @@ static void BuildPhongMaps(const bsp_model_t *mod) {
 }
 
 static void FreePhongMaps(void) {
-  release(phong_vertex_faces);
-  phong_vertex_faces = NULL;
-  release(phong_brush_side_windings);
-  phong_brush_side_windings = NULL;
+  phong_vertex_faces = release(phong_vertex_faces);
+  phong_brush_side_windings = release(phong_brush_side_windings);
 }
 
 /**

--- a/src/quemap/light.c
+++ b/src/quemap/light.c
@@ -163,8 +163,7 @@ void FreeLights(void) {
     FreeLight(VectorValue(lights, light_t *, i));
   }
 
-  release(lights);
-  lights = NULL;
+  lights = release(lights);
 }
 
 /**

--- a/src/quemap/light.c
+++ b/src/quemap/light.c
@@ -181,7 +181,7 @@ void BuildLights(void) {
   for (int32_t i = 0; i < Cm_Bsp()->num_entities; i++, entity++) {
     light_t *light = LightForEntity(*entity);
     if (light) {
-      $(lights, addElement, &light);
+      $(lights, add, &light);
     }
     Progress("Building lights", i * 100.f / Cm_Bsp()->num_entities);
   }

--- a/src/quemap/manifest.c
+++ b/src/quemap/manifest.c
@@ -47,7 +47,7 @@ static Order AssetPathCompare(const ident a, const ident b) {
 static void CollectAssetPath(const HashTable *table, ident key, ident value, ident data) {
 	Vector *asset_paths = data;
 	const char *path = value;
-	$(asset_paths, addElement, &path);
+	$(asset_paths, add, &path);
 }
 
 /**

--- a/src/quemap/manifest.c
+++ b/src/quemap/manifest.c
@@ -225,6 +225,7 @@ static void AddModel(const char *model) {
 static void AddEntities(void) {
 
 	List *entities = Cm_LoadEntities(bsp_file.entity_string);
+  entities->destroy = (Consumer) Cm_FreeEntity;
 
 	for (const ListNode *node = entities->head; node; node = node->next) {
 		const cm_entity_t *e = node->element;
@@ -242,8 +243,6 @@ static void AddEntities(void) {
 		}
 	}
 
-	entities->destroy = (ListDestroyFunc) Cm_FreeEntity;
-	$(entities, removeAll);
 	release(entities);
 }
 
@@ -295,8 +294,8 @@ int32_t WriteManifest(void) {
 	Com_Print("\nWriting manifest for %s\n\n", bsp_name);
 
 	paths = $(alloc(HashTable), init, HashTableHashStr, HashTableEqualStr);
-	paths->destroyKey = (HashTableDestroyFunc) free;
-	paths->destroyValue = (HashTableDestroyFunc) free;
+	paths->destroyKey = free;
+	paths->destroyValue = free;
 
 	LoadBSPFile(bsp_name, (1 << BSP_LUMP_MATERIALS) | (1 << BSP_LUMP_ENTITIES));
 

--- a/src/quemap/qzip.c
+++ b/src/quemap/qzip.c
@@ -64,7 +64,7 @@ int32_t ZIP_Main(void) {
 
   // the manifest includes the bsp and all referenced assets
   List *assets = $(alloc(List), init);
-  assets->destroy = (ListDestroyFunc) free;
+  assets->destroy = free;
 
   // include the manifest itself so the pk3 is self-contained
   $(assets, appendElement, q_strdup(mf_path));
@@ -138,7 +138,6 @@ int32_t ZIP_Main(void) {
           mz_zip_get_error_string(mz_zip_get_last_error(&zip)));
   }
 
-  $(assets, removeAll);
   release(assets);
 
   const uint32_t end = (uint32_t) SDL_GetTicks();

--- a/src/quemap/qzip.c
+++ b/src/quemap/qzip.c
@@ -38,7 +38,7 @@ static bool HasSuffix(const char *str, const char *suffix) {
 static void CollectManifestAsset(const HashTable *table, ident key, ident value, ident data) {
   List *assets = data;
   const cm_manifest_entry_t *entry = value;
-  $(assets, appendElement, q_strdup(entry->path));
+  $(assets, append, q_strdup(entry->path));
 }
 
 /**
@@ -67,7 +67,7 @@ int32_t ZIP_Main(void) {
   assets->destroy = free;
 
   // include the manifest itself so the pk3 is self-contained
-  $(assets, appendElement, q_strdup(mf_path));
+  $(assets, append, q_strdup(mf_path));
   $(manifest, enumerate, CollectManifestAsset, assets);
 
   Cm_FreeManifest(manifest);

--- a/src/quemap/tjunction.c
+++ b/src/quemap/tjunction.c
@@ -165,8 +165,7 @@ void FixTJunctions(tree_t *tree) {
   faces = $(alloc(Vector), initWithSize, sizeof(face_t *));
   faces_set = $(alloc(HashTable), init, HashTableHashDirect, HashTableEqualDirect);
   FixTJunctions_r(tree->head_node);
-  release(faces_set);
-  faces_set = NULL;
+  faces_set = release(faces_set);
 
   const int32_t largest_point_count = largest_winding;
   largest_winding = sizeof(cm_winding_t) + (sizeof(vec3_t) * largest_point_count);

--- a/src/quemap/tjunction.c
+++ b/src/quemap/tjunction.c
@@ -147,7 +147,7 @@ static void FixTJunctions_r(node_t *node) {
       continue;
     }
     
-    $(faces, addElement, &face);
+    $(faces, add, &face);
     $(faces_set, set, face, face);
 
     largest_winding = Maxi(largest_winding, face->w->num_points);

--- a/src/quemap/tree.c
+++ b/src/quemap/tree.c
@@ -258,7 +258,7 @@ static const brush_side_t *SelectSplitSide(node_t *node, csg_brush_t *brushes) {
       }
 
       intptr_t cached_plane = plane;
-      $(cache, addElement, &cached_plane);
+      $(cache, add, &cached_plane);
     }
   }
 

--- a/src/quemap/writebsp.c
+++ b/src/quemap/writebsp.c
@@ -635,7 +635,7 @@ static void EmitBlocks_r(bsp_model_t *mod, bsp_node_t *node) {
           Com_Verbose("Face %s @ %s resides in multiple blocks\n", material->name, vtos(Box3_Center(face->bounds)));
         }
         
-        $(faces, addElement, &face);
+        $(faces, add, &face);
       }
     }
 

--- a/src/server/sv_main.c
+++ b/src/server/sv_main.c
@@ -71,11 +71,7 @@ void Sv_DropClient(sv_client_t *client) {
   Mem_ClearBuffer(&client->net_chan.message);
   Mem_ClearBuffer(&client->datagram.buffer);
 
-  if (client->datagram.messages) {
-    $(client->datagram.messages, removeAll);
-    release(client->datagram.messages);
-    client->datagram.messages = NULL;
-  }
+  client->datagram.messages = release(client->datagram.messages);
 
   g_client_t *gclient = client->gclient;
   memset(client, 0, sizeof(*client));

--- a/src/server/sv_map_list.c
+++ b/src/server/sv_map_list.c
@@ -70,9 +70,9 @@ void Sv_InitMapList(void) {
   q_strlcpy(svs.maps.filename, sv_map_list->string, sizeof(svs.maps.filename));
 
   svs.maps.list = Cm_LoadEntities(buffer);
-  svs.maps.list->destroy = (Consumer) Cm_FreeEntity;
 
   List *valid = $(alloc(List), init);
+  valid->destroy = (Consumer) Cm_FreeEntity;
 
   int32_t i = 0;
   for (const ListNode *node = svs.maps.list->head; node; node = node->next, i++) {

--- a/src/server/sv_map_list.c
+++ b/src/server/sv_map_list.c
@@ -83,7 +83,7 @@ void Sv_InitMapList(void) {
       Com_Warn("Map list element %d in %s is missing \"name\"\n", i, sv_map_list->string);
       Cm_FreeEntity(props);
     } else {
-      $(valid, appendElement, props);
+      $(valid, append, props);
     }
   }
 

--- a/src/server/sv_map_list.c
+++ b/src/server/sv_map_list.c
@@ -70,6 +70,7 @@ void Sv_InitMapList(void) {
   q_strlcpy(svs.maps.filename, sv_map_list->string, sizeof(svs.maps.filename));
 
   svs.maps.list = Cm_LoadEntities(buffer);
+  svs.maps.list->destroy = (Consumer) Cm_FreeEntity;
 
   List *valid = $(alloc(List), init);
 
@@ -102,13 +103,7 @@ void Sv_InitMapList(void) {
  */
 void Sv_ShutdownMapList(void) {
 
-  if (svs.maps.list) {
-    svs.maps.list->destroy = (ListDestroyFunc) Cm_FreeEntity;
-    $(svs.maps.list, removeAll);
-    release(svs.maps.list);
-  }
-
-  svs.maps.list = NULL;
+  svs.maps.list = release(svs.maps.list);
   svs.maps.length = 0;
   svs.maps.index = -1;
   svs.maps.filename[0] = '\0';

--- a/src/server/sv_send.c
+++ b/src/server/sv_send.c
@@ -147,8 +147,9 @@ static void Sv_ClientDatagramMessage(sv_client_t *cl, byte *data, size_t len) {
 
   if (!cl->datagram.messages) {
     cl->datagram.messages = $(alloc(List), init);
-    cl->datagram.messages->destroy = (ListDestroyFunc) Mem_Free;
+    cl->datagram.messages->destroy = Mem_Free;
   }
+
   $(cl->datagram.messages, appendElement, msg);
 
   Mem_WriteBuffer(&cl->datagram.buffer, data, len);
@@ -398,11 +399,7 @@ void Sv_SendClientPackets(void) {
       // clean up for the next frame
       Mem_ClearBuffer(&cl->datagram.buffer);
 
-      if (cl->datagram.messages) {
-        $(cl->datagram.messages, removeAll); release(cl->datagram.messages); cl->datagram.messages = NULL;
-      }
-
-      cl->datagram.messages = NULL;
+      cl->datagram.messages = release(cl->datagram.messages);
 
     } else if (cl->net_chan.message.size) { // update reliable
       Netchan_Transmit(&cl->net_chan, NULL, 0);

--- a/src/server/sv_send.c
+++ b/src/server/sv_send.c
@@ -150,7 +150,7 @@ static void Sv_ClientDatagramMessage(sv_client_t *cl, byte *data, size_t len) {
     cl->datagram.messages->destroy = Mem_Free;
   }
 
-  $(cl->datagram.messages, appendElement, msg);
+  $(cl->datagram.messages, append, msg);
 
   Mem_WriteBuffer(&cl->datagram.buffer, data, len);
 }

--- a/src/server/sv_world.c
+++ b/src/server/sv_world.c
@@ -95,8 +95,7 @@ static sv_sector_t *Sv_CreateSector(int32_t depth, const box3_t bounds) {
 static void Sv_InitWorld(void) {
 
   for (size_t i = 0; i < sv_world.num_sectors; i++) {
-    release(sv_world.sectors[i].entities);
-    sv_world.sectors[i].entities = NULL;
+    sv_world.sectors[i].entities = release(sv_world.sectors[i].entities);
   }
 
   memset(&sv_world, 0, sizeof(sv_world));

--- a/src/server/sv_world.c
+++ b/src/server/sv_world.c
@@ -227,7 +227,7 @@ void Sv_LinkEntity(g_entity_t *ent) {
   if (!sector->entities) {
     sector->entities = $(alloc(List), init);
   }
-  $(sector->entities, prependElement, ent);
+  $(sector->entities, prepend, ent);
 }
 
 /**


### PR DESCRIPTION
When a binary update is available, `Cg_UpdateInstaller` never returned `1`, so `Installer_Init`'s frame loop ran forever and the game never reached `HomeViewController`. Additionally, `UpdateViewController::setStatus` was spawning a new `DialogViewController` child on every single frame of that infinite loop.

## Changes

- `Cg_UpdateInstaller` now treats `INSTALLER_UPDATE_AVAILABLE` as terminal: sets `MainViewController::updateAvailable`, pops `UpdateViewController`, and returns `1` to break the installer loop
- Removed the per-frame dialog from `UpdateViewController::setStatus`; shows a static "Update available." progress label instead
- `MainViewController::viewWillAppear` reads and clears `updateAvailable` and presents the "Download now?" dialog once in the correct context

## Testing

- [ ] Builds without warnings (`make -j$(nproc)`)
- [ ] Tests pass (`make check`)
- [ ] Tested in-game on 

## Notes

The `INSTALLER_UPDATE_AVAILABLE` state is now treated the same as `INSTALLER_DONE`/`INSTALLER_ERROR` from the frame-loop perspective - it terminates the installer screen immediately. The deferred flag approach means the dialog appears once `MainViewController` is on screen, matching the behavior of the quit/disconnect dialogs.