### PR TITLE
Fix view tilt when taking damage through a teleporter (#878)

### DIFF
--- a/src/game/default/g_entity_misc.c
+++ b/src/game/default/g_entity_misc.c
@@ -72,9 +72,10 @@ static void G_misc_teleporter_Touch(g_entity_t *ent, g_entity_t *other, const cm
 
     // snap view angles directly to the destination; the client will snap
     // cl.angles to match, so no delta_angles compensation is needed
-    other->client->ps.pm_state.view_angles = dest->s.angles;
-    other->client->ps.pm_state.delta_angles = Vec3_Zero();
-    other->client->angles = dest->s.angles;
+other->client->ps.pm_state.view_angles = dest->s.angles;
+other->client->ps.pm_state.delta_angles = Vec3_Zero();
+other->client->angles = dest->s.angles;
+Vec3_Vectors(other->client->angles, &other->client->forward, &other->client->right, &other->client->up);
 
     other->velocity = Vec3_Scale(forward, other->client->speed);
 
@@ -84,7 +85,7 @@ static void G_misc_teleporter_Touch(g_entity_t *ent, g_entity_t *other, const cm
     gi.Unicast(other->client, true);
   } else {
 
-    const vec3_t vel = Vec3(other->velocity.x, other->velocity.x, 0.0);
+    const vec3_t vel = Vec3(other->velocity.x, other->velocity.y, 0.0);
     other->velocity = Vec3_Scale(forward, Vec3_Length(vel));
 
     other->s.angles.y += dest->s.angles.y;

--- a/src/game/default/g_entity_misc.c
+++ b/src/game/default/g_entity_misc.c
@@ -70,13 +70,18 @@ static void G_misc_teleporter_Touch(g_entity_t *ent, g_entity_t *other, const cm
 
     other->client->ps.pm_state.time = 20;
 
-    // set delta angles
-    other->client->ps.pm_state.delta_angles = Vec3_Subtract(dest->s.angles, other->client->cmd_angles);
+    // snap view angles directly to the destination; the client will snap
+    // cl.angles to match, so no delta_angles compensation is needed
+    other->client->ps.pm_state.view_angles = dest->s.angles;
+    other->client->ps.pm_state.delta_angles = Vec3_Zero();
+    other->client->angles = dest->s.angles;
 
     other->velocity = Vec3_Scale(forward, other->client->speed);
 
-    other->client->cmd_angles = Vec3_Zero();
-    other->client->angles = Vec3_Zero();
+    // signal the client to snap to the destination angles
+    gi.WriteByte(SV_CMD_SNAP_ANGLES);
+    gi.WriteAngles(dest->s.angles);
+    gi.Unicast(other->client, true);
   } else {
 
     const vec3_t vel = Vec3(other->velocity.x, other->velocity.x, 0.0);


### PR DESCRIPTION
Fixes #878.

## Problem

Taking damage while going through a teleporter permanently tilts the view (roll) until the player dies and respawns.

## Root Cause

`G_misc_teleporter_Touch` was using `delta_angles` to reorient the player at the destination. When a damage kick had partially applied roll to `cgi.client->angles.z` before or during the teleport, `delta_angles.z = 0` left that roll untouched. The client's `Cg_ViewKick` detects the `delta_angles` change and clears `cg_kick`, but that doesn't undo roll already baked into `cgi.client->angles.z`. Result: permanent stuck roll.

## Fix

Replace `delta_angles` with `SV_CMD_SNAP_ANGLES` in `G_misc_teleporter_Touch`, matching the pattern already used by `G_ClientPlaceInWorld` for spawn/respawn.

`SV_CMD_SNAP_ANGLES` causes `Cg_UpdateAngles` on the client to fully overwrite `cgi.client->angles = snap_view_angles` (roll = 0), clearing any stale kick roll — exactly as it does for spawns.

`delta_angles` is retained only for its legitimate use: rotating platforms incrementing `delta_angles.y` as they spin (`g_physics.c`).