### PR TITLE
#862 Ability for items to respawn immediately if they land in a hazard like lava, slime

### DIFF
--- a/src/game/common/g_item.c
+++ b/src/game/common/g_item.c
@@ -172,6 +172,38 @@ static void G_ItemRespawn(g_entity_t *ent) {
 }
 
 /**
+ * @brief Returns an item flagged `hazard_respawn` to its map origin if it has ended up
+ * in lava or slime. Called from `G_CheckWater`, so that only items that are actually
+ * moving through the world are considered.
+ */
+void G_CheckItemHazard(g_entity_t *ent) {
+
+  if (!ent->item) {
+    return;
+  }
+
+  if (!(ent->spawn_flags & SF_ITEM_HAZARD_RESPAWN)) {
+    return;
+  }
+
+  if (!(ent->water_type & (CONTENTS_LAVA | CONTENTS_SLIME))) {
+    return;
+  }
+
+  if (!G_ItemRestoreOrigin(ent)) {
+    return;
+  }
+
+  ent->water_level = WATER_NONE;
+  ent->water_type = 0;
+
+  gi.LinkEntity(ent);
+
+  ent->s.event = EV_ITEM_RESPAWN;
+  ent->s.event_data = ent->item->def.tag;
+}
+
+/**
  * @brief Schedules an item entity to respawn after the specified delay in milliseconds.
  */
 void G_SetItemRespawn(g_entity_t *ent, uint32_t delay) {

--- a/src/game/common/g_item.c
+++ b/src/game/common/g_item.c
@@ -143,7 +143,8 @@ static bool G_ItemRestoreOrigin(g_entity_t *ent) {
 
   ent->s.origin = origin->vec3;
   ent->velocity = Vec3_Zero();
-  ent->ground.ent = NULL;
+  ent->avelocity = Vec3_Zero();
+  memset(&ent->ground, 0, sizeof(ent->ground));
 
   return true;
 }

--- a/src/game/common/g_item.c
+++ b/src/game/common/g_item.c
@@ -125,6 +125,30 @@ const g_item_t *G_ClientArmor(const g_client_t *cl) {
 }
 
 /**
+ * @brief Returns the item to the origin authored in the map, so that an item carried
+ * away by a mover comes back where the mapper placed it. Callers that are visible
+ * should expect the item to settle back onto the floor under its own physics.
+ * @return True if the item was moved.
+ */
+static bool G_ItemRestoreOrigin(g_entity_t *ent) {
+
+  const cm_entity_t *origin = gi.EntityValue(ent->def, "origin");
+  if (!(origin->parsed & ENTITY_VEC3)) {
+    return false;
+  }
+
+  if (Vec3_Equal(ent->s.origin, origin->vec3)) {
+    return false;
+  }
+
+  ent->s.origin = origin->vec3;
+  ent->velocity = Vec3_Zero();
+  ent->ground.ent = NULL;
+
+  return true;
+}
+
+/**
  * @brief Think function that respawns an item entity after its delay expires.
  */
 static void G_ItemRespawn(g_entity_t *ent) {
@@ -157,6 +181,8 @@ void G_SetItemRespawn(g_entity_t *ent, uint32_t delay) {
 
   ent->solid = SOLID_NOT;
   ent->sv_flags |= SVF_NO_CLIENT;
+
+  G_ItemRestoreOrigin(ent);
 
   gi.LinkEntity(ent);
 }

--- a/src/game/common/g_item.h
+++ b/src/game/common/g_item.h
@@ -41,6 +41,7 @@
   extern const box3_t ITEM_BOUNDS;
 
   bool G_AddAmmo(g_client_t *cl, const g_item_t *item, int16_t count);
+  void G_CheckItemHazard(g_entity_t *ent);
   g_entity_t *G_DropItem(g_client_t *cl, const g_item_t *item);
   void G_DropInventoryItem(g_client_t *cl, const g_item_t *item);
   bool G_ItemAvailable(const g_item_t *item);

--- a/src/game/common/g_physics.c
+++ b/src/game/common/g_physics.c
@@ -136,6 +136,8 @@ static void G_CheckWater(g_entity_t *ent) {
       }
     }
   }
+
+  G_CheckItemHazard(ent);
 }
 
 /**

--- a/src/game/ctf/g_types.h
+++ b/src/game/ctf/g_types.h
@@ -472,6 +472,7 @@ typedef struct g_entity_s g_entity_t;
 #define SF_ITEM_TRIGGER  0x00000001
 #define SF_ITEM_NO_TOUCH 0x00000002
 #define SF_ITEM_HOVER    0x00000004
+#define SF_ITEM_HAZARD_RESPAWN 0x00000008
 
 /**
  * @brief These spawn flags are actually set by the game module on entities

--- a/src/game/default/g_types.h
+++ b/src/game/default/g_types.h
@@ -453,6 +453,7 @@ typedef struct g_entity_s g_entity_t;
 #define SF_ITEM_TRIGGER  0x00000001
 #define SF_ITEM_NO_TOUCH 0x00000002
 #define SF_ITEM_HOVER    0x00000004
+#define SF_ITEM_HAZARD_RESPAWN 0x00000008
 
 /**
  * @brief These spawn flags are actually set by the game module on entities

--- a/src/game/lithium/g_types.h
+++ b/src/game/lithium/g_types.h
@@ -459,6 +459,7 @@ typedef struct g_entity_s g_entity_t;
 #define SF_ITEM_TRIGGER  0x00000001
 #define SF_ITEM_NO_TOUCH 0x00000002
 #define SF_ITEM_HOVER    0x00000004
+#define SF_ITEM_HAZARD_RESPAWN 0x00000008
 
 /**
  * @brief These spawn flags are actually set by the game module on entities


### PR DESCRIPTION
This pull request adds a mechanism to automatically return items to their original map positions if they fall into hazardous areas like lava or slime, provided they are flagged for this behavior. This helps prevent important items from becoming inaccessible during gameplay. The changes introduce a new spawn flag, a function to check and restore items from hazards, and integrate this check into the game’s physics update loop.

**Item hazard respawn feature:**

* Added a new spawn flag `SF_ITEM_HAZARD_RESPAWN` to indicate items that should return to their original map position if they end up in hazardous areas (`lava` or `slime`). [[1]](diffhunk://#diff-23943c3f38392cf1146f400e5f4f7ac393d1e3f8b673d0c8f0cd7ad1afeb2f8bR475) [[2]](diffhunk://#diff-1553817f041b29d544a242bf76664b42425dcd43f3fbd8941e21d166a76be0b6R456) [[3]](diffhunk://#diff-59a9a8c8ab76b8c4913e51a8b0faedcefb65b4626ff88bea249dd6d3a7405294R462)
* Implemented the `G_CheckItemHazard` function, which checks if an item flagged with `SF_ITEM_HAZARD_RESPAWN` is in a hazard and, if so, restores it to its original position. [[1]](diffhunk://#diff-83283dd17a6e689a4d7d9fd9be5c3fd822f64abdc2b0d0c170eec515891a6f67R174-R205) [[2]](diffhunk://#diff-41498040e9a97e5e604fb4653063209d81a4856802474a6c9c629321eda3bfdbR44)
* Added the internal helper function `G_ItemRestoreOrigin` to handle moving the item back to its map-authored origin and resetting its physics state.

**Integration into game logic:**

* Integrated the hazard check into the main physics update by calling `G_CheckItemHazard` from within `G_CheckWater`, ensuring items are checked each update cycle.
* Ensured that items are restored to their original positions upon respawn by calling `G_ItemRestoreOrigin` in `G_SetItemRespawn`.