### PR TITLE
Report Fs_SetGame unmount failure instead of hiding it

### DIFF
--- a/src/client/cl_parse.c
+++ b/src/client/cl_parse.c
@@ -286,7 +286,9 @@ static void Cl_ParseServerData(void) {
     Com_Error(ERROR_DROP, "Server sent an invalid game directory\n");
   }
 
-  Com_SetGame(str);
+  if (!Com_SetGame(str)) {
+    Com_Error(ERROR_DROP, "Failed to set game: %s\n", str);
+  }
 
   if (q_strcmp(cls.cgame_game, str)) {
     Cl_InitCgame();

--- a/src/common/common.c
+++ b/src/common/common.c
@@ -115,7 +115,6 @@ bool Com_SetGame(const char *game) {
   const bool initial = *quetoo.game == '\0';
 
   if (!Fs_SetGame(game)) {
-    Com_Warn("Failed to set game: %s\n", game);
     return false;
   }
 

--- a/src/common/common.c
+++ b/src/common/common.c
@@ -114,7 +114,10 @@ bool Com_SetGame(const char *game) {
   // game to another has to run the new game's config itself
   const bool initial = *quetoo.game == '\0';
 
-  Fs_SetGame(game);
+  if (!Fs_SetGame(game)) {
+    Com_Warn("Failed to set game: %s\n", game);
+    return false;
+  }
 
   q_strlcpy(quetoo.game, game, sizeof(quetoo.game));
 

--- a/src/common/filesystem.c
+++ b/src/common/filesystem.c
@@ -673,11 +673,14 @@ bool Fs_ValidGame(const char *dir) {
  * @details `Com_SetGame` is the only caller, and it holds the game that is
  * current and has already validated this name, so there is nothing to compare
  * against here: this only does the work.
+ * @return True if the search path now reflects `dir`, false if a mount that was
+ * still open (e.g. an open demo) could not be unmounted, leaving the search path
+ * partially torn down and the new game's paths never mounted.
  */
-void Fs_SetGame(const char *dir) {
+bool Fs_SetGame(const char *dir) {
 
   if (!Fs_ValidGame(dir)) {
-    return;
+    return false;
   }
 
   Com_Debug(DEBUG_FILESYSTEM, "Setting game: %s\n", dir);
@@ -697,7 +700,8 @@ void Fs_SetGame(const char *dir) {
       Com_Debug(DEBUG_FILESYSTEM, "Removing %s\n", *path);
       if (PHYSFS_unmount(*path) == 0) {
         Com_Warn("%s: %s\n", *path, Fs_LastError());
-        return;
+        PHYSFS_freeList(paths);
+        return false;
       }
     }
     path++;
@@ -714,6 +718,7 @@ void Fs_SetGame(const char *dir) {
   }
 
   Fs_AddUserSearchPath(dir);
+  return true;
 }
 
 /**

--- a/src/common/filesystem.h
+++ b/src/common/filesystem.h
@@ -54,7 +54,7 @@ void Fs_CompleteFile(const char *pattern, List *matches);
 void Fs_CompleteGame(const char *pattern, List *matches);
 void Fs_AddToSearchPath(const char *path);
 void Fs_AddToSearchPathv(const char *dir, ...) __attribute__((sentinel));
-void Fs_SetGame(const char *dir);
+bool Fs_SetGame(const char *dir);
 void Fs_SetWriteDir(const char *dir);
 bool Fs_ValidGame(const char *dir);
 const char *Fs_WriteDir(void);


### PR DESCRIPTION
## Summary
Fixes #921. `Fs_SetGame` returned `void` and couldn't report `PHYSFS_unmount` failure. On failure it warned and returned mid-teardown, leaving the search path half-dismantled, the new game's paths never mounted, and the `paths` list from `PHYSFS_getSearchPath()` leaked. `Com_SetGame` had already told the caller the switch succeeded, so `quetoo.game` and the real search path disagreed from then on.

## Fix
- `Fs_SetGame` now returns `bool`: `false` on an invalid game or unmount failure (freeing the leaked `paths` list first), `true` on success.
- `Com_SetGame` checks it and returns `false` without writing `quetoo.game` on failure, so the cvar and search path stay consistent.
- `Cl_ParseServerData` now `Com_Error(ERROR_DROP, ...)`s if `Com_SetGame` fails, consistent with how it already handles adjacent failure modes (invalid game directory, protocol mismatch) in the same function.
- The `game` console command (`Game_f`) already checked `Com_SetGame`'s return value, so it now benefits automatically.

## Test plan
- [x] Builds cleanly (`autoreconf -i && ./configure && make -j4`)
- [ ] Manual repro: play on `ctf` with a demo open under the user directory, then `game lithium`; confirm failure is now reported and `quetoo.game` doesn't drift from the actual search path

Fully repairing the half-dismantled search path on unmount failure (e.g. remounting what was removed) is out of scope here — this PR is about detecting and reporting the failure, not making the teardown atomic.