### PR TITLE
Close leaked cgame handle on failed init

### DIFF
--- a/src/client/cl_cgame.c
+++ b/src/client/cl_cgame.c
@@ -151,6 +151,10 @@ void Cl_InitCgame(void) {
 
   if (cls.cgame) {
     Cl_ShutdownCgame();
+  } else if (cgame_handle) {
+    removeClassImage(cgame_handle);
+    Sys_CloseLibrary(cgame_handle);
+    cgame_handle = NULL;
   }
 
   Com_Print("Client game initialization...\n");


### PR DESCRIPTION
## Summary
Fixes #920. If `Cl_InitCgame` fails after `Sys_OpenLibrary` succeeds and `addClassImage(cgame_handle)` runs — e.g. an unresolved `Cg_LoadCgame` symbol — `cls.cgame` stays NULL (the failure path calls `Com_Error`, which longjmps out before `cls.cgame` is ever assigned). The next `Cl_InitCgame` only cleans up via `if (cls.cgame) { Cl_ShutdownCgame(); }`, which is false here, so the previous handle is silently overwritten: never `dlclose`d, its class image never removed. `MAX_CLASS_IMAGES` is 8 with an assert, so repeated failed loads eventually abort.

## Fix
Added an `else if (cgame_handle)` branch that cleans up a stale handle (`removeClassImage`, `Sys_CloseLibrary`, null it out) before the new `Sys_OpenLibrary` call overwrites the static — mirroring the existing cleanup pairing/ordering in `Cl_ShutdownCgame`.

## Test plan
- [x] Builds cleanly (`autoreconf -i && ./configure && make -j4`)
- [ ] Manual repro: force a cgame load failure (unresolved symbol) twice in a row, confirm no leaked handle / no `MAX_CLASS_IMAGES` assert after repeated failures