### PR TITLE
Reimplement r_modulate_mesh scoped to players and items

### DIFF
--- a/src/client/renderer/r_main.c
+++ b/src/client/renderer/r_main.c
@@ -54,6 +54,7 @@ cvar_t *r_gpu_driver;
 cvar_t *r_hardness;
 cvar_t *r_lighting_distance;
 cvar_t *r_modulate;
+cvar_t *r_modulate_mesh;
 cvar_t *r_saturation;
 cvar_t *r_parallax;
 cvar_t *r_parallax_shadow;
@@ -410,6 +411,7 @@ static void R_InitLocal(void) {
   r_hardness = Cvar_Add("r_hardness", "1", CVAR_ARCHIVE, "Controls the hardness of bump-mapping effects.");
   r_lighting_distance = Cvar_Add("r_lighting_distance", "2048", CVAR_ARCHIVE, "Distance threshold for vertex lighting.");
   r_modulate = Cvar_Add("r_modulate", "1", CVAR_ARCHIVE, "Controls the brightness of static lighting.");
+  r_modulate_mesh = Cvar_Add("r_modulate_mesh", "1", CVAR_ARCHIVE, "Controls the brightness of players and items, to increase their visibility.");
   r_saturation = Cvar_Add("r_saturation", "1", CVAR_ARCHIVE, "Controls the color saturation of the rendered scene. 0 = grayscale, 1 = normal, 2 = vivid.");
   r_parallax = Cvar_Add("r_parallax", "1", CVAR_ARCHIVE, "Controls the intensity of parallax effects.");
   r_parallax_shadow = Cvar_Add("r_parallax_shadow", "1", CVAR_ARCHIVE, "Controls the intensity of parallax self-shadow effects.");

--- a/src/client/renderer/r_main.h
+++ b/src/client/renderer/r_main.h
@@ -40,6 +40,7 @@ extern cvar_t *r_gpu_driver;
 extern cvar_t *r_hardness;
 extern cvar_t *r_lighting_distance;
 extern cvar_t *r_modulate;
+extern cvar_t *r_modulate_mesh;
 extern cvar_t *r_saturation;
 extern cvar_t *r_parallax;
 extern cvar_t *r_parallax_shadow;

--- a/src/client/renderer/r_mesh_draw.c
+++ b/src/client/renderer/r_mesh_draw.c
@@ -341,6 +341,12 @@ static void R_BindMeshEntityFace(const r_entity_t *e, const r_mesh_model_t *mesh
     .color = e->color,
   };
 
+  // scale rgb only, CPU-side, for entities the server has opted in to boosting
+  // (players, items); alpha is left untouched
+  if (e->effects & EF_MODULATE) {
+    locals.color.xyz = Vec3_Scale(locals.color.xyz, r_modulate_mesh->value);
+  }
+
   memcpy(&locals.active_dynamic_lights, r_mesh_draw.active_dynamic_lights, sizeof(locals.active_dynamic_lights));
 
   switch (r_mesh_draw.material->cm->surface & SURF_MASK_BLEND) {

--- a/src/client/renderer/r_types.h
+++ b/src/client/renderer/r_types.h
@@ -1704,6 +1704,13 @@ typedef struct {
 #define MAX_SPRITE_INSTANCES (MAX_SPRITES + MAX_BEAMS)
 
 /**
+ * @brief Mirrors the game modules' `EF_MODULATE` (`g_types.h`), which is identical
+ * across all three modules. The renderer has no visibility into a per-module
+ * header, so this bit is redeclared here rather than shared by inclusion.
+ */
+#define EF_MODULATE (EF_GAME << 17)
+
+/**
  * @brief Renderer-local entity effect bits.
  */
 #define EF_SELF      (1 << 23)

--- a/src/game/common/g_client.c
+++ b/src/game/common/g_client.c
@@ -1008,7 +1008,7 @@ static void G_ClientRespawn_(g_client_t *cl) {
 
   ent->velocity = Vec3_Zero();
 
-  ent->s.effects = EF_CLIENT;
+  ent->s.effects = EF_CLIENT | EF_MODULATE;
   ent->s.model1 = 0;
   ent->s.model2 = 0;
   ent->s.model3 = 0;
@@ -1140,7 +1140,7 @@ void G_ClientBegin(g_client_t *cl) {
   cl->entity = G_AllocEntity("client");
   cl->entity->client = cl;
   cl->entity->s.client = cl->ps.client;
-  cl->entity->s.effects = EF_CLIENT;
+  cl->entity->s.effects = EF_CLIENT | EF_MODULATE;
   cl->ps.entity = cl->entity->s.number;
 
   cl->cmd_angles = Vec3_Zero();

--- a/src/game/common/g_item.c
+++ b/src/game/common/g_item.c
@@ -815,7 +815,7 @@ g_entity_t *G_DropItem(g_client_t *cl, const g_item_t *item) {
   it->spawn_flags |= SF_ITEM_DROPPED;
   it->move_type = MOVE_TYPE_BOUNCE;
   it->Touch = G_TouchItem;
-  it->s.effects = item->def.effects;
+  it->s.effects = item->def.effects | EF_MODULATE;
 
   if (item->def.light_radius) {
     it->s.effects |= EF_LIGHT | EF_LIGHT_PULSE;
@@ -1127,7 +1127,7 @@ void G_SpawnItem(g_entity_t *ent, const g_item_t *item) {
     ent->s.model1 = ent->item->model_index;
   }
 
-  ent->s.effects = item->def.effects;
+  ent->s.effects = item->def.effects | EF_MODULATE;
 
   if (item->def.light_radius) {
     ent->s.effects |= EF_LIGHT | EF_LIGHT_PULSE;

--- a/src/game/ctf/g_types.h
+++ b/src/game/ctf/g_types.h
@@ -306,6 +306,7 @@ typedef enum {
 #define EF_TEAM_TINT       (EF_GAME << 14) // tint by the team color provided
 #define EF_INVISIBILITY    (EF_GAME << 15) // ring of shadows (invisible shell)
 #define EF_INVULNERABILITY (EF_GAME << 16) // invulnerability shell
+#define EF_MODULATE        (EF_GAME << 17) // boost mesh brightness; mirrored in r_types.h
 
 #define EF_CTF_MASK   (EF_CTF_RED | EF_CTF_BLUE | EF_CTF_YELLOW | EF_CTF_GREEN)
 

--- a/src/game/default/g_types.h
+++ b/src/game/default/g_types.h
@@ -287,6 +287,7 @@ typedef enum {
 #define EF_TEAM_TINT       (EF_GAME << 14) // tint by the team color provided
 #define EF_INVISIBILITY    (EF_GAME << 15) // ring of shadows (invisible shell)
 #define EF_INVULNERABILITY (EF_GAME << 16) // invulnerability shell
+#define EF_MODULATE        (EF_GAME << 17) // boost mesh brightness; mirrored in r_types.h
 
 /**
  * @brief The lightning gun overrides animation1 to inform the client what

--- a/src/game/lithium/g_types.h
+++ b/src/game/lithium/g_types.h
@@ -292,6 +292,7 @@ typedef enum {
 #define EF_TEAM_TINT       (EF_GAME << 14) // tint by the team color provided
 #define EF_INVISIBILITY    (EF_GAME << 15) // ring of shadows (invisible shell)
 #define EF_INVULNERABILITY (EF_GAME << 16) // invulnerability shell
+#define EF_MODULATE        (EF_GAME << 17) // boost mesh brightness; mirrored in r_types.h
 
 /**
  * @brief The lightning gun overrides animation1 to inform the client what


### PR DESCRIPTION
## Summary
Fixes #847. `r_modulate_mesh` previously affected every mesh entity — including the weapon view model and map decoration models (e.g. plants) — and was fought over across several commits (`13181cc4e`, `4d171e688`, `a4a0864bc`, `72cc76f73`, `2c4bc38b7`) before being pulled entirely.

Per the maintainer's own implementation hint on the issue: "like the old `EF_PULSE` from Quake2 — let the server assign it to the things that should be brightened, and let the renderer statically multiply their color uniform by some scale. Opting in via `ent->s.effects` is necessary to select only the things this should apply to: items and players."

## Implementation
- New `EF_MODULATE` effect bit (`EF_GAME << 17`), defined identically across all three modules' `g_types.h`, and mirrored in `r_types.h` since the pure renderer can't include a per-module header.
- Server sets it on all items (`g_item.c`, the two places that copy an item definition's effects onto its entity state) and living players (`g_client.c`'s two spawn baselines) — corpses/gibbed states are separate assignment sites and deliberately excluded.
- New `r_modulate_mesh` cvar (defaults to `1`, neutral — matches the old cvar's default) controls the intensity.
- `R_BindMeshEntityFace` (`r_mesh_draw.c`) scales `locals.color.xyz` (RGB only, alpha untouched) by `r_modulate_mesh->value` when `e->effects & EF_MODULATE`, CPU-side — no GL state changes, no uniform for entities that don't opt in.

The weapon view model is structurally excluded: it's a fresh client-only entity (`cg_weapon.c`) that never inherits effects from a networked entity, so it can never carry `EF_MODULATE`. Map decoration entities never have this bit set either — verified no other assignment site in `src/game/common/` or any module ORs it in.

## Test plan
- [x] Builds cleanly across all three game/cgame modules and the renderer
- [ ] Manual: confirm players and items appear brighter with `r_modulate_mesh` raised above 1, and the weapon view model / map decoration models (e.g. plants on edge) are unaffected