### PR TITLE
Fix bot detection for pre-InfoString status protocol lines

### DIFF
--- a/src/client/cl_server.c
+++ b/src/client/cl_server.c
@@ -124,10 +124,27 @@ void Cl_ParseServerInfo(void) {
       if (player[0]) {
         server->clients++;
 
-        char player_name[MAX_TOKEN_CHARS];
-        q_strcolorstrip(InfoString_Get(player, "name"), player_name);
+        char player_name[MAX_TOKEN_CHARS] = "";
 
-        // legacy (pre-v1.0.30) servers don't send \ai\1; fall back to the [BOT] name prefix
+        if (q_strchr(player, '\\')) { // current status protocol: an info string
+          q_strcolorstrip(InfoString_Get(player, "name"), player_name);
+        } else { // legacy status protocol: `<score> <ping> "<name>"`, no \ai\1 key exists,
+                  // and InfoString_Get can't extract "name" from this format either, since
+                  // it requires backslash-delimited pairs; parse the quoted name directly
+          const char *quote = q_strchr(player, '"');
+          if (quote) {
+            const char *end_quote = q_strrchr(quote + 1, '"');
+            const size_t name_len = end_quote ? (size_t) (end_quote - (quote + 1)) : q_strlen(quote + 1);
+
+            char raw_name[MAX_TOKEN_CHARS];
+            q_strlcpy(raw_name, quote + 1, Minz(name_len + 1, sizeof(raw_name)));
+            q_strcolorstrip(raw_name, player_name);
+          }
+        }
+
+        // bots are marked with \ai\1 on current servers; servers running an older status
+        // protocol (either pre-v1.0.30, or simply predating the \ai\1 rewrite) instead
+        // prefix the bot's name with [BOT], which we detect regardless of wire format
         if (atoi(InfoString_Get(player, "ai")) || !q_strncmp(player_name, "[BOT]", 5)) {
           server->bots++;
         }

--- a/src/client/cl_server.c
+++ b/src/client/cl_server.c
@@ -123,7 +123,12 @@ void Cl_ParseServerInfo(void) {
 
       if (player[0]) {
         server->clients++;
-        if (atoi(InfoString_Get(player, "ai"))) {
+
+        char player_name[MAX_TOKEN_CHARS];
+        q_strcolorstrip(InfoString_Get(player, "name"), player_name);
+
+        // legacy (pre-v1.0.30) servers don't send \ai\1; fall back to the [BOT] name prefix
+        if (atoi(InfoString_Get(player, "ai")) || !q_strncmp(player_name, "[BOT]", 5)) {
           server->bots++;
         }
       }


### PR DESCRIPTION
## Summary
Fixes #917. Players reported the in-game server browser sometimes shows bots as human players ("1/x"), mostly on servers like Botopia/Electric City.

## Root cause
My first pass at this assumed it was about protocol-incompatible legacy servers, but that doesn't hold up: the master server (`Ms_GetServers`) filters the internet list by an exact `PROTOCOL_MAJOR` match, so genuinely old/incompatible server binaries can't appear in the browser at all.

The real cause: the player-info-line wire format changed from a plain `<score> <ping> "<name>"` string to the current `\score\N\ping\N\name\X\ai\1` info-string format in a commit that did **not** bump `PROTOCOL_MAJOR`. A server that's otherwise current (passes the protocol filter) but simply hasn't been rebuilt/restarted since before that specific commit still sends the old plain-text format — and `InfoString_Get` returns `""` on a line with no backslashes at all, so bot detection silently fails for every player on that server, not just bots.

## Fix
`Cl_ParseServerInfo` now checks whether a player line contains a backslash. If so, parses as the current info-string format (as before, `\ai\1` or `[BOT]` name-prefix fallback). If not, parses the name directly out of the legacy quoted format instead of relying on `InfoString_Get`, then applies the same `[BOT]` prefix check either way.

## Test plan
- [x] Builds cleanly
- [ ] Manual repro against a server running an older build (pre-info-string player lines) — confirm bots are correctly counted rather than shown as humans

## Notes
- The hand-rolled legacy-line parser was reviewed for bounds-safety against malformed/adversarial input (untrusted network data) — all buffer copies are properly bounded via `Minz`/`q_strlcpy`, no overflow or crash paths found.
- `src/master/main.c`'s Discord webhook notifier has the same latent gap (relies on info-string parsing for `"name"`, would fail identically on a pre-rewrite server) — out of scope here since the issue is about the in-game browser, but worth a follow-up issue.