### PR TITLE
Prepend autocomplete match when it sorts first

### DIFF
--- a/src/common/console.c
+++ b/src/common/console.c
@@ -432,7 +432,11 @@ void Con_AutocompleteMatch(List *matches, const char *name, const char *descript
     }
   }
 
-  $(matches, insertAfter, insert_after, match);
+  if (insert_after) {
+    $(matches, insertAfter, insert_after, match);
+  } else {
+    $(matches, prepend, match);
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary
Fixes #924. `Con_AutocompleteMatch` computes the correct sorted insertion point, then inserts with `insertAfter(matches, insert_after, match)`. `insert_after` is NULL when the new match sorts before everything already in the list, but Objectively's `insertAfter` falls through to `append` when passed a NULL node rather than prepending, so results come out in feed order instead of sorted whenever a new match belongs at the front.

## Fix
Branch on `insert_after`: keep `insertAfter` when it's set, and call `prepend` explicitly when it's NULL. `prepend` is a plain O(1) head insertion and correctly handles both the "sorts before everything" case and the empty-list case.

## Test plan
- [x] Builds cleanly, `make check` passes (`check_cmd`, `check_cvar`)
- [ ] Manual repro: `game <tab>` should offer matches in sorted order

No dedicated unit test exists for `Con_AutocompleteMatch` (`src/tests` has no `check_console.c`) — pre-existing gap, not introduced by this change.