### PR TITLE
Add cg_fov_scale for Hor+ widescreen field-of-view scaling

### DIFF
--- a/src/cgame/default/cg_main.c
+++ b/src/cgame/default/cg_main.c
@@ -57,6 +57,7 @@ cvar_t *cg_force_skin;
 cvar_t *cg_fov;
 cvar_t *cg_fov_zoom;
 cvar_t *cg_fov_interpolate;
+cvar_t *cg_fov_scale;
 cvar_t *cg_hit_sound;
 cvar_t *cg_predict;
 cvar_t *cg_quick_join_max_ping;
@@ -132,6 +133,7 @@ static void Cg_Init(void) {
   cg_fov = cgi.AddCvar("cg_fov", "110", CVAR_ARCHIVE, "Horizontal field of view, in degrees");
   cg_fov_zoom = cgi.AddCvar("cg_fov_zoom", "55", CVAR_ARCHIVE, "Zoomed in field of view");
   cg_fov_interpolate = cgi.AddCvar("cg_fov_interpolate", "1", CVAR_ARCHIVE, "Interpolate between field of view changes (default 1.0).");
+  cg_fov_scale = cgi.AddCvar("cg_fov_scale", "0", CVAR_ARCHIVE, "Field of view aspect scaling: 0 = classic (cg_fov is the horizontal FOV; vertical FOV shrinks on wide displays); 1 = Hor+ (cg_fov is the horizontal FOV at 16:9; the vertical FOV is locked to 16:9 and the horizontal FOV widens for wide/ultrawide displays).");
   cg_hit_sound = cgi.AddCvar("cg_hit_sound", "1", CVAR_ARCHIVE, "If a hit sound is played when damaging an enemy.");
   cg_predict = cgi.AddCvar("cg_predict", "1", 0, "Use client side movement prediction");
   cg_quick_join_max_ping = cgi.AddCvar("cg_quick_join_max_ping", "200", CVAR_ARCHIVE, "Maximum ping allowed for quick join");

--- a/src/cgame/default/cg_main.h
+++ b/src/cgame/default/cg_main.h
@@ -60,6 +60,7 @@ extern cvar_t *cg_force_skin;
 extern cvar_t *cg_fov;
 extern cvar_t *cg_fov_zoom;
 extern cvar_t *cg_fov_interpolate;
+extern cvar_t *cg_fov_scale;
 extern cvar_t *cg_hit_sound;
 extern cvar_t *cg_predict;
 extern cvar_t *cg_quick_join_max_ping;

--- a/src/cgame/default/cg_view.c
+++ b/src/cgame/default/cg_view.c
@@ -44,7 +44,13 @@ static void Cg_UpdateFov(void) {
     }
 
     if (time == 0) {
-      prev = cgi.view->fov.x * 2.f;
+      // Reconstruct the previous cg_fov (the horizontal reference FOV) from the
+      // current view, the inverse of the per-mode derivation below. In Hor+ mode
+      // fov.x is the aspect-expanded horizontal, so derive it from the locked
+      // 16:9 vertical instead.
+      prev = cg_fov_scale->integer
+        ? 2.f * Degrees(atanf(tanf(Radians(cgi.view->fov.y)) * (16.f / 9.f)))
+        : cgi.view->fov.x * 2.f;
       next = cg_fov->value;
       time = cgi.client->unclamped_time;
     }
@@ -61,12 +67,25 @@ static void Cg_UpdateFov(void) {
     cg_fov->modified = false;
   }
 
-  cgi.view->fov.x = fov / 2.f;
-
   const float width = cgi.view->viewport.z;
   const float height = cgi.view->viewport.w;
 
-  cgi.view->fov.y = Degrees(atanf(tanf(Radians(fov / 2.f)) * height / width));
+  if (cg_fov_scale->integer) {
+    // Hor+ (horizontal-plus) widescreen scaling. cg_fov is the horizontal FOV at
+    // a 16:9 reference; lock the vertical FOV to that 16:9 value and widen the
+    // horizontal FOV for the actual aspect ratio. Wide / ultrawide displays then
+    // show more at the sides while keeping the vertical extent (and the
+    // first-person weapon) intact. fov.x/fov.y are half-angles, in degrees.
+    const float fov_y = atanf(tanf(Radians(fov / 2.f)) * (9.f / 16.f));
+    cgi.view->fov.y = Degrees(fov_y);
+    cgi.view->fov.x = Degrees(atanf(tanf(fov_y) * width / height));
+  } else {
+    // Classic behavior: cg_fov is the literal horizontal FOV and the vertical FOV
+    // is derived from the aspect ratio (vertical-minus), which shrinks the
+    // vertical FOV on wide displays.
+    cgi.view->fov.x = fov / 2.f;
+    cgi.view->fov.y = Degrees(atanf(tanf(Radians(fov / 2.f)) * height / width));
+  }
 }
 
 /**


### PR DESCRIPTION
## What

Adds a `cg_fov_scale` cvar controlling how the field of view adapts to the display aspect ratio:

- `cg_fov_scale 0` (**default**): classic behavior, unchanged — `cg_fov` is the literal horizontal FOV and the vertical FOV is derived from the aspect ratio.
- `cg_fov_scale 1`: **Hor+** (horizontal-plus) — `cg_fov` is the horizontal FOV at a 16:9 reference; the vertical FOV is locked to 16:9 and the horizontal FOV widens for the actual aspect ratio.

## Why

`cg_fov` is currently a fixed horizontal FOV, so wider displays get a *smaller vertical* FOV (vertical-minus). On 21:9 / 32:9 ultrawide this noticeably crops the view and the first-person weapon — you have to set `cg_fov` very high to see the whole gun. Hor+ is the standard modern widescreen convention: the vertical FOV stays fixed and wider screens simply show more to the sides.

On a 16:9 display, `cg_fov_scale 1` produces exactly `cg_fov` horizontally (so the number stays intuitive); on wider displays the horizontal FOV expands from there.

## Notes

- Default is `0`, so **existing behavior is unchanged** unless a user opts in.
- `cg_fov_interpolate` reconstruction is made mode-aware so smooth FOV/zoom transitions work in both modes.
- The change is confined to the default cgame (`cg_view.c` plus the cvar declaration/registration) — 3 files, +26/−4.

## Testing

Hor+ behavior verified on a 32:9 (5120×1440) display in a downstream build: at a normal `cg_fov` the full viewmodel stays in frame and the horizontal view widens, while `cg_fov_scale 0` reproduces current behavior exactly. The cvar form here is the same math gated behind `cg_fov_scale`.
