### PR TITLE
Restart level when g_hook is toggled

### DIFF
--- a/src/game/common/g_hook.c
+++ b/src/game/common/g_hook.c
@@ -132,6 +132,7 @@ static void G_ConfigureLevel_Hook(void) {
  * @brief Applies the hook's own cvars.
  */
 static bool G_CheckCvars_Hook(void) {
+  bool restart = false;
 
   if (g_hook->modified) {
     g_hook->modified = false;
@@ -139,6 +140,8 @@ static bool G_CheckCvars_Hook(void) {
     G_Hook_CheckState();
 
     gi.BroadcastPrint(PRINT_HIGH, "Hook has been %s\n", G_Hook_Enabled() ? "enabled" : "disabled");
+
+    restart = true;
   }
 
   if (g_hook_speed->modified) {
@@ -166,7 +169,7 @@ static bool G_CheckCvars_Hook(void) {
     gi.BroadcastPrint(PRINT_HIGH, "Hook style has been changed to %s\n", g_hook_style->string);
   }
 
-  return previous.CheckCvars();
+  return previous.CheckCvars() || restart;
 }
 
 /**


### PR DESCRIPTION
## Summary
Fixes #923. `G_CheckCvars_Hook` returned `previous.CheckCvars()` without requesting a level restart when `g_hook` is toggled, unlike `G_CheckCvars_Tech`. A client mid-pull when an admin sets `g_hook 0` got stuck forever: `g_hook_enabled` goes false, `G_HookDetach`/`G_HookThink` both early-return, and nothing ever clears `cl->hook.pull`.

## Fix
Mirrors `G_CheckCvars_Tech`'s existing pattern: sets `restart = true` when `g_hook->modified`, and returns `previous.CheckCvars() || restart`. The level restart's `G_ClientRespawn_` memsets each client's state (including `hook.pull`), which unsticks the client — no direct hook-teardown special-casing needed.

## Test plan
- [x] Builds cleanly (`autoreconf -i && ./configure && make -j4`)
- [ ] Manual repro: pull on hook, `g_hook 0` mid-pull, confirm client is freed on the ensuing restart rather than stuck in `PM_HOOK_PULL`

Note: toggling `g_hook` now forces a full level restart in both directions (on and off), same trade-off `g_techs` already accepts.