### PR TITLE
Declare Mem_Link's parameters in the order it defines them

### DIFF
--- a/src/common/mem.h
+++ b/src/common/mem.h
@@ -31,7 +31,7 @@ void *Mem_TagMalloc(size_t size, mem_tag_t tag);
 void *Mem_LinkMalloc(size_t size, void *parent);
 void *Mem_Malloc(size_t size);
 void *Mem_Realloc(void *p, size_t size);
-void *Mem_Link(void *parent, void *child);
+void *Mem_Link(void *child, void *parent);
 size_t Mem_Size(void);
 char *Mem_TagCopyString(const char *in, mem_tag_t tag);
 char *Mem_CopyString(const char *in);


### PR DESCRIPTION
`src/common/mem.h` declared `Mem_Link(void *parent, void *child)` while `src/common/mem.c` defines `Mem_Link(void *child, void *parent)`, and the body treats its first argument as the child. Both parameters are `void *`, so the compiler compared the types, found them identical, and said nothing.

**Nothing is broken.** All twenty-two callers pass `(child, parent)`, matching the definition:

```c
cmd->name  = Mem_Link(Mem_TagCopyString(name, MEM_TAG_CMD), cmd);   // cmd.c
var->string = Mem_Link(Mem_TagCopyString(value, MEM_TAG_CVAR), var); // cvar.c
```

`check_mem.c`'s assertions agree — `Mem_Link(child, parent2)` under the comment "Reparent child to parent2", after which freeing `parent1` does *not* free the child and freeing `parent2` does. And the function returns `child`, for the `x = Mem_Link(x, parent)` idiom.

So only the declaration was wrong. This changes the header rather than the call sites, and no behaviour changes — the diff is one line, and the definition is untouched.

Found while reviewing #936, where the same hazard bit a `const char *`/`const char *` reorder: a declaration and definition disagreeing on the order of two same-typed parameters compiles cleanly and silently does the wrong thing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)