### PR TITLE
Skip the frame cleanly when there is no command buffer

### DIFF
--- a/src/client/renderer/r_main.c
+++ b/src/client/renderer/r_main.c
@@ -291,6 +291,9 @@ void R_DrawMainView(r_view_t *view) {
   assert(view);
 
   CommandBuffer *commands = r_context.device->commands;
+  if (!commands) {
+    return;
+  }
 
   {
     CopyPass *pass = $(commands, beginCopyPass);
@@ -342,11 +345,14 @@ void R_DrawPlayerModelView(r_view_t *view) {
 
   assert(view);
 
+  CommandBuffer *commands = r_context.device->commands;
+  if (!commands) {
+    return;
+  }
+
   R_UpdateUniforms(view);
 
   R_UpdateEntities(view, NULL);
-
-  CommandBuffer *commands = r_context.device->commands;
 
   Framebuffer *framebuffer = view->framebuffer;
 
@@ -373,7 +379,9 @@ void R_EndFrame(void) {
 
   R_Draw2D();
 
-  $(r_context.device, endFrame);
+  if (r_context.device->commands) {
+    $(r_context.device, endFrame);
+  }
 }
 
 /**


### PR DESCRIPTION
RenderDevice::beginFrame returns NULL when the window has no drawable area, but R_BeginFrame ignored that and the rest of the frame ran regardless. R_DrawMainView and R_DrawPlayerModelView dereferenced the NULL command buffer, and R_EndFrame called endFrame unconditionally, whose GPU_Assert exits the process. Minimising the window was enough to hit it.

Guard both view draws and skip endFrame, matching what R_DrawPost and R_Draw2D already do. R_Draw2D is still called so it clears the 2D geometry it accumulated, rather than leaking it into the next frame.

Refs #945

Depends on https://github.com/jdolan/ObjectivelyGPU/pull/5