### PR TITLE
Tune func_bob curve/timing, add trigger_push start_off/toggle

### DIFF
--- a/src/game/common/g_entity_func.c
+++ b/src/game/common/g_entity_func.c
@@ -699,15 +699,22 @@ static void G_func_bob_Bottom(g_entity_t *ent);
 static void G_func_bob_Ease(g_entity_t *ent) {
   g_move_info_t *move = &ent->move_info;
 
+  const float total_distance = Vec3_Distance(move->start_origin, move->end_origin);
+
   vec3_t dir;
   const float remaining = Vec3_DistanceDir(move->dest, ent->s.origin, &dir);
 
-  if (remaining <= .25f || Vec3_Dot(dir, move->dir) < 0.f) {
+  // G_MoveInfo_Linear_Done snaps position exactly to `dest`, so this threshold is the size of
+  // that final pop. A fixed .25 units is invisible on a long mover but reads as a visible jump
+  // on a short leg (e.g. .25 is ~3% of an 8-unit travel) - scale it down for short legs instead,
+  // capped at the old constant so long legs keep the same tolerance as before.
+  const float arrival_epsilon = Clampf(total_distance * .01f, .01f, .25f);
+
+  if (remaining <= arrival_epsilon || Vec3_Dot(dir, move->dir) < 0.f) {
     G_MoveInfo_Linear_Done(ent);
     return;
   }
 
-  const float total_distance = Vec3_Distance(move->start_origin, move->end_origin);
   const float traveled = total_distance - remaining;
 
   const float t = traveled / total_distance;
@@ -807,13 +814,18 @@ static void G_func_bob_Use(g_entity_t *ent, g_entity_t *other, g_entity_t *activ
  velocity : The direction and distance to travel from the spawn origin, e.g. "0 0 32".
  speed : The peak speed reached at the midpoint of travel (default 100). Motion eases from 0 up
          to this and back down to 0 at each end, like a pendulum or a floating object bobbing.
- compression : Shapes the ease curve (default 1, pure sine). Greater than 1 narrows the peak and
-               adds "hang time" at each end; less than 1 flattens/widens the peak.
+ compression : Shapes the ease curve. Greater than 1 narrows the peak and adds "hang time" at each
+               end; less than 1 flattens/widens the peak. If unset, auto-derived from how long the
+               leg takes to traverse (velocity's distance divided by speed) so legs far from a ~1
+               second sweet spot in either direction - too short (stutters) or too long (a slow
+               crawl before the entity gets moving) - get a flatter curve instead of always
+               defaulting to a pure sine; set explicitly to override.
  wait : Seconds to pause at each end before reversing (default 0, i.e. continuous bobbing).
- drift : Multiplier (default 1) on the entity's own natural cycle length, used to pick a random
-         startup delay so multiple func_bobs with identical keys don't move in lockstep. 1 spans
-         one full cycle (complete phase coverage); raise it for extra margin, lower it to allow
-         more visible clustering.
+ drift : Multiplier (default 0, i.e. no startup delay) on the entity's own natural cycle length,
+         used to pick a random startup delay so multiple func_bobs with identical keys don't move
+         in lockstep - set this on an array of identical func_bobs to desync them. 1 spans one
+         full cycle (complete phase coverage); raise it for extra margin, lower it to allow more
+         visible clustering.
  dmg : The damage inflicted on players who block the entity (default 2).
  sound : The looping sound to play while moving.
  targetname : The target name of this entity if it is to be triggered, to toggle it on or off.
@@ -839,11 +851,6 @@ void G_func_bob(g_entity_t *ent) {
     ent->speed = 100.0;
   }
 
-  // reuse the generic `random` field to cache the "compression" exponent, read once here rather
-  // than every tick in G_func_bob_Ease
-  const float compression = gi.EntityValue(ent->def, "compression")->value;
-  ent->random = compression > 0.f ? compression : 1.f;
-
   if (!ent->damage) {
     ent->damage = 2;
   }
@@ -851,8 +858,30 @@ void G_func_bob(g_entity_t *ent) {
   ent->pos1 = ent->s.origin;
   ent->pos2 = Vec3_Add(ent->pos1, gi.EntityValue(ent->def, "velocity")->vec3);
 
-  if (Vec3_Equal(ent->pos1, ent->pos2)) {
+  const float total_distance = Vec3_Distance(ent->pos1, ent->pos2);
+  if (total_distance == 0.f) {
     G_Warn("%s @ %s has no \"velocity\" and will not move\n", ent->classname, vtos(ent->s.origin));
+  }
+
+  // Average speed of a half-sine leg is (2/pi) * peak, giving leg_time = distance * pi / (2 * speed).
+  const float leg_time = total_distance > 0.f ? (total_distance * (float) M_PI) / (2.f * ent->speed) : 0.f;
+
+  // reuse the generic `random` field to cache the "compression" exponent, read once here rather
+  // than every tick in G_func_bob_Ease. If unset, auto-derive it from the leg's duration instead of
+  // defaulting to a flat 1 (pure sine): a full sine only reads right for a leg lasting roughly a
+  // second. Shorter legs (too few ticks to render the ease smoothly) and longer legs (the sine's
+  // slow "wings" become a disproportionate chunk of real time, e.g. a multi-second crawl before a
+  // platform gets moving) both want a flatter curve; a continuous falloff in log(leg_time) treats
+  // "half as long" and "twice as long" symmetrically, tapering toward a floor the farther the leg
+  // is from that ~1s sweet spot in either direction. Calibrated against two tested legs: ~1s
+  // (wants ~1.0) and ~7s (wants ~0.5) - solving for the width that fits both against a 0.35 floor.
+  // log(0) degrades gracefully to the floor for a zero-velocity leg, no special case needed.
+  const float compression = gi.EntityValue(ent->def, "compression")->value;
+  if (compression > 0.f) {
+    ent->random = compression;
+  } else {
+    const float z = logf(leg_time) / 1.61f;
+    ent->random = .35f + .65f * expf(-z * z);
   }
 
   ent->move_info.speed = ent->speed;
@@ -868,23 +897,23 @@ void G_func_bob(g_entity_t *ent) {
   gi.LinkEntity(ent);
 
   if (!(ent->spawn_flags & BOB_START_OFF)) {
-    // Stagger the initial phase across identical func_bobs so they don't move in lockstep.
+    // Stagger the initial phase across identical func_bobs so they don't move in lockstep, but
+    // only when the mapper opts in via "drift" - absent means a single (or non-array) func_bob
+    // starts moving immediately, same as every other func_* entity, rather than picking a hidden
+    // random delay across its own cycle by default.
+    //
     // A random startup delay only decorrelates phase if it spans a full cycle - a flat number
     // of seconds looks random for some speed/distance/wait combos and barely-desynced for
     // others, since the mapper has no easy way to know the entity's actual cycle length. So
-    // derive the window from the entity's own numbers: average speed of a half-sine leg is
-    // (2/pi) * peak, giving leg_time = distance * pi / (2 * speed); the full up-down-wait cycle
-    // is twice that plus twice the wait.
-    const float total_distance = Vec3_Distance(ent->pos1, ent->pos2);
-    const float leg_time = total_distance > 0.f ? (total_distance * (float) M_PI) / (2.f * ent->speed) : 0.f;
+    // derive the window from the entity's own numbers: the full up-down-wait cycle is twice
+    // the leg time (computed above, alongside the auto-compression derivation) plus twice the wait.
     const float cycle_time = 2.f * (leg_time + ent->wait);
 
-    const float drift = gi.EntityValue(ent->def, "drift")->value;
-    const float drift_scale = drift > 0.f ? drift : 1.f;
+    const float drift_scale = gi.EntityValue(ent->def, "drift")->value;
 
     ent->Think = G_func_bob_GoingUp;
     ent->next_think = g_level.time + QUETOO_TICK_MILLIS +
-                       (uint32_t) (RandomRangef(0.f, drift_scale * cycle_time) * 1000.f);
+                       (uint32_t) (RandomRangef(0.f, Maxf(drift_scale, 0.f) * cycle_time) * 1000.f);
   }
 }
 

--- a/src/game/common/g_entity_trigger.c
+++ b/src/game/common/g_entity_trigger.c
@@ -221,6 +221,8 @@ void G_trigger_always(g_entity_t *ent) {
 
 #define PUSH_ONCE 1
 #define PUSH_EFFECT 2
+#define PUSH_START_OFF 4
+#define PUSH_TOGGLE 8
 
 /**
  * @brief Handles touch events on a `trigger_push`, applying velocity to the touching entity.
@@ -251,6 +253,26 @@ static void G_trigger_push_Touch(g_entity_t *ent, g_entity_t *other, const cm_tr
 }
 
 /**
+ * @brief Handles use activation of a `trigger_push`, toggling its solidity on or off.
+ */
+static void G_trigger_push_Use(g_entity_t *ent, g_entity_t *other, g_entity_t *activator) {
+
+  if (ent->solid == SOLID_NOT) {
+    ent->solid = SOLID_TRIGGER;
+  } else {
+    ent->solid = SOLID_NOT;
+  }
+
+  gi.LinkEntity(ent);
+
+  G_Debug("%s is now %s\n", etos(ent), ent->solid == SOLID_NOT ? "off" : "on");
+
+  if (!(ent->spawn_flags & PUSH_TOGGLE)) {
+    ent->Use = NULL;
+  }
+}
+
+/**
  * @brief Creates an effect trail for the specified entity.
  */
 static void G_trigger_push_Effect(g_entity_t *ent) {
@@ -265,17 +287,20 @@ static void G_trigger_push_Effect(g_entity_t *ent) {
   gi.LinkEntity(effect);
 }
 
-/*QUAKED trigger_push (.5 .5 .5) ? push_once push_effects
+/*QUAKED trigger_push (.5 .5 .5) ? push_once push_effects start_off toggle
  Pushes the player in any direction. These are commonly used to make jump pads to send the player upwards. Using the angles key, you can project the player in any direction using "pitch yaw roll."
 
  -------- Keys --------
  angles : The direction to push the player in "pitch yaw roll" notation (e.g. -80 270 0).
  sound : The sound effect to play when the player is pushed (default "trigger/push").
  speed : The speed with which to push the player (default 100).
+ targetname : The target name of this entity, if it is to be triggered.
 
  -------- Spawn flags --------
  push_once : If set, the pusher is freed after it is used once.
  push_effects : If set, emit particle effects to indicate that a pusher is here.
+ start_off : If set, this entity must be activated before it will push players.
+ toggle : If set, this entity is toggled each time it is activated.
  */
 void G_trigger_push(g_entity_t *ent) {
 
@@ -292,6 +317,13 @@ void G_trigger_push(g_entity_t *ent) {
 
   if (!ent->speed) {
     ent->speed = 100;
+  }
+
+  if (ent->spawn_flags & (PUSH_START_OFF | PUSH_TOGGLE)) {
+    if (ent->spawn_flags & PUSH_START_OFF) {
+      ent->solid = SOLID_NOT;
+    }
+    ent->Use = G_trigger_push_Use;
   }
 
   gi.LinkEntity(ent);


### PR DESCRIPTION
## Summary

**func_bob** (follow-up tuning after #911):
- Scale the arrival-snap threshold to the leg's own travel distance (1% of distance, floored at `.01`, capped at the old flat `.25`) instead of a fixed `.25` units. `G_MoveInfo_Linear_Done` snaps position exactly to the destination once within this threshold, and a flat `.25` was a visible pop on short legs (e.g. ~3% of an 8-unit travel used for a shadow-sync bob).
- Auto-derive `compression` from the leg's duration when the key is unset, instead of always defaulting to a flat `1.0` (pure sine). Uses a continuous falloff in `log(leg_time)` that peaks at `1.0` for a leg around 1 second and tapers toward a `.35` floor for legs much shorter (too few ticks, stutters) or much longer (the sine's slow "wings" become a multi-second crawl before the entity visibly starts moving) than that. Calibrated against two tested legs (~1s and ~7s). Explicit `compression` keys still override.
- `drift` now defaults to `0` (no startup delay) instead of silently defaulting to a full-cycle random delay whenever unset - the old default caused multi-second startup delays on any `func_bob` that wasn't actually part of a desynced array. Negative values are clamped to `0` rather than risking undefined behavior in the float-to-`uint32_t` cast.

**trigger_push**:
- Adds `start_off` and `toggle` spawnflags so `trigger_push` can spawn inactive and be toggled on/off via `Use`, matching the pattern already used elsewhere (e.g. `func_bob`).

## Test plan
- [x] Builds clean (`game.vcxproj`)
- [x] Manually tested in-map: short-leg arrival snap, long-leg startup delay, auto-compression on both a small shadow-sync bob and a 448-unit platform
- [ ] `trigger_push` start_off/toggle behavior