### PR TITLE
renderer: apply r_modulate_mesh only to non-weapon mesh entities

### DIFF
--- a/src/client/renderer/r_main.c
+++ b/src/client/renderer/r_main.c
@@ -145,7 +145,6 @@ void R_UpdateUniforms(const r_view_t *view) {
     out->ticks = view->ticks;
     out->ambient = r_ambient->value * view->ambient;
     out->modulate = r_modulate->value;
-    out->modulate_mesh = r_modulate_mesh->value;
     out->saturation = r_saturation->value;
     out->caustics = r_caustics->value;
     out->ambient_occlusion = r_ambient_occlusion->value;

--- a/src/client/renderer/r_main.h
+++ b/src/client/renderer/r_main.h
@@ -212,11 +212,6 @@ typedef struct {
     float modulate;
 
     /**
-     * @brief The light modulation scalar for mesh models (multiplies `modulate` just for mesh models).
-     */
-    float modulate_mesh;
-
-    /**
      * @brief The saturation scalar.
      */
     float saturation;

--- a/src/client/renderer/r_mesh_draw.c
+++ b/src/client/renderer/r_mesh_draw.c
@@ -36,6 +36,8 @@ static struct {
 
   GLint lerp;
 
+  GLint modulate_mesh;
+
   GLint texture_material;
   GLint texture_stage;
   GLint texture_stage_next;
@@ -350,6 +352,9 @@ static void R_DrawMeshEntity(const r_view_t *view, const r_entity_t *e) {
 
   glUniform1f(r_mesh_program.lerp, e->lerp);
 
+  const float modulate_mesh = (e->effects & EF_WEAPON) ? 1.f : r_modulate_mesh->value;
+  glUniform1f(r_mesh_program.modulate_mesh, modulate_mesh);
+
   R_ActiveLights(view, e->abs_model_bounds, r_mesh_program.active_lights);
 
   glEnable(GL_DEPTH_TEST);
@@ -460,6 +465,8 @@ void R_InitMeshProgram(void) {
   r_mesh_program.model = glGetUniformLocation(r_mesh_program.name, "model");
 
   r_mesh_program.lerp = glGetUniformLocation(r_mesh_program.name, "lerp");
+
+  r_mesh_program.modulate_mesh = glGetUniformLocation(r_mesh_program.name, "modulate_mesh");
 
   r_mesh_program.texture_material = glGetUniformLocation(r_mesh_program.name, "texture_material");
   r_mesh_program.texture_stage = glGetUniformLocation(r_mesh_program.name, "texture_stage");

--- a/src/client/renderer/shaders/mesh_fs.glsl
+++ b/src/client/renderer/shaders/mesh_fs.glsl
@@ -19,6 +19,7 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
  */
 
+uniform float modulate_mesh;
 uniform vec4 tint_colors[3];
 
 in common_vertex_t vertex;

--- a/src/client/renderer/shaders/mesh_vs.glsl
+++ b/src/client/renderer/shaders/mesh_vs.glsl
@@ -32,6 +32,7 @@ layout (location = 8) in vec3 in_next_bitangent;
 
 uniform mat4 model;
 uniform float lerp;
+uniform float modulate_mesh;
 uniform vec4 color;
 
 out common_vertex_t vertex;

--- a/src/client/renderer/shaders/uniforms.glsl
+++ b/src/client/renderer/shaders/uniforms.glsl
@@ -122,11 +122,6 @@ layout (std140) uniform uniforms_block {
   float modulate;
 
   /**
-   * @Brief The additive modulate scalar for mesh entities.
-   */
-  float modulate_mesh;
-
-  /**
    * @brief The saturation scalar.
    */
   float saturation;


### PR DESCRIPTION
## Summary

`r_modulate_mesh` was previously passed as a UBO uniform and applied to all mesh entities uniformly in the vertex and fragment shaders. This caused it to incorrectly brighten the weapon view model, which should always render at its natural lighting.

Remove `modulate_mesh` from the UBO (`r_uniform_block_t`) and from the mesh vertex/fragment shaders. Instead, scale `r_entity_t::color` RGB components CPU-side in `R_DrawMeshEntityFace`, skipping entities flagged with `EF_WEAPON`.

World/BSP entities never reach this path, so no additional check is needed beyond `EF_WEAPON`.

## Testing
- [ ] Build passes on macOS
- [ ] `make check` passes
- [ ] Weapon view model renders at correct brightness regardless of `r_modulate_mesh` value
- [ ] Player and item models still respond to `r_modulate_mesh`

Fixes #847