### PR TITLE
Simulate and preview movers in the in-game editor

### DIFF
--- a/src/cgame/common/cg_editor.c
+++ b/src/cgame/common/cg_editor.c
@@ -100,6 +100,41 @@ static vec4_t Cg_AddEditorEntity_Light(cg_editor_entity_t *edit) {
 }
 
 /**
+ * @brief Resolves the transform from world space to the entity's model space, in which
+ * the BSP brushes of an entity with an origin are stored.
+ */
+static mat4_t Cg_EditorEntityInverseMatrix(const cg_editor_entity_t *edit) {
+
+  const cl_entity_t *ent = edit->ent;
+  const float scale = cgi.EntityValue(edit->def, "scale")->value ?: 1.f;
+
+  return Mat4_Inverse(Mat4_FromRotationTranslationScale(ent->angles, ent->origin, scale));
+}
+
+/**
+ * @brief Draws a brush wireframe in the entity's frame of reference.
+ * @details BSP brushes of an entity with an origin are stored in model space, so they
+ * must be transformed by the entity's matrix to be drawn where the entity is.
+ */
+static void Cg_DrawEditorBrush(const box3_t bounds, const mat4_t matrix, const color_t color) {
+  static const int32_t edges[] = {
+    0, 1, 1, 3, 3, 2, 2, 0,
+    4, 5, 5, 7, 7, 6, 6, 4,
+    0, 4, 1, 5, 2, 6, 3, 7
+  };
+
+  vec3_t points[8];
+  Box3_ToPoints(bounds, points);
+
+  vec3_t lines[lengthof(edges)];
+  for (size_t i = 0; i < lengthof(edges); i++) {
+    lines[i] = Mat4_Transform(matrix, points[edges[i]]);
+  }
+
+  cgi.Draw3DLines(SDL_GPU_PRIMITIVETYPE_LINELIST, lines, lengthof(lines), color, true);
+}
+
+/**
  * @brief Populates the view and sound stage for the given editor frame.
  */
 void Cg_PopulateEditorScene(const cl_frame_t *frame) {
@@ -111,6 +146,9 @@ void Cg_PopulateEditorScene(const cl_frame_t *frame) {
     cgi.Print("^5To move a selected entity, use W, A, S, D, E, C\n");
     cgi.Print("^5Use your normal hotkeys to cut, copy and paste entities\n");
     cgi.Print("^5To toggle func_group entities, use G\n");
+    cgi.Print("^5To activate a selected mover, use U\n");
+    cgi.Print("^5Movers are previewed with their real behavior; a func_train will\n");
+    cgi.Print("^5relocate to its first path_corner, as it does in game\n");
     cgi.Print("^6To select a material, place your crosshair over it and press ESC\n");
 
     did_print_help = true;
@@ -154,7 +192,7 @@ void Cg_PopulateEditorScene(const cl_frame_t *frame) {
     const bool is_selected = cg_editor.selected == edit->number;
 
     if (edit->brushes) {
-      cgi.AddEntity(cgi.view, &(const r_entity_t) {
+      const r_entity_t *e = cgi.AddEntity(cgi.view, &(const r_entity_t) {
         .id = edit,
         .origin = ent->origin,
         .angles = ent->angles,
@@ -166,15 +204,11 @@ void Cg_PopulateEditorScene(const cl_frame_t *frame) {
         .model = edit->model
       });
 
-      if (is_selected) {
+      if (is_selected || q_strcmp(classname, "worldspawn")) {
+        const color_t color = is_selected ? color_red : Color4fv(debug_color);
         for (uint32_t j = 0; j < edit->brushes->count; j++) {
           const cm_bsp_brush_t *brush = VectorValue(edit->brushes, cm_bsp_brush_t *, j);
-          cgi.Draw3DBox(brush->bounds, color_red, true);
-        }
-      } else if (q_strcmp(classname, "worldspawn")) {
-        for (uint32_t j = 0; j < edit->brushes->count; j++) {
-          const cm_bsp_brush_t *brush = VectorValue(edit->brushes, cm_bsp_brush_t *, j);
-          cgi.Draw3DBox(brush->bounds, Color4fv(debug_color), true);
+          Cg_DrawEditorBrush(brush->bounds, e->matrix, color);
         }
       }
 
@@ -397,10 +431,15 @@ cg_editor_trace_t Cg_EntitySelectionTrace(const vec3_t start, const vec3_t end) 
     }
 
     if (edit->brushes) {
+      const mat4_t inverse = Cg_EditorEntityInverseMatrix(edit);
+
+      const vec3_t model_start = Mat4_Transform(inverse, start);
+      const vec3_t model_end = Mat4_Transform(inverse, end);
+
       for (uint32_t j = 0; j < edit->brushes->count; j++) {
         const cm_bsp_brush_t *brush = VectorValue(edit->brushes, cm_bsp_brush_t *, j);
 
-        const cm_trace_t tr = cgi.TraceToBrush(start, end, brush);
+        const cm_trace_t tr = cgi.TraceToBrush(model_start, model_end, brush);
 
         if (tr.start_solid || tr.fraction >= out.trace.fraction) {
           continue;
@@ -408,6 +447,7 @@ cg_editor_trace_t Cg_EntitySelectionTrace(const vec3_t start, const vec3_t end) 
 
         out.ent = edit;
         out.trace = tr;
+        out.trace.end = Vec3_Mix(start, end, tr.fraction);
       }
     } else {
 
@@ -450,10 +490,15 @@ cg_editor_trace_t Cg_MaterialSelectionTrace(const vec3_t start, const vec3_t end
     }
 
     if (edit->brushes) {
+      const mat4_t inverse = Cg_EditorEntityInverseMatrix(edit);
+
+      const vec3_t model_start = Mat4_Transform(inverse, start);
+      const vec3_t model_end = Mat4_Transform(inverse, end);
+
       for (uint32_t j = 0; j < edit->brushes->count; j++) {
         const cm_bsp_brush_t *brush = VectorValue(edit->brushes, cm_bsp_brush_t *, j);
 
-        const cm_trace_t tr = cgi.TraceToBrush(start, end, brush);
+        const cm_trace_t tr = cgi.TraceToBrush(model_start, model_end, brush);
 
         if (tr.start_solid || tr.fraction >= out.trace.fraction) {
           continue;
@@ -461,6 +506,7 @@ cg_editor_trace_t Cg_MaterialSelectionTrace(const vec3_t start, const vec3_t end
 
         out.ent = edit;
         out.trace = tr;
+        out.trace.end = Vec3_Mix(start, end, tr.fraction);
       }
     } else if (IS_MESH_MODEL(edit->model)) {
 

--- a/src/cgame/common/ui/editor/EntityViewController.c
+++ b/src/cgame/common/ui/editor/EntityViewController.c
@@ -211,6 +211,10 @@ static void respondToKeyEvent(EntityViewController *self, const SDL_Event *event
       cgi.Print("func_group entities %s\n", self->show_func_groups ? "^2shown" : "^1hidden");
     }
 
+    if (key == SDLK_U && cgi.GetKeyDest() == KEY_UI && self->entity) {
+      cgi.Cbuf(va("editor_use %d\n", self->entity->number));
+    }
+
     if (cgi.GetKeyDest() == KEY_UI && e) {
 
       vec3_t move = Vec3_Zero();

--- a/src/collision/cm_entity.c
+++ b/src/collision/cm_entity.c
@@ -39,6 +39,9 @@ void Cm_FreeEntity(cm_entity_t *entity) {
 
   while (e) {
     next = e->next;
+    if (e->brushes) {
+      Mem_Free(e->brushes);
+    }
     Mem_Free(e);
     e = next;
   }

--- a/src/game/common/g_cmd.c
+++ b/src/game/common/g_cmd.c
@@ -666,6 +666,42 @@ static void G_Admin_f(g_client_t *cl) {
   }
 }
 
+/**
+ * @brief Fires the specified entity on behalf of the editor client, so that movers
+ * can be previewed without a functioning trigger.
+ */
+static void G_EditorUse_f(g_client_t *cl) {
+
+  if (!editor->value) {
+    return;
+  }
+
+  if (gi.Argc() != 2) {
+    gi.ClientPrint(cl, PRINT_HIGH, "Usage: editor_use <entity>\n");
+    return;
+  }
+
+  const int32_t number = atoi(gi.Argv(1));
+
+  if (number < 0 || number >= sv_max_entities->integer) {
+    gi.ClientPrint(cl, PRINT_HIGH, "Invalid entity %d\n", number);
+    return;
+  }
+
+  g_entity_t *ent = ge.entities[number];
+
+  if (!ent->in_use) {
+    gi.ClientPrint(cl, PRINT_HIGH, "Entity %d is not in use\n", number);
+    return;
+  }
+
+  if (ent->Use) {
+    ent->Use(ent, cl->entity, cl->entity);
+  } else {
+    G_UseTargets(ent, cl->entity);
+  }
+}
+
 #if defined(_DEBUG)
 void G_RecordPmove(void);
 void G_PlayPmove(void);
@@ -725,6 +761,8 @@ void G_ClientCommand(g_client_t *cl) {
     G_ClientChasePrevious(cl);
   } else if (q_strcmp(cmd, "chase_next") == 0) {
     G_ClientChaseNext(cl);
+  } else if (q_strcmp(cmd, "editor_use") == 0) {
+    G_EditorUse_f(cl);
   }
 #if defined(_DEBUG)
   else if (q_strcmp(cmd, "pmove_record") == 0) {

--- a/src/game/common/g_entity.c
+++ b/src/game/common/g_entity.c
@@ -114,14 +114,9 @@ static const cm_entity_t *G_MapValue(const char *key) {
 }
 
 /**
- * @brief Populates common entity fields and then dispatches the class initializer.
+ * @brief Populates the entity fields which are common to all classes from its definition.
  */
-static void G_SpawnEntity(cm_entity_t *def) {
-
-  const char *classname = gi.EntityValue(def, "classname")->string;
-  g_entity_t *ent = G_AllocEntity(classname);
-
-  ent->def = def;
+static void G_InitEntityFields(g_entity_t *ent) {
 
   ent->s.origin = gi.EntityValue(ent->def, "origin")->vec3;
   ent->s.angles = gi.EntityValue(ent->def, "angles")->vec3;
@@ -152,6 +147,19 @@ static void G_SpawnEntity(cm_entity_t *def) {
   ent->health = gi.EntityValue(ent->def, "health")->integer;
   ent->damage = gi.EntityValue(ent->def, "dmg")->integer;
   ent->mass = gi.EntityValue(ent->def, "mass")->value;
+}
+
+/**
+ * @brief Populates common entity fields and then dispatches the class initializer.
+ */
+static void G_SpawnEntity(cm_entity_t *def) {
+
+  const char *classname = gi.EntityValue(def, "classname")->string;
+  g_entity_t *ent = G_AllocEntity(classname);
+
+  ent->def = def;
+
+  G_InitEntityFields(ent);
 
   // check item spawn functions
   const g_item_t *it = G_FindItemByClassName(ent->classname);
@@ -173,6 +181,113 @@ static void G_SpawnEntity(cm_entity_t *def) {
   G_Warn("%s doesn't have a spawn function\n", etos(ent));
 
   G_FreeEntity(ent);
+}
+
+/**
+ * @brief The entity classes which are fully initialized in editor mode, so that
+ * their movement can be previewed. All other classes are left as inert editor
+ * placeholders.
+ */
+static const struct {
+  const char *classname;
+  bool inline_model;
+} g_editor_entity_classes[] = {
+
+  { "func_bob", true },
+  { "func_button", true },
+  { "func_conveyor", true },
+  { "func_door", true },
+  { "func_door_rotating", true },
+  { "func_door_secret", true },
+  { "func_plat", true },
+  { "func_rotating", true },
+  { "func_timer", false },
+  { "func_train", true },
+};
+
+/**
+ * @brief Resolves the class initializer to run for the given editor entity, or `NULL`
+ * if it should remain an inert placeholder.
+ */
+static const g_entity_class_t *G_EditorEntityClass(const g_entity_t *ent) {
+
+  for (size_t i = 0; i < lengthof(g_editor_entity_classes); i++) {
+
+    if (q_strcmp(g_editor_entity_classes[i].classname, ent->classname)) {
+      continue;
+    }
+
+    if (g_editor_entity_classes[i].inline_model) {
+      if (!ent->model || ent->model[0] != '*') {
+        G_Warn("%s has no inline model\n", etos(ent));
+        return NULL;
+      }
+    }
+
+    for (size_t j = 0; j < lengthof(g_entity_classes); j++) {
+      if (!q_strcmp(g_entity_classes[j].classname, ent->classname)) {
+        return g_entity_classes + j;
+      }
+    }
+
+    G_Error("%s has no spawn function\n", etos(ent));
+  }
+
+  return NULL;
+}
+
+/**
+ * @brief Frees the editor entity at the given number, as well as any entities it owns.
+ * @details Movers such as doors and platforms allocate their own proximity triggers,
+ * which must not outlive them.
+ */
+void G_FreeEditorEntity(int32_t number) {
+
+  g_entity_t *ent = ge.entities[number];
+
+  for (int32_t i = 0; i < sv_max_entities->integer; i++) {
+
+    g_entity_t *e = ge.entities[i];
+
+    if (e == ent || !e->in_use || e->client) {
+      continue;
+    }
+
+    if (e->owner == ent || e->enemy == ent) {
+      G_FreeEntity(e);
+    }
+  }
+
+  G_FreeEntity(ent);
+}
+
+/**
+ * @brief Spawns the editor entity at its BSP entity index, so that entity numbers
+ * and config string slots remain stable for the editor.
+ * @details Movers are fully initialized so that they can be previewed in motion.
+ * All other classes become inert placeholders, which the server configures for
+ * presentation in `Sv_ConfigureEditorEntity`.
+ */
+void G_SpawnEditorEntity(int32_t number, cm_entity_t *def) {
+
+  if (ge.entities[number]->in_use) {
+    G_FreeEditorEntity(number);
+  }
+
+  const char *classname = gi.EntityValue(def, "classname")->string;
+  g_entity_t *ent = G_AllocEntityAt(number, classname);
+
+  ent->def = def;
+
+  G_InitEntityFields(ent);
+
+  const g_entity_class_t *clazz = G_EditorEntityClass(ent);
+  if (clazz) {
+    clazz->Init(ent);
+  } else {
+    ent->solid = SOLID_EDITOR;
+    gi.LinkEntity(ent);
+  }
 }
 
 /**
@@ -482,7 +597,11 @@ void G_SpawnEntities(const char *name, const cm_entity_t *props, cm_entity_t *co
   G_InitMedia();
 
   for (size_t i = 0; i < num_entities; i++) {
-    G_SpawnEntity(entities[i]);
+    if (editor->value) {
+      G_SpawnEditorEntity((int32_t) i, entities[i]);
+    } else {
+      G_SpawnEntity(entities[i]);
+    }
   }
 
   G_InitEntityTeams();

--- a/src/game/common/g_entity.c
+++ b/src/game/common/g_entity.c
@@ -237,9 +237,11 @@ static const g_entity_class_t *G_EditorEntityClass(const g_entity_t *ent) {
 }
 
 /**
- * @brief Frees the editor entity at the given number, as well as any entities it owns.
+ * @brief Frees the editor entity at the given number, as well as any entities it owns
+ * or that share its definition.
  * @details Movers such as doors and platforms allocate their own proximity triggers,
- * which must not outlive them.
+ * which must not outlive them. `G_UseTargets` delay temporaries alias the firing
+ * entity's definition, which the server frees once this returns.
  */
 void G_FreeEditorEntity(int32_t number) {
 
@@ -253,7 +255,7 @@ void G_FreeEditorEntity(int32_t number) {
       continue;
     }
 
-    if (e->owner == ent || e->enemy == ent) {
+    if (e->owner == ent || e->enemy == ent || (ent->def && e->def == ent->def)) {
       G_FreeEntity(e);
     }
   }

--- a/src/game/common/g_entity.h
+++ b/src/game/common/g_entity.h
@@ -25,4 +25,6 @@
 
 #if defined(__G_LOCAL_H__)
 void G_SpawnEntities(const char *name, const cm_entity_t *props, cm_entity_t *const *entities, size_t num_entities);
+void G_SpawnEditorEntity(int32_t number, cm_entity_t *def);
+void G_FreeEditorEntity(int32_t number);
 #endif

--- a/src/game/common/g_main.c
+++ b/src/game/common/g_main.c
@@ -132,7 +132,6 @@ cvar_t *g_balance_supershotgun_refire;
 cvar_t *g_balance_supershotgun_spread_x;
 cvar_t *g_balance_supershotgun_spread_y;
 cvar_t *g_cheats;
-cvar_t *g_editor_simulate;
 cvar_t *g_frag_limit;
 cvar_t *g_friendly_fire;
 cvar_t *g_gameplay;
@@ -817,7 +816,7 @@ static void G_Frame(void) {
 
     if (ent->client) {
       G_ClientBeginFrame(ent->client);
-    } else if (!editor->value || g_editor_simulate->value) {
+    } else {
       G_RunEntity(ent);
     }
 
@@ -1028,8 +1027,6 @@ void G_Init(void) {
     "0"
 #endif
     , CVAR_SERVER_INFO, NULL);
-  g_editor_simulate = gi.AddCvar("g_editor_simulate", "1", 0,
-    "Runs entity physics and thinking in editor mode, so that movers can be previewed.");
   g_frag_limit = gi.AddCvar("g_frag_limit", "30", CVAR_SERVER_INFO, "The frag limit per level.");
   g_friendly_fire = gi.AddCvar("g_friendly_fire", "1", CVAR_SERVER_INFO, "Factor of how much damage can be dealt to teammates.");
   g_gameplay = gi.AddCvar("g_gameplay", "default", CVAR_SERVER_INFO,

--- a/src/game/common/g_main.c
+++ b/src/game/common/g_main.c
@@ -132,6 +132,7 @@ cvar_t *g_balance_supershotgun_refire;
 cvar_t *g_balance_supershotgun_spread_x;
 cvar_t *g_balance_supershotgun_spread_y;
 cvar_t *g_cheats;
+cvar_t *g_editor_simulate;
 cvar_t *g_frag_limit;
 cvar_t *g_friendly_fire;
 cvar_t *g_gameplay;
@@ -816,7 +817,7 @@ static void G_Frame(void) {
 
     if (ent->client) {
       G_ClientBeginFrame(ent->client);
-    } else {
+    } else if (!editor->value || g_editor_simulate->value) {
       G_RunEntity(ent);
     }
 
@@ -1027,6 +1028,8 @@ void G_Init(void) {
     "0"
 #endif
     , CVAR_SERVER_INFO, NULL);
+  g_editor_simulate = gi.AddCvar("g_editor_simulate", "1", 0,
+    "Runs entity physics and thinking in editor mode, so that movers can be previewed.");
   g_frag_limit = gi.AddCvar("g_frag_limit", "30", CVAR_SERVER_INFO, "The frag limit per level.");
   g_friendly_fire = gi.AddCvar("g_friendly_fire", "1", CVAR_SERVER_INFO, "Factor of how much damage can be dealt to teammates.");
   g_gameplay = gi.AddCvar("g_gameplay", "default", CVAR_SERVER_INFO,
@@ -1171,6 +1174,8 @@ g_export_t *G_LoadGame(g_import_t *import) {
   ge.Init = G_Init;
   ge.Shutdown = G_Shutdown;
   ge.SpawnEntities = G_SpawnEntities;
+  ge.SpawnEditorEntity = G_SpawnEditorEntity;
+  ge.FreeEditorEntity = G_FreeEditorEntity;
   ge.ClientThink = G_ClientThink;
   ge.ClientConnect = G_ClientConnect;
   ge.ClientUserInfoChanged = G_ClientUserInfoChanged;

--- a/src/game/common/g_main.h
+++ b/src/game/common/g_main.h
@@ -149,7 +149,6 @@ extern cvar_t *g_balance_supershotgun_refire;
 extern cvar_t *g_balance_supershotgun_spread_x;
 extern cvar_t *g_balance_supershotgun_spread_y;
 extern cvar_t *g_cheats;
-extern cvar_t *g_editor_simulate;
 extern cvar_t *g_frag_limit;
 extern cvar_t *g_friendly_fire;
 extern cvar_t *g_gameplay;

--- a/src/game/common/g_main.h
+++ b/src/game/common/g_main.h
@@ -149,6 +149,7 @@ extern cvar_t *g_balance_supershotgun_refire;
 extern cvar_t *g_balance_supershotgun_spread_x;
 extern cvar_t *g_balance_supershotgun_spread_y;
 extern cvar_t *g_cheats;
+extern cvar_t *g_editor_simulate;
 extern cvar_t *g_frag_limit;
 extern cvar_t *g_friendly_fire;
 extern cvar_t *g_gameplay;

--- a/src/game/common/g_util.c
+++ b/src/game/common/g_util.c
@@ -318,11 +318,11 @@ void G_SetMoveDir(g_entity_t *ent) {
 g_entity_t *G_AllocEntityAt(int32_t number, const char *classname) {
   static uint8_t g_spawn_id;
 
-if (number < 0 || number >= sv_max_entities->integer) {
-  G_Error("Entity %d out of range (sv_max_entities=%d)\n", number, sv_max_entities->integer);
-}
+  if (number < 0 || number >= sv_max_entities->integer) {
+    G_Error("Entity %d out of range (sv_max_entities=%d)\n", number, sv_max_entities->integer);
+  }
 
-g_entity_t *e = ge.entities[number];
+  g_entity_t *e = ge.entities[number];
 
   if (e->in_use) {
     G_Error("Entity %d is already in use: %s\n", number, etos(e));

--- a/src/game/common/g_util.c
+++ b/src/game/common/g_util.c
@@ -313,24 +313,36 @@ void G_SetMoveDir(g_entity_t *ent) {
 }
 
 /**
+ * @brief Allocates the entity at the specified index, which must be free.
+ */
+g_entity_t *G_AllocEntityAt(int32_t number, const char *classname) {
+  static uint8_t g_spawn_id;
+
+  g_entity_t *e = ge.entities[number];
+
+  if (e->in_use) {
+    G_Error("Entity %d is already in use: %s\n", number, etos(e));
+  }
+
+  e->classname = classname;
+  e->in_use = true;
+  e->water_level = WATER_UNKNOWN;
+  e->timestamp = g_level.time;
+  e->s.number = number;
+  e->s.spawn_id = g_spawn_id++;
+
+  return e;
+}
+
+/**
  * @brief Allocates an entity for use.
  */
 g_entity_t *G_AllocEntity(const char *classname) {
-  static uint8_t g_spawn_id;
 
   for (int32_t i = 0; i < sv_max_entities->integer; i++) {
 
-    g_entity_t *e = ge.entities[i];
-    if (!e->in_use) {
-
-      e->classname = classname;
-      e->in_use = true;
-      e->water_level = WATER_UNKNOWN;
-      e->timestamp = g_level.time;
-      e->s.number = i;
-      e->s.spawn_id = g_spawn_id++;
-
-      return e;
+    if (!ge.entities[i]->in_use) {
+      return G_AllocEntityAt(i, classname);
     }
   }
 

--- a/src/game/common/g_util.c
+++ b/src/game/common/g_util.c
@@ -318,7 +318,11 @@ void G_SetMoveDir(g_entity_t *ent) {
 g_entity_t *G_AllocEntityAt(int32_t number, const char *classname) {
   static uint8_t g_spawn_id;
 
-  g_entity_t *e = ge.entities[number];
+if (number < 0 || number >= sv_max_entities->integer) {
+  G_Error("Entity %d out of range (sv_max_entities=%d)\n", number, sv_max_entities->integer);
+}
+
+g_entity_t *e = ge.entities[number];
 
   if (e->in_use) {
     G_Error("Entity %d is already in use: %s\n", number, etos(e));

--- a/src/game/common/g_util.h
+++ b/src/game/common/g_util.h
@@ -51,6 +51,7 @@ bool G_IsSky(const cm_trace_t *trace);
 void G_SetAnimation(g_client_t *cl, entity_animation_t anim, bool restart);
 bool G_IsAnimation(g_client_t *cl, entity_animation_t anim);
 g_entity_t *G_AllocEntity(const char *classname);
+g_entity_t *G_AllocEntityAt(int32_t number, const char *classname);
 void G_FreeEntity(g_entity_t *ent);
 void G_TeamCenterPrint(const g_team_t *team, const char *fmt, ...) __attribute__((format(printf, 2, 3)));
 

--- a/src/game/game.h
+++ b/src/game/game.h
@@ -25,7 +25,7 @@
 #include "collision/cm_types.h"
 #include <Objectively/Vector.h>
 
-#define GAME_API_VERSION 32
+#define GAME_API_VERSION 33
 
 /**
  * @brief Server flags for `g_entity_t`.
@@ -728,6 +728,18 @@ typedef struct g_export_s {
    * @param name The map name, e.g. "edge"
    */
   void (*SpawnEntities)(const char *name, const cm_entity_t *props, cm_entity_t *const *entities, size_t num_entities);
+
+  /**
+   * @brief Called in editor mode to spawn or respawn a single entity at the given
+   * entity number, taking ownership of `def`.
+   */
+  void (*SpawnEditorEntity)(int32_t number, cm_entity_t *def);
+
+  /**
+   * @brief Called in editor mode to free the entity at the given entity number,
+   * as well as any entities it owns.
+   */
+  void (*FreeEditorEntity)(int32_t number);
 
   /**
    * @brief Called when a client connects with valid user info; return false to reject.

--- a/src/server/sv_editor.c
+++ b/src/server/sv_editor.c
@@ -99,13 +99,23 @@ void Sv_EditEditorEntity(int32_t number, const char *info) {
 
   cm_entity_t *def = Cm_EntityFromInfoString(info);
 
+  if (!def) {
+    Com_Warn("Invalid entity info string for %d\n", number);
+    return;
+  }
+
   if (number > -1) {
     g_entity_t *entity = sv.entities[number].gent;
     cm_entity_t *ent = (cm_entity_t *) entity->def;
-    def->brushes = ent->brushes;
-    ent->brushes = NULL;
+
+    if (ent) {
+      def->brushes = ent->brushes;
+      ent->brushes = NULL;
+    }
+
+    svs.game->FreeEditorEntity(number);
+
     Cm_FreeEntity(ent);
-    entity->def = NULL;
   } else {
     for (int32_t i = Cm_Bsp()->num_entities; i < sv_max_entities->integer; i++) {
       if (sv.entities[i].gent->in_use == false) {
@@ -121,22 +131,23 @@ void Sv_EditEditorEntity(int32_t number, const char *info) {
     }
   }
 
-if (!def) {
-  Com_Warn("Invalid entity info string for %d\n", number);
-  return;
-}
+  svs.game->SpawnEditorEntity(number, def);
 
-svs.game->SpawnEditorEntity(number, def);
-
-Sv_ConfigureEditorEntity(number);
+  Sv_ConfigureEditorEntity(number);
 }
 
 /**
  * @brief Removes an editor entity from the world and clears its config string slot.
+ * @details The definition is server owned, so it is freed here, after the game module
+ * has torn down every entity referencing it.
  */
 void Sv_FreeEditorEntity(int32_t number) {
 
+  cm_entity_t *def = (cm_entity_t *) sv.entities[number].gent->def;
+
   svs.game->FreeEditorEntity(number);
+
+  Cm_FreeEntity(def);
 
   Sv_SetConfigString(CS_ENTITIES + number, "");
 }

--- a/src/server/sv_editor.c
+++ b/src/server/sv_editor.c
@@ -22,30 +22,26 @@
 #include "sv_local.h"
 
 /**
- * @brief Spawn an editor entity; a non-functional bounding box.
+ * @brief Applies editor presentation to the entity the game module spawned, and
+ * publishes its definition to the client.
+ * @details Entities the game left as `SOLID_EDITOR` are non-functional bounding
+ * boxes, and are sized here. Movers are fully initialized by the game module, and
+ * keep the bounds and solidity it gave them.
  */
-void Sv_SpawnEditorEntity(int32_t number, cm_entity_t *def) {
+void Sv_ConfigureEditorEntity(int32_t number) {
 
   g_entity_t *ent = sv.entities[number].gent;
 
-  ent->def = Cm_CopyEntity(def);
-  ent->in_use = true;
-  ent->classname = Cm_EntityValue(ent->def, "classname")->string;
-  ent->bounds = Box3_FromCenterRadius(Vec3_Zero(), 8.f);
-  ent->solid = SOLID_EDITOR;
+  if (!ent->in_use) {
+    return;
+  }
 
-  ent->s.number = number;
-  ent->s.origin = Cm_EntityValue(ent->def, "origin")->vec3;
-  ent->s.angles = Cm_EntityValue(ent->def, "angles")->vec3;
   ent->s.color = Color32i(0xffffffff);
 
   if (!q_strcmp(ent->classname, "worldspawn")) {
     ent->s.effects = EF_WORLD;
   } else if (!q_strncmp(ent->classname, "info_player", q_strlen("info_player"))) {
-    ent->bounds = Box3(Vec3(-16.f, -16.f, -24.f), Vec3(16.f, 16.f, 36.f));
     ent->s.color = Color32i(0xffff00ff);
-  } else if (!q_strncmp(ent->classname, "light", q_strlen("light"))) {
-    ent->bounds = Box3_FromCenterRadius(Vec3_Zero(), 4.f);
   } else if (!q_strncmp(ent->classname, "trigger_", q_strlen("trigger_"))) {
     ent->s.color = Color32i(0xff0088ff);
   } else if (!q_strncmp(ent->classname, "func_", q_strlen("func_"))) {
@@ -56,27 +52,38 @@ void Sv_SpawnEditorEntity(int32_t number, cm_entity_t *def) {
     ent->s.color = Color32i(0xffffff00);
   }
 
-  // use the BSP inline model to set bounds
-  const char *model = Cm_EntityValue(ent->def, "model")->string;
-  if (*model == '*') {
-    const cm_bsp_model_t *mod = Cm_Model(model);
-    ent->bounds = mod->bounds;
-  } else {
-    // entity may have brushes without an inline model (e.g. misc_dust, brushes merged into worldspawn)
-    // brush->entity always points to the original Cm_Bsp() entity; def may be a re-parsed copy after edits
-    const cm_entity_t *bsp_def = number < Cm_Bsp()->num_entities ? Cm_Bsp()->entities[number] : def;
-    Vector *brushes = Cm_EntityBrushes(bsp_def);
-    if (brushes->count) {
-      ent->bounds = Box3_Null();
-      for (uint32_t j = 0; j < brushes->count; j++) {
-        const cm_bsp_brush_t *brush = VectorValue(brushes, cm_bsp_brush_t *, j);
-        ent->bounds = Box3_Union(ent->bounds, brush->bounds);
-      }
-    }
-    release(brushes);
-  }
+  if (ent->solid == SOLID_EDITOR) {
 
-  Sv_LinkEntity(ent);
+    ent->bounds = Box3_FromCenterRadius(Vec3_Zero(), 8.f);
+
+    if (!q_strncmp(ent->classname, "info_player", q_strlen("info_player"))) {
+      ent->bounds = Box3(Vec3(-16.f, -16.f, -24.f), Vec3(16.f, 16.f, 36.f));
+    } else if (!q_strncmp(ent->classname, "light", q_strlen("light"))) {
+      ent->bounds = Box3_FromCenterRadius(Vec3_Zero(), 4.f);
+    }
+
+    // use the BSP inline model to set bounds
+    const char *model = Cm_EntityValue(ent->def, "model")->string;
+    if (*model == '*') {
+      const cm_bsp_model_t *mod = Cm_Model(model);
+      ent->bounds = mod->bounds;
+    } else {
+      // entity may have brushes without an inline model (e.g. misc_dust, brushes merged into worldspawn)
+      // brush->entity always points to the original Cm_Bsp() entity; def may be a re-parsed copy after edits
+      const cm_entity_t *bsp_def = number < Cm_Bsp()->num_entities ? Cm_Bsp()->entities[number] : ent->def;
+      Vector *brushes = Cm_EntityBrushes(bsp_def);
+      if (brushes->count) {
+        ent->bounds = Box3_Null();
+        for (uint32_t j = 0; j < brushes->count; j++) {
+          const cm_bsp_brush_t *brush = VectorValue(brushes, cm_bsp_brush_t *, j);
+          ent->bounds = Box3_Union(ent->bounds, brush->bounds);
+        }
+      }
+      release(brushes);
+    }
+
+    Sv_LinkEntity(ent);
+  }
 
   char *info = Cm_EntityToInfoString(ent->def);
 
@@ -98,6 +105,7 @@ void Sv_EditEditorEntity(int32_t number, const char *info) {
     def->brushes = ent->brushes;
     ent->brushes = NULL;
     Cm_FreeEntity(ent);
+    entity->def = NULL;
   } else {
     for (int32_t i = Cm_Bsp()->num_entities; i < sv_max_entities->integer; i++) {
       if (sv.entities[i].gent->in_use == false) {
@@ -113,7 +121,9 @@ void Sv_EditEditorEntity(int32_t number, const char *info) {
     }
   }
 
-  Sv_SpawnEditorEntity(number, def);
+  svs.game->SpawnEditorEntity(number, def);
+
+  Sv_ConfigureEditorEntity(number);
 }
 
 /**
@@ -121,9 +131,7 @@ void Sv_EditEditorEntity(int32_t number, const char *info) {
  */
 void Sv_FreeEditorEntity(int32_t number) {
 
-  g_entity_t *entity = sv.entities[number].gent;
-
-  memset(entity, 0, sizeof(*entity));
+  svs.game->FreeEditorEntity(number);
 
   Sv_SetConfigString(CS_ENTITIES + number, "");
 }

--- a/src/server/sv_editor.c
+++ b/src/server/sv_editor.c
@@ -121,9 +121,14 @@ void Sv_EditEditorEntity(int32_t number, const char *info) {
     }
   }
 
-  svs.game->SpawnEditorEntity(number, def);
+if (!def) {
+  Com_Warn("Invalid entity info string for %d\n", number);
+  return;
+}
 
-  Sv_ConfigureEditorEntity(number);
+svs.game->SpawnEditorEntity(number, def);
+
+Sv_ConfigureEditorEntity(number);
 }
 
 /**

--- a/src/server/sv_editor.c
+++ b/src/server/sv_editor.c
@@ -177,13 +177,13 @@ void Sv_SaveEditorMap_f(void) {
   Fs_Print(file, "// Format: Quake3\n");
 
   int32_t entity_num = 0;
-  for (int32_t i = 0; i < MAX_ENTITIES; i++) {
+  for (int32_t i = 0; i < sv_max_entities->integer; i++) {
 
-    const g_entity_t *ent = sv.entities[i].gent;
-    if (!ent->in_use) {
+    if (!sv.config_strings[CS_ENTITIES + i][0]) {
       continue;
     }
 
+    const g_entity_t *ent = sv.entities[i].gent;
     if (!ent->def) {
       continue;
     }

--- a/src/server/sv_editor.h
+++ b/src/server/sv_editor.h
@@ -24,7 +24,7 @@
 #include "sv_types.h"
 
 #if defined(__SV_LOCAL_H__)
-void Sv_SpawnEditorEntity(int32_t number, cm_entity_t *def);
+void Sv_ConfigureEditorEntity(int32_t number);
 void Sv_EditEditorEntity(int32_t number, const char *info);
 void Sv_FreeEditorEntity(int32_t number);
 void Sv_LoadEditorMap(void);

--- a/src/server/sv_world.c
+++ b/src/server/sv_world.c
@@ -117,10 +117,19 @@ void Sv_SpawnEntities(const char *name, const cm_entity_t *props) {
   if (editor->value) {
     Sv_LoadEditorMap();
 
-    svs.game->SpawnEntities(name, props, NULL, 0);
+    const int32_t num_entities = Cm_Bsp()->num_entities;
 
-    for (int32_t i = 0; i < Cm_Bsp()->num_entities; i++) {
-      Sv_SpawnEditorEntity(i, Cm_Bsp()->entities[i]);
+    cm_entity_t **defs = Mem_TagMalloc(sizeof(cm_entity_t *) * num_entities, MEM_TAG_SERVER);
+    for (int32_t i = 0; i < num_entities; i++) {
+      defs[i] = Cm_CopyEntity(Cm_Bsp()->entities[i]);
+    }
+
+    svs.game->SpawnEntities(name, props, defs, num_entities);
+
+    Mem_Free(defs);
+
+    for (int32_t i = 0; i < num_entities; i++) {
+      Sv_ConfigureEditorEntity(i);
     }
   } else {
     svs.game->SpawnEntities(name, props, Cm_Bsp()->entities, Cm_Bsp()->num_entities);

--- a/src/server/sv_world.c
+++ b/src/server/sv_world.c
@@ -117,11 +117,12 @@ void Sv_SpawnEntities(const char *name, const cm_entity_t *props) {
   if (editor->value) {
     Sv_LoadEditorMap();
 
-const int32_t num_entities = Cm_Bsp()->num_entities;
+    const int32_t num_entities = Cm_Bsp()->num_entities;
 
-if (num_entities > sv_max_entities->integer) {
-  Com_Error(ERROR_DROP, "Map has %d entities but sv_max_entities is %d\n", num_entities, sv_max_entities->integer);
-}
+    if (num_entities > sv_max_entities->integer) {
+      Com_Error(ERROR_DROP, "Map has %d entities but sv_max_entities is %d\n",
+        num_entities, sv_max_entities->integer);
+    }
 
     cm_entity_t **defs = Mem_TagMalloc(sizeof(cm_entity_t *) * num_entities, MEM_TAG_SERVER);
     for (int32_t i = 0; i < num_entities; i++) {

--- a/src/server/sv_world.c
+++ b/src/server/sv_world.c
@@ -117,7 +117,11 @@ void Sv_SpawnEntities(const char *name, const cm_entity_t *props) {
   if (editor->value) {
     Sv_LoadEditorMap();
 
-    const int32_t num_entities = Cm_Bsp()->num_entities;
+const int32_t num_entities = Cm_Bsp()->num_entities;
+
+if (num_entities > sv_max_entities->integer) {
+  Com_Error(ERROR_DROP, "Map has %d entities but sv_max_entities is %d\n", num_entities, sv_max_entities->integer);
+}
 
     cm_entity_t **defs = Mem_TagMalloc(sizeof(cm_entity_t *) * num_entities, MEM_TAG_SERVER);
     for (int32_t i = 0; i < num_entities; i++) {


### PR DESCRIPTION
Closes #939.

Doors, plats, trains, buttons and the rest now move in the in-game editor, driven by the real game code rather than a client-side reimplementation.

## Approach

The impediment turned out to be narrower than the discussion on #939 assumed: `G_Frame` *is* called in editor mode, but in editor mode the game module was never given the map's entities. `Sv_SpawnEntities` called `SpawnEntities(name, props, NULL, 0)` and the server then hand-built inert `SOLID_EDITOR` placeholders straight into `svs.game->entities[]`, with no `move_type`, `Think`, `Use` or common fields — so `G_Frame` walked them and correctly did nothing.

So neither "bite the bullet on the whole game module" nor "fake it on the client": in editor mode every BSP entity is now spawned by the game module at its own entity index, and only a whitelist of mover classes gets its real `clazz->Init`. Everything else stays exactly the inert placeholder it is today, and the server still owns presentation only (colors, placeholder bounds, config strings, `.map` save).

Consequences of that split:

- **Targeting and teaming come for free.** `G_func_train_Next` and `G_InitEntityTeams` read only the common fields that `G_InitEntityFields` populates, so `path_corner`, `info_notnull` and door team slaves can stay placeholders.
- **Triggering stays explicit.** The editor client is a spectator with `solid = SOLID_NOT`, so touch triggers never fire — which is what we want while flying around a map. Movers are fired with a new `editor_use` command, bound to <kbd>U</kbd> on the selected entity.

Whitelisted: `func_bob`, `func_button`, `func_conveyor`, `func_door`, `func_door_rotating`, `func_door_secret`, `func_plat`, `func_rotating`, `func_timer`, `func_train`. Deliberately excluded: `worldspawn` (would start music and coerce gameplay), `func_wall`/`func_water` (static), and all `trigger_*`/`target_*`. Classes that need an inline model are only initialized when they have one, so a malformed `func_*` stays an inert box instead of tripping the `SOLID_BSP` assert in `Cl_Interpolate`.

`GAME_API_VERSION` is bumped to 33 for the two new `g_export_t` entries. No protocol change.

## Two bugs fixed along the way

**`save_editor_map` wrote duplicate entities** (first commit, deliberately separable). `G_UseTargets` allocates a delay temporary that copies `temp->def = ent->def`; the old `in_use && def` filter wrote those into the user's `.map`. Now filtered on the editor's `CS_ENTITIES` config string, which only authored map entities have. This became reachable the moment targeting started running, and it overwrites the user's source file, so it went in first.

**Brush wireframes and selection were drawn at the world origin.** `quemap` subtracts the origin from all brush planes for any entity with a non-zero `origin` key, so those BSP brushes are stored in model space — but `Cg_PopulateEditorScene` and both selection traces used `brush->bounds` untranslated. Confirmed on `gehenna`, whose `func_door_rotating` sits at `448 -1472 400` while its brush bounds are `(-184,-24,-112)..(152,24,56)`. Both now go through the entity's matrix, which fixes the offset, handles rotation, and keeps the wireframe on a mover as it moves.

## Verification

All three build systems' shared sources compile clean; `default`, `ctf` and `lithium` all build (`G_SpawnEditorEntity` lives in `src/game/common`).

Headless, over all 22 stock maps in editor mode:

- No warnings, errors or asserts on any map.
- Saved entity count equals the source `.map`'s entity count on all 22 — nothing dropped, nothing injected.
- Saved `.map` is byte-identical to what `main` writes (checked on `claustrophobopolis` and `abase`).
- Movers are live: baseline entity count goes 1 -> 30 on `claustrophobopolis`, 1 -> 16 on `warehouse`, 1 -> 14 on `abase`.

The duplicate-entity fix was confirmed load-bearing on `abase`, which has a `func_timer` with `delay 0.5` firing a relay. Sampling 30 saves per run:

| filter | result |
| --- | --- |
| old (`in_use && def`) | 363 entities, and **364 in ~16% of saves** |
| new (config string) | 363 entities, every save |

In game: movers move, doors open and close with sounds on <kbd>U</kbd>, live entity edits re-init cleanly, and the `func_door_rotating` wireframe and hitbox now sit on the door.

## Known limitation

Editing one door of a `team` chain re-initializes it without re-linking the team, so its siblings' `team_next` still points at it while its own chain is cleared. Editor-preview only, no crash: the edited door previews independently until the map is reloaded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

