### PR TITLE
Give func_train an origin brush, per-corner angles and speed

### DIFF
--- a/src/game/common/g_entity_func.c
+++ b/src/game/common/g_entity_func.c
@@ -2461,6 +2461,7 @@ again:
   if (speed != dest_speed) {
     G_MoveInfo_Linear_Init_Ramp(ent, dest, speed, dest_speed, G_func_train_Wait);
   } else {
+    ent->move_info.start_speed = dest_speed;
     ent->move_info.speed = dest_speed;
     G_MoveInfo_Linear_Init(ent, dest, G_func_train_Wait);
     G_MoveInfo_Angular_Lerp(ent, Vec3_Distance(dest, ent->move_info.start_origin), dest_speed);
@@ -2470,7 +2471,9 @@ again:
 }
 
 /**
- * @brief Resumes train movement toward the current target `path_corner` after a stop.
+ * @brief Resumes train movement toward the current target `path_corner` after a stop. A ramped leg
+ * picks up where it left off: the ramp is a function of how far along the leg we are, so retaining
+ * the leg's original `start_origin` is all it takes to resume at the speed we stopped at.
  */
 static void G_func_train_Resume(g_entity_t *ent) {
   g_entity_t *target;
@@ -2480,15 +2483,19 @@ static void G_func_train_Resume(g_entity_t *ent) {
 
   dest = Vec3_Add(target->s.origin, G_func_train_Offset(ent));
   ent->move_info.state = MOVE_STATE_TOP;
-  ent->move_info.start_origin = ent->s.origin;
   ent->move_info.end_origin = dest;
 
   ent->move_info.start_angles = ent->s.angles;
-  ent->move_info.speed = target->speed ? : ent->speed;
   ent->avelocity = Vec3_Zero();
 
-  G_MoveInfo_Linear_Init(ent, dest, G_func_train_Wait);
-  G_MoveInfo_Angular_Lerp(ent, Vec3_Distance(dest, ent->s.origin), ent->move_info.speed);
+  const float speed = ent->move_info.speed;
+
+  if (ent->move_info.start_speed != speed) {
+    G_MoveInfo_Linear_Init_Ramp(ent, dest, ent->move_info.start_speed, speed, G_func_train_Wait);
+  } else {
+    G_MoveInfo_Linear_Init(ent, dest, G_func_train_Wait);
+    G_MoveInfo_Angular_Lerp(ent, Vec3_Distance(dest, ent->s.origin), speed);
+  }
 
   ent->spawn_flags |= TRAIN_START_ON;
 }

--- a/src/game/common/g_entity_func.c
+++ b/src/game/common/g_entity_func.c
@@ -85,6 +85,8 @@ static void G_MoveInfo_Linear_Constant(g_entity_t *ent) {
   const float distance = Vec3_Distance(move->dest, ent->s.origin);
   move->const_frames = distance / move->speed * QUETOO_TICK_RATE;
 
+  move->current_speed = move->speed;
+
   ent->velocity = Vec3_Scale(move->dir, move->speed);
 
   ent->next_think = g_level.time + move->const_frames * QUETOO_TICK_MILLIS;
@@ -224,11 +226,50 @@ static void G_MoveInfo_Linear_Accelerate(g_entity_t *ent) {
 }
 
 /**
- * @brief Sets up movement for the specified entity. Both constant and
- * accelerative movements are initiated through this function. Animations are
- * also kicked off here.
+ * @brief The angular delta from `a` to `b`, per axis, taking the shortest arc. This matches the
+ * convention in `Vec3_MixEuler`, so the server's rotation follows the path the client renders.
  */
-static void G_MoveInfo_Linear_Init(g_entity_t *ent, const vec3_t dest, void (*Done)(g_entity_t *)) {
+static vec3_t G_MoveInfo_Angular_Delta(const vec3_t a, const vec3_t b) {
+
+  vec3_t delta = Vec3_Subtract(b, a);
+
+  for (size_t i = 0; i < 3; i++) {
+    delta.xyz[i] = fmodf(delta.xyz[i], 360.f);
+    if (delta.xyz[i] >= 180.f) {
+      delta.xyz[i] -= 360.f;
+    } else if (delta.xyz[i] <= -180.f) {
+      delta.xyz[i] += 360.f;
+    }
+  }
+
+  return delta;
+}
+
+/**
+ * @brief Solves the angular velocity that lands the entity on `move_info.end_angles` exactly as it
+ * covers the remaining `distance` of its move at `speed`. Because this is derived from the speed the
+ * entity is travelling *right now*, it is safe to call each tick of a ramped move, whose duration is
+ * not simply distance over speed.
+ */
+static void G_MoveInfo_Angular_Lerp(g_entity_t *ent, float distance, float speed) {
+  g_move_info_t *move = &ent->move_info;
+
+  if (Vec3_Equal(move->start_angles, move->end_angles)) {
+    return;
+  }
+
+  const float time = Maxf(distance / Maxf(speed, 1.f), QUETOO_TICK_SECONDS);
+
+  const vec3_t delta = G_MoveInfo_Angular_Delta(ent->s.angles, move->end_angles);
+
+  ent->avelocity = Vec3_Scale(delta, 1.f / time);
+}
+
+/**
+ * @brief Resets velocity and resolves the direction of travel towards `dest`, common to all
+ * linear movement.
+ */
+static void G_MoveInfo_Linear_Setup(g_entity_t *ent, const vec3_t dest, void (*Done)(g_entity_t *)) {
   g_move_info_t *move = &ent->move_info;
 
   ent->velocity = Vec3_Zero();
@@ -239,6 +280,61 @@ static void G_MoveInfo_Linear_Init(g_entity_t *ent, const vec3_t dest, void (*Do
   move->dir = Vec3_Normalize(move->dir);
 
   move->Done = Done;
+}
+
+/**
+ * @brief Mixes speed from `move_info.start_speed` to `move_info.speed` as a function of the
+ * distance covered, which is what a mapper means by a mover that speeds up over its run.
+ */
+static void G_MoveInfo_Linear_Ramp(g_entity_t *ent) {
+  g_move_info_t *move = &ent->move_info;
+
+  const float distance = Vec3_Distance(move->dest, ent->s.origin);
+  const float total = Vec3_Distance(move->end_origin, move->start_origin);
+
+  const float frac = total > 0.f ? Clampf01(1.f - distance / total) : 1.f;
+
+  move->current_speed = Mixf(move->start_speed, move->speed, frac);
+
+  ent->velocity = Vec3_Scale(move->dir, move->current_speed);
+
+  G_MoveInfo_Angular_Lerp(ent, distance, move->current_speed);
+
+  if (distance <= move->current_speed * QUETOO_TICK_SECONDS) {
+    ent->Think = G_MoveInfo_Linear_Final;
+  } else {
+    ent->Think = G_MoveInfo_Linear_Ramp;
+  }
+
+  ent->next_think = g_level.time + QUETOO_TICK_MILLIS;
+}
+
+/**
+ * @brief Sets up a move that ramps linearly from `speed_start` to `speed_end` over its length. The
+ * caller must have set `move_info.start_origin` and `end_origin`, from which the ramp resolves how
+ * far along the move the entity is.
+ */
+static void G_MoveInfo_Linear_Init_Ramp(g_entity_t *ent, const vec3_t dest, float speed_start,
+                                        float speed_end, void (*Done)(g_entity_t *)) {
+  g_move_info_t *move = &ent->move_info;
+
+  G_MoveInfo_Linear_Setup(ent, dest, Done);
+
+  move->start_speed = Maxf(speed_start, 1.f);
+  move->speed = Maxf(speed_end, 1.f);
+
+  G_MoveInfo_Linear_Ramp(ent);
+}
+
+/**
+ * @brief Sets up movement for the specified entity. Both constant and
+ * accelerative movements are initiated through this function. Animations are
+ * also kicked off here.
+ */
+static void G_MoveInfo_Linear_Init(g_entity_t *ent, const vec3_t dest, void (*Done)(g_entity_t *)) {
+  g_move_info_t *move = &ent->move_info;
+
+  G_MoveInfo_Linear_Setup(ent, dest, Done);
 
   if (move->accel == 0.0 && move->decel == 0.0) { // constant
     const g_entity_t *master = (ent->flags & FL_TEAM_SLAVE) ? ent->team_master : ent;
@@ -2154,12 +2250,63 @@ void G_func_water(g_entity_t *ent) {
 #define TRAIN_TOGGLE    2
 #define TRAIN_BLOCK_STOPS  4
 
+#define PATH_CORNER_TELEPORT  1
+#define PATH_CORNER_SILENT    2
+
 static void G_func_train_Next(g_entity_t *ent);
+
+/**
+ * @brief Trains built around a `common/origin` brush are positioned by that origin, which is also
+ * the point they rotate about. Trains without one are positioned by their lower bounding corner,
+ * as they always have been.
+ */
+static bool G_func_train_HasOrigin(const g_entity_t *ent) {
+
+  const cm_entity_t *origin = gi.EntityValue(ent->def, "origin");
+
+  return (origin->parsed & ENTITY_VEC3) && !Vec3_Equal(origin->vec3, Vec3_Zero());
+}
+
+/**
+ * @brief The offset from a `path_corner`'s origin to the train's own origin.
+ */
+static vec3_t G_func_train_Offset(const g_entity_t *ent) {
+
+  return G_func_train_HasOrigin(ent) ? Vec3_Zero() : Vec3_Negate(ent->bounds.mins);
+}
+
+/**
+ * @brief Resolves the angles a train should hold on arriving at `corner`, defaulting to its
+ * current angles when the corner specifies none. Rotation requires an origin brush to pivot
+ * about, so it is ignored for legacy trains.
+ */
+static vec3_t G_func_train_Angles(const g_entity_t *ent, const g_entity_t *corner) {
+
+  const bool has_angles = gi.EntityValue(corner->def, "angles")->parsed & ENTITY_VEC3;
+  const bool has_angle = gi.EntityValue(corner->def, "angle")->parsed & ENTITY_FLOAT;
+
+  if (!has_angles && !has_angle) {
+    return ent->s.angles;
+  }
+
+  if (!G_func_train_HasOrigin(ent)) {
+    G_Debug("%s has angles but %s has no origin brush to rotate about\n", etos(corner), etos(ent));
+    return ent->s.angles;
+  }
+
+  return corner->s.angles;
+}
 
 /**
  * @brief Called when a train arrives at a `path_corner`, firing pathtargets and scheduling the next segment.
  */
 static void G_func_train_Wait(g_entity_t *ent) {
+
+  if (!Vec3_Equal(ent->s.angles, ent->move_info.end_angles)) {
+    ent->s.angles = ent->move_info.end_angles;
+    ent->avelocity = Vec3_Zero();
+    gi.LinkEntity(ent);
+  }
 
   const char *path_target = gi.EntityValue(ent->target_ent->def, "pathtarget")->nullable_string;
   if (path_target) {
@@ -2183,6 +2330,7 @@ static void G_func_train_Wait(g_entity_t *ent) {
       G_func_train_Next(ent);
       ent->spawn_flags &= ~TRAIN_START_ON;
       ent->velocity = Vec3_Zero();
+      ent->avelocity = Vec3_Zero();
       ent->next_think = 0;
     }
 
@@ -2223,19 +2371,26 @@ again:
   ent->target = target->target;
 
   // check for a teleport path_corner
-  if (target->spawn_flags & 1) {
+  if (target->spawn_flags & PATH_CORNER_TELEPORT) {
     if (!first) {
       G_Debug("%s has teleport path_corner %s\n", etos(ent), etos(target));
       return;
     }
     first = false;
-    ent->s.origin = Vec3_Subtract(target->s.origin, ent->bounds.mins);
-    if (!(target->spawn_flags & 2)) {
+    ent->s.origin = Vec3_Add(target->s.origin, G_func_train_Offset(ent));
+
+    ent->s.angles = G_func_train_Angles(ent, target);
+    ent->avelocity = Vec3_Zero();
+    ent->move_info.speed = target->speed ? : ent->speed;
+
+    if (!(target->spawn_flags & PATH_CORNER_SILENT)) {
       ent->s.event = EV_CLIENT_TELEPORT;
     }
     gi.LinkEntity(ent);
     goto again;
   }
+
+  const float speed = ent->move_info.speed;
 
   ent->move_info.wait = target->wait;
   ent->target_ent = target;
@@ -2250,11 +2405,25 @@ again:
     ent->s.sound = ent->move_info.sound_middle;
   }
 
-  dest = Vec3_Subtract(target->s.origin, ent->bounds.mins);
+  dest = Vec3_Add(target->s.origin, G_func_train_Offset(ent));
   ent->move_info.state = MOVE_STATE_TOP;
   ent->move_info.start_origin = ent->s.origin;
   ent->move_info.end_origin = dest;
-  G_MoveInfo_Linear_Init(ent, dest, G_func_train_Wait);
+
+  ent->move_info.start_angles = ent->s.angles;
+  ent->move_info.end_angles = G_func_train_Angles(ent, target);
+  ent->avelocity = Vec3_Zero();
+
+  const float dest_speed = target->speed ? : ent->speed;
+
+  if (speed != dest_speed) {
+    G_MoveInfo_Linear_Init_Ramp(ent, dest, speed, dest_speed, G_func_train_Wait);
+  } else {
+    ent->move_info.speed = dest_speed;
+    G_MoveInfo_Linear_Init(ent, dest, G_func_train_Wait);
+    G_MoveInfo_Angular_Lerp(ent, Vec3_Distance(dest, ent->move_info.start_origin), dest_speed);
+  }
+
   ent->spawn_flags |= TRAIN_START_ON;
 }
 
@@ -2267,11 +2436,18 @@ static void G_func_train_Resume(g_entity_t *ent) {
 
   target = ent->target_ent;
 
-  dest = Vec3_Subtract(target->s.origin, ent->bounds.mins);
+  dest = Vec3_Add(target->s.origin, G_func_train_Offset(ent));
   ent->move_info.state = MOVE_STATE_TOP;
   ent->move_info.start_origin = ent->s.origin;
   ent->move_info.end_origin = dest;
+
+  ent->move_info.start_angles = ent->s.angles;
+  ent->move_info.speed = target->speed ? : ent->speed;
+  ent->avelocity = Vec3_Zero();
+
   G_MoveInfo_Linear_Init(ent, dest, G_func_train_Wait);
+  G_MoveInfo_Angular_Lerp(ent, Vec3_Distance(dest, ent->s.origin), ent->move_info.speed);
+
   ent->spawn_flags |= TRAIN_START_ON;
 }
 
@@ -2292,7 +2468,13 @@ static void G_func_train_Find(g_entity_t *ent) {
   }
   ent->target = target->target;
 
-  ent->s.origin = Vec3_Subtract(target->s.origin, ent->bounds.mins);
+  ent->s.origin = Vec3_Add(target->s.origin, G_func_train_Offset(ent));
+
+  ent->s.angles = G_func_train_Angles(ent, target);
+  ent->move_info.start_angles = ent->s.angles;
+  ent->move_info.end_angles = ent->s.angles;
+  ent->move_info.speed = target->speed ? : ent->speed;
+
   gi.LinkEntity(ent);
 
   // if not triggered, start immediately
@@ -2320,6 +2502,7 @@ static void G_func_train_Use(g_entity_t *ent, g_entity_t *other,
     }
     ent->spawn_flags &= ~TRAIN_START_ON;
     ent->velocity = Vec3_Zero();
+    ent->avelocity = Vec3_Zero();
     ent->next_think = 0;
   } else {
     if (ent->target_ent) {
@@ -2331,25 +2514,52 @@ static void G_func_train_Use(g_entity_t *ent, g_entity_t *other,
 }
 
 /*QUAKED func_train (0 .5 .8) ? start_on toggle block_stops
- Trains are moving solids that players can ride along a series of path_corners. The origin of
- each corner specifies the lower bounding point of the train at that corner. If the train is
+ Trains are moving solids that players can ride along a series of path_corners. If the train is
  the target of a button or trigger, it will not begin moving until activated.
+
+ Trains are positioned one of two ways. Given a `common/origin` brush, the origin of each corner
+ specifies the train's own origin at that corner, and that origin is also the point the train
+ rotates about. Without one, the origin of each corner specifies the lower bounding point of the
+ train, and the train cannot rotate.
 
  -------- Keys --------
  speed : The speed with which the train moves (default 100).
  dmg : The damage inflicted on players who block the train (default 2).
  sound : The looping sound to play while the train is in motion.
+ angles : The initial orientation of the train. Requires an origin brush, and is overridden by
+ the angles of the first path_corner if it specifies any.
  targetname : The target name of this entity if it is to be triggered.
 
  -------- Spawn flags --------
  start_on : If set, the train will begin moving once spawned.
  toggle : If set, the train will start or stop each time it is activated.
  block_stops : When blocked, stop moving and inflict no damage.
+
+ -------- Path corner keys --------
+ wait : The time in seconds to wait at this corner before moving on.
+ speed : The speed the train travels at as it arrives here, mixed from the speed of the corner it
+ departed, so that a cart can pick up speed downhill and lose it climbing. Defaults to the train's
+ own speed. Because the client stops interpolating an entity that moves more than 60 units in a
+ single frame, speeds much above 2400 will render as a stutter rather than as motion.
+ angles : The orientation the train holds on arriving here, rotating into it over the length of
+ the leg. Requires the train to have an origin brush.
+ pathtarget : Fired when the train arrives here.
+ target : The next corner in the route. Point the last corner back at the first to loop.
+
+ -------- Path corner spawn flags --------
+ teleport : The train jumps to this corner rather than travelling to it, restoring the corner's
+ angles, and carries straight on to the corner's own target. Combine with a looping route to send
+ a train back to its start: flag the first corner `teleport` + `silent` and give the last corner
+ a `wait` and a `target` back to it. Riders are not carried through the jump, and the mapper is
+ responsible for hiding both corners from view.
+ silent : Suppress the teleport effect.
  */
 void G_func_train(g_entity_t *ent) {
   ent->move_type = MOVE_TYPE_PUSH;
 
-  ent->s.angles = Vec3_Zero();
+  if (!G_func_train_HasOrigin(ent)) {
+    ent->s.angles = Vec3_Zero();
+  }
 
   if (ent->spawn_flags & TRAIN_BLOCK_STOPS) {
     ent->damage = 0;

--- a/src/game/common/g_entity_func.c
+++ b/src/game/common/g_entity_func.c
@@ -258,7 +258,7 @@ static void G_MoveInfo_Angular_Lerp(g_entity_t *ent, float distance, float speed
     return;
   }
 
-  const float time = Maxf(distance / Maxf(speed, __FLT_EPSILON__), QUETOO_TICK_SECONDS);
+  const float time = Maxf(distance / Maxf(speed, FLT_EPSILON), QUETOO_TICK_SECONDS);
 
   const vec3_t delta = G_MoveInfo_Angular_Delta(ent->s.angles, move->end_angles);
 

--- a/src/game/common/g_entity_func.c
+++ b/src/game/common/g_entity_func.c
@@ -258,7 +258,7 @@ static void G_MoveInfo_Angular_Lerp(g_entity_t *ent, float distance, float speed
     return;
   }
 
-  const float time = Maxf(distance / Maxf(speed, 1.f), QUETOO_TICK_SECONDS);
+  const float time = Maxf(distance / Maxf(speed, __FLT_EPSILON__), QUETOO_TICK_SECONDS);
 
   const vec3_t delta = G_MoveInfo_Angular_Delta(ent->s.angles, move->end_angles);
 

--- a/src/game/common/g_entity_func.c
+++ b/src/game/common/g_entity_func.c
@@ -2576,6 +2576,7 @@ static void G_func_train_Use(g_entity_t *ent, g_entity_t *other,
  Angle a corner explicitly only where that is not what you want.
 
  -------- Keys --------
+ target : The first path_corner of the train's route. Required.
  speed : The speed with which the train moves (default 100).
  dmg : The damage inflicted on players who block the train (default 2).
  sound : The looping sound to play while the train is in motion.
@@ -2687,6 +2688,7 @@ static void G_func_timer_Use(g_entity_t *ent, g_entity_t *other,
  Time delay trigger that will continuously fire its targets after a preset time delay. The time delay can also be randomized. When triggered, the timer will toggle on/off.
 
  -------- Keys --------
+ target : The entities to fire on each tick of the timer.
  wait : Delay in seconds between each triggering of all targets (default 1).
  random : Random time variance in seconds added to "wait" delay (default 0).
  delay :  Additional delay before the first firing when start_on (default 0).

--- a/src/game/common/g_entity_func.c
+++ b/src/game/common/g_entity_func.c
@@ -2276,25 +2276,67 @@ static vec3_t G_func_train_Offset(const g_entity_t *ent) {
 }
 
 /**
- * @brief Resolves the angles a train should hold on arriving at `corner`, defaulting to its
- * current angles when the corner specifies none. Rotation requires an origin brush to pivot
- * about, so it is ignored for legacy trains.
+ * @brief Whether `corner` orients the train explicitly, by either key an editor might write for
+ * it: `angle` for the rotation widget, or `angles` for all three axes.
  */
-static vec3_t G_func_train_Angles(const g_entity_t *ent, const g_entity_t *corner) {
+static bool G_path_corner_HasAngles(const g_entity_t *corner) {
 
-  const bool has_angles = gi.EntityValue(corner->def, "angles")->parsed & ENTITY_VEC3;
-  const bool has_angle = gi.EntityValue(corner->def, "angle")->parsed & ENTITY_FLOAT;
+  return (gi.EntityValue(corner->def, "angles")->parsed & ENTITY_VEC3) ||
+         (gi.EntityValue(corner->def, "angle")->parsed & ENTITY_FLOAT);
+}
 
-  if (!has_angles && !has_angle) {
-    return ent->s.angles;
-  }
+/**
+ * @brief The angles that face a train travelling from `from` towards `to`, or its current angles
+ * if the two coincide and there is no direction to face.
+ */
+static vec3_t G_func_train_AnglesForLeg(const g_entity_t *ent, const vec3_t from, const vec3_t to) {
+
+  const vec3_t dir = Vec3_Subtract(to, from);
+
+  return Vec3_Equal(dir, Vec3_Zero()) ? ent->s.angles : Vec3_Euler(dir);
+}
+
+/**
+ * @brief The angles a train holds on arriving at `corner` from `from`. A corner that orients the
+ * train explicitly wins; otherwise the train faces the leg it just travelled, so that a cart
+ * follows its rails without the mapper angling every corner by hand. Rotation pivots about the
+ * train's origin, so it requires an origin brush and is skipped for legacy trains.
+ */
+static vec3_t G_func_train_Angles(const g_entity_t *ent, const g_entity_t *corner, const vec3_t from) {
 
   if (!G_func_train_HasOrigin(ent)) {
-    G_Debug("%s has angles but %s has no origin brush to rotate about\n", etos(corner), etos(ent));
+    if (G_path_corner_HasAngles(corner)) {
+      G_Debug("%s has angles but %s has no origin brush to rotate about\n", etos(corner), etos(ent));
+    }
     return ent->s.angles;
   }
 
-  return corner->s.angles;
+  if (G_path_corner_HasAngles(corner)) {
+    return corner->s.angles;
+  }
+
+  return G_func_train_AnglesForLeg(ent, from, corner->s.origin);
+}
+
+/**
+ * @brief The angles a train holds while standing at `corner` with no leg behind it to face, as
+ * when it spawns or teleports. Having nothing to look back on, it looks ahead to the corner it
+ * will depart towards, so that it starts out aligned with its route rather than snapping around
+ * over its first leg.
+ */
+static vec3_t G_func_train_AnglesAt(const g_entity_t *ent, const g_entity_t *corner) {
+
+  if (!G_func_train_HasOrigin(ent)) {
+    return ent->s.angles;
+  }
+
+  if (G_path_corner_HasAngles(corner)) {
+    return corner->s.angles;
+  }
+
+  const g_entity_t *next = corner->target ? G_PickTarget(corner->target) : NULL;
+
+  return next ? G_func_train_AnglesForLeg(ent, corner->s.origin, next->s.origin) : ent->s.angles;
 }
 
 /**
@@ -2379,7 +2421,7 @@ again:
     first = false;
     ent->s.origin = Vec3_Add(target->s.origin, G_func_train_Offset(ent));
 
-    ent->s.angles = G_func_train_Angles(ent, target);
+    ent->s.angles = G_func_train_AnglesAt(ent, target);
     ent->avelocity = Vec3_Zero();
     ent->move_info.speed = target->speed ? : ent->speed;
 
@@ -2411,7 +2453,7 @@ again:
   ent->move_info.end_origin = dest;
 
   ent->move_info.start_angles = ent->s.angles;
-  ent->move_info.end_angles = G_func_train_Angles(ent, target);
+  ent->move_info.end_angles = G_func_train_Angles(ent, target, ent->s.origin);
   ent->avelocity = Vec3_Zero();
 
   const float dest_speed = target->speed ? : ent->speed;
@@ -2470,7 +2512,7 @@ static void G_func_train_Find(g_entity_t *ent) {
 
   ent->s.origin = Vec3_Add(target->s.origin, G_func_train_Offset(ent));
 
-  ent->s.angles = G_func_train_Angles(ent, target);
+  ent->s.angles = G_func_train_AnglesAt(ent, target);
   ent->move_info.start_angles = ent->s.angles;
   ent->move_info.end_angles = ent->s.angles;
   ent->move_info.speed = target->speed ? : ent->speed;
@@ -2522,12 +2564,14 @@ static void G_func_train_Use(g_entity_t *ent, g_entity_t *other,
  rotates about. Without one, the origin of each corner specifies the lower bounding point of the
  train, and the train cannot rotate.
 
+ An origin brush is therefore all it takes to make a train turn: it will face along each leg of
+ its route, turning and pitching to follow the rails, without any corner being angled by hand.
+ Angle a corner explicitly only where that is not what you want.
+
  -------- Keys --------
  speed : The speed with which the train moves (default 100).
  dmg : The damage inflicted on players who block the train (default 2).
  sound : The looping sound to play while the train is in motion.
- angles : The initial orientation of the train. Requires an origin brush, and is overridden by
- the angles of the first path_corner if it specifies any.
  targetname : The target name of this entity if it is to be triggered.
 
  -------- Spawn flags --------
@@ -2542,7 +2586,8 @@ static void G_func_train_Use(g_entity_t *ent, g_entity_t *other,
  own speed. Because the client stops interpolating an entity that moves more than 60 units in a
  single frame, speeds much above 2400 will render as a stutter rather than as motion.
  angles : The orientation the train holds on arriving here, rotating into it over the length of
- the leg. Requires the train to have an origin brush.
+ the leg. Requires the train to have an origin brush. `angle` is accepted for yaw alone. Omit both
+ and the train faces the leg it travelled to get here, which is usually what you want.
  pathtarget : Fired when the train arrives here.
  target : The next corner in the route. Point the last corner back at the first to loop.
 

--- a/src/game/common/g_entity_misc.c
+++ b/src/game/common/g_entity_misc.c
@@ -172,6 +172,7 @@ static void G_misc_teleporter_Think(g_entity_t *ent) {
  Warps players who touch this entity to the targeted misc_teleporter_dest entity.
 
  -------- Keys --------
+ target : The misc_teleporter_dest to warp players to. Required.
  sound : The sound to play at the teleporter and destination on use (default "misc/teleport").
 
  -------- Spawn flags --------

--- a/src/game/common/g_entity_trigger.c
+++ b/src/game/common/g_entity_trigger.c
@@ -207,7 +207,7 @@ void G_trigger_relay(g_entity_t *ent) {
  delay : The delay in seconds between activation and firing of targets (default 0.2).
  message : An optional message to display when this trigger fires.
  target : The name of the entity or team to use on activation.
- kill_target : The name of the entity or team to kill on activation.
+ killtarget : The name of the entity or team to kill on activation.
  */
 void G_trigger_always(g_entity_t *ent) {
 

--- a/src/game/ctf/g_types.h
+++ b/src/game/ctf/g_types.h
@@ -608,9 +608,15 @@ typedef struct {
   float accel;
 
   /**
-   * @brief Constant travel speed.
+   * @brief Constant travel speed. For a ramped move, the speed at the end of the move.
    */
   float speed;
+
+  /**
+   * @brief The speed at the start of a ramped move, from which the entity is mixed towards
+   * `speed` over the course of the move.
+   */
+  float start_speed;
 
   /**
    * @brief Deceleration rate.

--- a/src/game/default/g_types.h
+++ b/src/game/default/g_types.h
@@ -589,9 +589,15 @@ typedef struct {
   float accel;
 
   /**
-   * @brief Constant travel speed.
+   * @brief Constant travel speed. For a ramped move, the speed at the end of the move.
    */
   float speed;
+
+  /**
+   * @brief The speed at the start of a ramped move, from which the entity is mixed towards
+   * `speed` over the course of the move.
+   */
+  float start_speed;
 
   /**
    * @brief Deceleration rate.

--- a/src/game/lithium/g_types.h
+++ b/src/game/lithium/g_types.h
@@ -595,9 +595,15 @@ typedef struct {
   float accel;
 
   /**
-   * @brief Constant travel speed.
+   * @brief Constant travel speed. For a ramped move, the speed at the end of the move.
    */
   float speed;
+
+  /**
+   * @brief The speed at the start of a ramped move, from which the entity is mixed towards
+   * `speed` over the course of the move.
+   */
+  float start_speed;
 
   /**
    * @brief Deceleration rate.


### PR DESCRIPTION
Implements the mapper-facing primitives from #862 — the pieces a rail-car `func_train` needs before the ballistic derail and rider work can build on it. Riding is out of scope: `ground.ent` already carries items and players.

All three additions are opt-in by the absence of a key, so existing maps are unaffected.

## Origin brush

Given a `common/origin` brush, a train is positioned by its own origin at each `path_corner`, and rotates about that point. Without one it is positioned by its lower bounding corner, exactly as before.

quemap already does all the compiler-side work here — `src/quemap/map.c:690-699` strips the origin brush and writes the `origin` key, and `:837-857` rebases the entity's planes and texture vectors around it. The game module only had to honor it. Note that `G_func_train_HasOrigin`'s non-zero test deliberately mirrors quemap's own test at `map.c:840`: an origin brush at exactly the world origin is *not* rebased by the compiler, so the model stays in world coordinates and is correctly classified as legacy.

Origin-brush trains did not work at all before this — the mins math would have placed the model's *local* mins on the corner — so there is nothing here to regress.

## Angles

An origin brush is all it takes to make a train turn. Rather than requiring `angles` on every corner, a train faces the leg it is travelling — `Vec3_Euler` over the delta between corners — so a cart turns and pitches to follow its rails unaided. A corner that specifies `angles` (or `angle` for yaw alone) still wins, for where following the track is not what the mapper wants.

The origin brush is the sole opt-in for rotation, so there is no spawnflag: a mapper who does not want a train to turn does not give it one.

Standing at a corner with no leg behind it to face — at spawn, or after a teleport — a train looks *ahead* to the corner it will depart towards instead. So it starts out aligned with its route rather than snapping around over its first leg, and it arrives from a teleport already pointing down the track.

The angular velocity is re-solved every tick from the distance remaining rather than precomputed. That makes it independent of the speed profile — with `dθ/dt = -θv/x` and `dx/dt = -v`, `v` cancels to give `θ ∝ x` — which matters because a ramped leg's duration is `d·ln(b/a)/(b-a)`, not `d/speed`. It is snapped on arrival, since `G_MoveInfo_Linear_Done` snaps origin but knows nothing of angles.

`G_Physics_Push` already carries rider yaw through `G_Physics_Push_Rotate_Entity`, and rotated `SOLID_BSP` collision already works on both server (`Sv_LinkEntity` → `Cm_TransformedBoxTrace`) and client (`Cl_ClipTraceToEntities`), so no engine changes were needed.

One consequence worth knowing when authoring: a train turns *over* the leg that leads away from a corner, not instantaneously at the corner. With a `wait` set it sits still pointing along the leg it arrived on, then swings onto the next heading as it pulls away.

## path_corner `speed`

A leg mixes speed from the corner it departed to the corner it arrives at, as a function of distance covered — constant acceleration in space, which is what a mapper means by a cart that picks up speed downhill and loses it climbing.

This fits neither existing movement path (`_Constant` is one velocity for the whole leg; `_Accelerate` is a discrete frame planner around a single speed), so it gets its own per-tick think. `G_MoveInfo_Linear_Init` is refactored to share its preamble via a new `G_MoveInfo_Linear_Setup` but is otherwise behaviorally identical, leaving the door, plat, button, secret-door and bob paths alone. `G_MoveInfo_Linear_Constant` now also sets `current_speed = move->speed`, which is simply true while the mover is moving and is written where nothing reads it before it is re-zeroed.

Both endpoint speeds are floored above zero, since a corner with `speed 0` would otherwise stall the train forever. The departure speed is carried in `move_info.speed` rather than read back off `target_ent`, which keeps the first leg — and the leg following a teleport corner — consistent with every other.

## Documentation

The QUAKED block now covers both positioning conventions, the new corner keys, and the previously **undocumented** `path_corner` `teleport`/`silent` spawnflags. Those already implement the loop-back reset asked for in #862, with no new code: flag the first corner `teleport` + `silent`, give the last corner a `wait` and a `target` back to it, and the train jumps home and carries on. This is why the PR adds no `TRAIN_RESET` spawnflag — it would duplicate an existing mechanism and be less flexible, since a teleport corner can sit anywhere in the route. Riders are not carried through the jump, which is documented.

Also documents the ~2400 u/s effective ceiling on a leg: `MAX_DELTA_ORIGIN` is only 60 units per frame at 40Hz, above which `Cl_ValidDeltaEntity` stops interpolating and the motion renders as a snap.

## Reviewer notes

- **One new struct field**, `start_speed` on `g_move_info_t`, added to all three of `src/game/{default,ctf,lithium}/g_types.h`. Repurposing `distance` or `accel` to hold a speed would have been misleading.
- A read-only review pass caught a genuine bug introduced here: `G_Physics_Push` rotates on any non-zero `avelocity` without consulting `next_think`, but the two places that stop a train zeroed only `velocity`. Harmless before (trains never rotated); now a train toggled off mid-rotation would spin forever and crush its riders. Fixed at all three sites, including `_Resume`, which relied on the angular solve overwriting it — but that solve deliberately early-returns on a non-rotating leg.
- `G_MoveInfo_Angular_Delta` uses a full `fmodf` rather than a single ±360 correction, so it cannot be reached in a bad state.

## Testing

**Not yet tested in game.** Verified that all three game modules compile clean with the project's own flags at `-Wall -Wextra`. @jdolan is planning to exercise it against the mine-themed map with the railway cart.

Worth checking when it is:

- **Regression first** — an existing map with a `func_train` (no `origin` key, no corner `angles` or `speed`): positioning, timing and sounds should be unchanged. Then a `func_door`, `func_plat`, `func_button` and `func_door_secret`, to confirm the `G_MoveInfo_Linear_Init` extraction changed nothing.
- The cart starts centered on its origin brush, not offset by its mins, and already pointing down the track.
- It turns and pitches to follow the rails with no corner angled by hand; a corner given explicit `angles` overrides that.
- It visibly accelerates downhill and decelerates uphill, and rotation still completes with translation on the ramped legs.
- An item dropped on the cart rides it through the rotation; riding it yourself, you are carried and yaw-rotated, and your own traces line up with the rotated hull.
- A `toggle` train stopped mid-rotation stops rotating.
- A teleport-flagged first corner sends the cart home with its angles restored.

Refs #862
