### PR TITLE
Add target_ballistics and target_turret

### DIFF
--- a/src/cgame/common/cg_entity_effect.c
+++ b/src/cgame/common/cg_entity_effect.c
@@ -44,6 +44,7 @@ vec3_t Cg_EffectColor(float *hue, const float default_hue) {
 vec3_t Cg_ClientEffectColor(const int32_t client, float *hue, const float default_hue) {
 
   assert(client >= 0);
+  assert(client <= MAX_CLIENTS);
 
   float client_hue = -1.f;
 

--- a/src/cgame/common/cg_entity_effect.c
+++ b/src/cgame/common/cg_entity_effect.c
@@ -38,14 +38,19 @@ vec3_t Cg_EffectColor(float *hue, const float default_hue) {
 
 /**
  * @brief Returns the effect color for the given client, using their team or personal hue.
+ * @param client A client number, or any value `>= MAX_CLIENTS` for effects owned by the world,
+ * which resolve to `default_hue`.
  */
 vec3_t Cg_ClientEffectColor(const int32_t client, float *hue, const float default_hue) {
 
   assert(client >= 0);
-  assert(client < MAX_CLIENTS);
 
-  const cg_client_info_t *ci = &cg_state.clients[client];
-  float client_hue = ci->team ? ci->team->hue : ci->hue;
+  float client_hue = -1.f;
+
+  if (client < MAX_CLIENTS) {
+    const cg_client_info_t *ci = &cg_state.clients[client];
+    client_hue = ci->team ? ci->team->hue : ci->hue;
+  }
 
   const vec3_t color = Cg_EffectColor(&client_hue, default_hue);
 

--- a/src/cgame/common/cg_entity_effect.c
+++ b/src/cgame/common/cg_entity_effect.c
@@ -44,7 +44,6 @@ vec3_t Cg_EffectColor(float *hue, const float default_hue) {
 vec3_t Cg_ClientEffectColor(const int32_t client, float *hue, const float default_hue) {
 
   assert(client >= 0);
-  assert(client <= MAX_CLIENTS);
 
   float client_hue = -1.f;
 

--- a/src/cgame/common/cg_muzzle_flash.c
+++ b/src/cgame/common/cg_muzzle_flash.c
@@ -24,11 +24,11 @@
 /**
  * @brief Renders the blaster muzzle flash with a dynamic light and optional bubble trail.
  */
-static void Cg_BlasterFlash(const cl_entity_t *ent) {
+static void Cg_BlasterFlash(const vec3_t muzzle, const vec3_t origin, const vec3_t angles, const int32_t client) {
 
-  const vec3_t color = Cg_ClientEffectColor(ent->current.client, NULL, color_hue_orange);
+  const vec3_t color = Cg_ClientEffectColor(client, NULL, color_hue_orange);
 
-  vec3_t org = cg_state.clients[ent->current.client].weapon_muzzle;
+  vec3_t org = muzzle;
 
   Cg_AddLight(&(cg_light_t) {
     .origin = org,
@@ -39,9 +39,9 @@ static void Cg_BlasterFlash(const cl_entity_t *ent) {
   });
 
   vec3_t org2, forward, right;
-  Vec3_Vectors(ent->angles, &forward, &right, NULL);
-  if (cgi.PointContents(ent->origin) & CONTENTS_MASK_LIQUID) {
-    org2 = Vec3_Fmaf(ent->origin, 40.f, forward);
+  Vec3_Vectors(angles, &forward, &right, NULL);
+  if (cgi.PointContents(origin) & CONTENTS_MASK_LIQUID) {
+    org2 = Vec3_Fmaf(origin, 40.f, forward);
     Cg_BubbleTrail(NULL, org, org2, 8.f);
     return;
   }
@@ -74,12 +74,12 @@ static void Cg_BlasterFlash(const cl_entity_t *ent) {
 /**
  * @brief Shotgun muzzle flash.
  */
-static void Cg_ShotgunFlash(const cl_entity_t *ent) {
+static void Cg_ShotgunFlash(const vec3_t muzzle, const vec3_t origin, const vec3_t angles, const int32_t client) {
 
-  vec3_t org = cg_state.clients[ent->current.client].weapon_muzzle;
+  vec3_t org = muzzle;
 
   vec3_t forward, right;
-  Vec3_Vectors(ent->angles, &forward, &right, NULL);
+  Vec3_Vectors(angles, &forward, &right, NULL);
 
   Cg_AddLight(&(cg_light_t) {
     .origin = org,
@@ -89,8 +89,8 @@ static void Cg_ShotgunFlash(const cl_entity_t *ent) {
     .decay = 250,
   });
 
-  if (cgi.PointContents(ent->origin) & CONTENTS_MASK_LIQUID) {
-    Cg_BubbleTrail(NULL, org, Vec3_Fmaf(ent->origin, 40.f, forward), 4.f);
+  if (cgi.PointContents(origin) & CONTENTS_MASK_LIQUID) {
+    Cg_BubbleTrail(NULL, org, Vec3_Fmaf(origin, 40.f, forward), 4.f);
     return;
   }
 
@@ -147,12 +147,12 @@ static void Cg_ShotgunFlash(const cl_entity_t *ent) {
 /**
  * @brief Quake shotgun muzzle flash.
  */
-static void Cg_QuakeShotgunFlash(const cl_entity_t *ent) {
+static void Cg_QuakeShotgunFlash(const vec3_t muzzle, const vec3_t origin, const vec3_t angles, const int32_t client) {
 
-  vec3_t org = cg_state.clients[ent->current.client].weapon_muzzle;
+  vec3_t org = muzzle;
 
   vec3_t forward, right;
-  Vec3_Vectors(ent->angles, &forward, &right, NULL);
+  Vec3_Vectors(angles, &forward, &right, NULL);
 
   Cg_AddLight(&(cg_light_t) {
     .origin = org,
@@ -162,8 +162,8 @@ static void Cg_QuakeShotgunFlash(const cl_entity_t *ent) {
     .decay = 250,
   });
 
-  if (cgi.PointContents(ent->origin) & CONTENTS_MASK_LIQUID) {
-    Cg_BubbleTrail(NULL, org, Vec3_Fmaf(ent->origin, 40.f, forward), 4.f);
+  if (cgi.PointContents(origin) & CONTENTS_MASK_LIQUID) {
+    Cg_BubbleTrail(NULL, org, Vec3_Fmaf(origin, 40.f, forward), 4.f);
     return;
   }
 
@@ -220,12 +220,12 @@ static void Cg_QuakeShotgunFlash(const cl_entity_t *ent) {
 /**
  * @brief Super shotgun muzzle flash.
  */
-static void Cg_SuperShotgunFlash(const cl_entity_t *ent) {
+static void Cg_SuperShotgunFlash(const vec3_t muzzle, const vec3_t origin, const vec3_t angles, const int32_t client) {
 
-  vec3_t org = cg_state.clients[ent->current.client].weapon_muzzle;
+  vec3_t org = muzzle;
 
   vec3_t forward, right;
-  Vec3_Vectors(ent->angles, &forward, &right, NULL);
+  Vec3_Vectors(angles, &forward, &right, NULL);
 
   Cg_AddLight(&(cg_light_t) {
     .origin = org,
@@ -235,8 +235,8 @@ static void Cg_SuperShotgunFlash(const cl_entity_t *ent) {
     .decay = 300,
   });
 
-  if (cgi.PointContents(ent->origin) & CONTENTS_MASK_LIQUID) {
-    Cg_BubbleTrail(NULL, org, Vec3_Fmaf(ent->origin, 40.f, forward), 8.f);
+  if (cgi.PointContents(origin) & CONTENTS_MASK_LIQUID) {
+    Cg_BubbleTrail(NULL, org, Vec3_Fmaf(origin, 40.f, forward), 8.f);
     return;
   }
 
@@ -297,12 +297,12 @@ static void Cg_SuperShotgunFlash(const cl_entity_t *ent) {
 /**
  * @brief Quake super shotgun muzzle flash.
  */
-static void Cg_QuakeSuperShotgunFlash(const cl_entity_t *ent) {
+static void Cg_QuakeSuperShotgunFlash(const vec3_t muzzle, const vec3_t origin, const vec3_t angles, const int32_t client) {
 
-  vec3_t org = cg_state.clients[ent->current.client].weapon_muzzle;
+  vec3_t org = muzzle;
 
   vec3_t forward, right;
-  Vec3_Vectors(ent->angles, &forward, &right, NULL);
+  Vec3_Vectors(angles, &forward, &right, NULL);
 
   Cg_AddLight(&(cg_light_t) {
     .origin = org,
@@ -312,8 +312,8 @@ static void Cg_QuakeSuperShotgunFlash(const cl_entity_t *ent) {
     .decay = 300,
   });
 
-  if (cgi.PointContents(ent->origin) & CONTENTS_MASK_LIQUID) {
-    Cg_BubbleTrail(NULL, org, Vec3_Fmaf(ent->origin, 40.f, forward), 8.f);
+  if (cgi.PointContents(origin) & CONTENTS_MASK_LIQUID) {
+    Cg_BubbleTrail(NULL, org, Vec3_Fmaf(origin, 40.f, forward), 8.f);
     return;
   }
 
@@ -370,12 +370,12 @@ static void Cg_QuakeSuperShotgunFlash(const cl_entity_t *ent) {
 /**
  * @brief Machinegun muzzle flash.
  */
-static void Cg_MachinegunFlash(const cl_entity_t *ent) {
+static void Cg_MachinegunFlash(const vec3_t muzzle, const vec3_t origin, const vec3_t angles, const int32_t client) {
 
-  vec3_t org = cg_state.clients[ent->current.client].weapon_muzzle;
+  vec3_t org = muzzle;
 
   vec3_t forward, right;
-  Vec3_Vectors(ent->angles, &forward, &right, NULL);
+  Vec3_Vectors(angles, &forward, &right, NULL);
 
   Cg_AddLight(&(cg_light_t) {
     .origin = org,
@@ -385,8 +385,8 @@ static void Cg_MachinegunFlash(const cl_entity_t *ent) {
     .decay = 150,
   });
 
-  if (cgi.PointContents(ent->origin) & CONTENTS_MASK_LIQUID) {
-    Cg_BubbleTrail(NULL, org, Vec3_Fmaf(ent->origin, 40.f, forward), 2.f);
+  if (cgi.PointContents(origin) & CONTENTS_MASK_LIQUID) {
+    Cg_BubbleTrail(NULL, org, Vec3_Fmaf(origin, 40.f, forward), 2.f);
     return;
   }
 
@@ -433,12 +433,12 @@ static void Cg_MachinegunFlash(const cl_entity_t *ent) {
 /**
  * @brief Grenade launcher muzzle flash.
  */
-static void Cg_GrenadeFlash(const cl_entity_t *ent) {
+static void Cg_GrenadeFlash(const vec3_t muzzle, const vec3_t origin, const vec3_t angles, const int32_t client) {
 
-  vec3_t org = cg_state.clients[ent->current.client].weapon_muzzle;
+  vec3_t org = muzzle;
 
   vec3_t forward, right;
-  Vec3_Vectors(ent->angles, &forward, &right, NULL);
+  Vec3_Vectors(angles, &forward, &right, NULL);
 
   Cg_AddLight(&(cg_light_t) {
     .origin = org,
@@ -448,8 +448,8 @@ static void Cg_GrenadeFlash(const cl_entity_t *ent) {
     .decay = 350,
   });
 
-  if (cgi.PointContents(ent->origin) & CONTENTS_MASK_LIQUID) {
-    Cg_BubbleTrail(NULL, org, Vec3_Fmaf(ent->origin, 40.f, forward), 4.f);
+  if (cgi.PointContents(origin) & CONTENTS_MASK_LIQUID) {
+    Cg_BubbleTrail(NULL, org, Vec3_Fmaf(origin, 40.f, forward), 4.f);
     return;
   }
 
@@ -495,12 +495,12 @@ static void Cg_GrenadeFlash(const cl_entity_t *ent) {
 /**
  * @brief Quake grenade launcher muzzle flash.
  */
-static void Cg_QuakeGrenadeFlash(const cl_entity_t *ent) {
+static void Cg_QuakeGrenadeFlash(const vec3_t muzzle, const vec3_t origin, const vec3_t angles, const int32_t client) {
 
-  vec3_t org = cg_state.clients[ent->current.client].weapon_muzzle;
+  vec3_t org = muzzle;
 
   vec3_t forward, right;
-  Vec3_Vectors(ent->angles, &forward, &right, NULL);
+  Vec3_Vectors(angles, &forward, &right, NULL);
 
   Cg_AddLight(&(cg_light_t) {
     .origin = org,
@@ -510,8 +510,8 @@ static void Cg_QuakeGrenadeFlash(const cl_entity_t *ent) {
     .decay = 350,
   });
 
-  if (cgi.PointContents(ent->origin) & CONTENTS_MASK_LIQUID) {
-    Cg_BubbleTrail(NULL, org, Vec3_Fmaf(ent->origin, 40.f, forward), 4.f);
+  if (cgi.PointContents(origin) & CONTENTS_MASK_LIQUID) {
+    Cg_BubbleTrail(NULL, org, Vec3_Fmaf(origin, 40.f, forward), 4.f);
     return;
   }
 
@@ -554,12 +554,12 @@ static void Cg_QuakeGrenadeFlash(const cl_entity_t *ent) {
 /**
  * @brief Renders the rocket launcher muzzle flash with a dynamic light and optional bubble trail.
  */
-static void Cg_RocketFlash(const cl_entity_t *ent) {
+static void Cg_RocketFlash(const vec3_t muzzle, const vec3_t origin, const vec3_t angles, const int32_t client) {
 
-  vec3_t org = cg_state.clients[ent->current.client].weapon_muzzle;
+  vec3_t org = muzzle;
 
   vec3_t forward, right;
-  Vec3_Vectors(ent->angles, &forward, &right, NULL);
+  Vec3_Vectors(angles, &forward, &right, NULL);
 
   Cg_AddLight(&(cg_light_t) {
     .origin = org,
@@ -569,8 +569,8 @@ static void Cg_RocketFlash(const cl_entity_t *ent) {
     .decay = 400
   });
 
-  if (cgi.PointContents(ent->origin) & CONTENTS_MASK_LIQUID) {
-    const vec3_t org2 = Vec3_Fmaf(ent->origin, 40.f, forward);
+  if (cgi.PointContents(origin) & CONTENTS_MASK_LIQUID) {
+    const vec3_t org2 = Vec3_Fmaf(origin, 40.f, forward);
     Cg_BubbleTrail(NULL, org, org2, 2.f);
     return;
   }
@@ -630,12 +630,12 @@ static void Cg_RocketFlash(const cl_entity_t *ent) {
 /**
  * @brief Quake rocket launcher muzzle flash.
  */
-static void Cg_QuakeRocketFlash(const cl_entity_t *ent) {
+static void Cg_QuakeRocketFlash(const vec3_t muzzle, const vec3_t origin, const vec3_t angles, const int32_t client) {
 
-  vec3_t org = cg_state.clients[ent->current.client].weapon_muzzle;
+  vec3_t org = muzzle;
 
   vec3_t forward, right;
-  Vec3_Vectors(ent->angles, &forward, &right, NULL);
+  Vec3_Vectors(angles, &forward, &right, NULL);
 
   Cg_AddLight(&(cg_light_t) {
     .origin = org,
@@ -645,8 +645,8 @@ static void Cg_QuakeRocketFlash(const cl_entity_t *ent) {
     .decay = 400
   });
 
-  if (cgi.PointContents(ent->origin) & CONTENTS_MASK_LIQUID) {
-    const vec3_t org2 = Vec3_Fmaf(ent->origin, 40.f, forward);
+  if (cgi.PointContents(origin) & CONTENTS_MASK_LIQUID) {
+    const vec3_t org2 = Vec3_Fmaf(origin, 40.f, forward);
     Cg_BubbleTrail(NULL, org, org2, 2.f);
     return;
   }
@@ -702,14 +702,14 @@ static void Cg_QuakeRocketFlash(const cl_entity_t *ent) {
 /**
  * @brief Hyperblaster muzzle flash.
  */
-static void Cg_HyperblasterFlash(const cl_entity_t *ent) {
+static void Cg_HyperblasterFlash(const vec3_t muzzle, const vec3_t origin, const vec3_t angles, const int32_t client) {
 
-  vec3_t org = cg_state.clients[ent->current.client].weapon_muzzle;
+  vec3_t org = muzzle;
 
   const vec3_t color = ColorHSV(204.f, .8f, 1.f).vec3;
 
   vec3_t forward;
-  Vec3_Vectors(ent->angles, &forward, NULL, NULL);
+  Vec3_Vectors(angles, &forward, NULL, NULL);
 
   Cg_AddLight(&(cg_light_t) {
     .origin = org,
@@ -745,9 +745,9 @@ static void Cg_HyperblasterFlash(const cl_entity_t *ent) {
 /**
  * @brief BFG muzzle flash.
  */
-static void Cg_BfgFlash(const cl_entity_t *ent) {
+static void Cg_BfgFlash(const vec3_t muzzle, const vec3_t origin, const vec3_t angles, const int32_t client) {
 
-  vec3_t org = cg_state.clients[ent->current.client].weapon_muzzle;
+  vec3_t org = muzzle;
 
   const vec3_t color = ColorHSV(85.f, .9f, 1.f).vec3;
 
@@ -759,10 +759,10 @@ static void Cg_BfgFlash(const cl_entity_t *ent) {
     .decay = 500,
   });
 
-  if (cgi.PointContents(ent->origin) & CONTENTS_MASK_LIQUID) {
+  if (cgi.PointContents(origin) & CONTENTS_MASK_LIQUID) {
     vec3_t forward;
-    Vec3_Vectors(ent->angles, &forward, NULL, NULL);
-    Cg_BubbleTrail(NULL, org, Vec3_Fmaf(ent->origin, 40.f, forward), 4.f);
+    Vec3_Vectors(angles, &forward, NULL, NULL);
+    Cg_BubbleTrail(NULL, org, Vec3_Fmaf(origin, 40.f, forward), 4.f);
     return;
   }
 
@@ -818,12 +818,12 @@ static void Cg_BfgFlash(const cl_entity_t *ent) {
 /**
  * @brief Quake nailgun muzzle flash — small, sharp, no big flame cone.
  */
-static void Cg_QuakeNailgunFlash(const cl_entity_t *ent) {
+static void Cg_QuakeNailgunFlash(const vec3_t muzzle, const vec3_t origin, const vec3_t angles, const int32_t client) {
 
-  vec3_t org = cg_state.clients[ent->current.client].weapon_muzzle;
+  vec3_t org = muzzle;
 
   vec3_t forward;
-  Vec3_Vectors(ent->angles, &forward, NULL, NULL);
+  Vec3_Vectors(angles, &forward, NULL, NULL);
 
   Cg_AddLight(&(cg_light_t) {
     .origin = org,
@@ -833,8 +833,8 @@ static void Cg_QuakeNailgunFlash(const cl_entity_t *ent) {
     .decay = 100,
   });
 
-  if (cgi.PointContents(ent->origin) & CONTENTS_MASK_LIQUID) {
-    Cg_BubbleTrail(NULL, org, Vec3_Fmaf(ent->origin, 30.f, forward), 2.f);
+  if (cgi.PointContents(origin) & CONTENTS_MASK_LIQUID) {
+    Cg_BubbleTrail(NULL, org, Vec3_Fmaf(origin, 30.f, forward), 2.f);
     return;
   }
 
@@ -864,12 +864,12 @@ static void Cg_QuakeNailgunFlash(const cl_entity_t *ent) {
 /**
  * @brief Quake super nailgun muzzle flash.
  */
-static void Cg_QuakeSuperNailgunFlash(const cl_entity_t *ent) {
+static void Cg_QuakeSuperNailgunFlash(const vec3_t muzzle, const vec3_t origin, const vec3_t angles, const int32_t client) {
 
-  vec3_t org = cg_state.clients[ent->current.client].weapon_muzzle;
+  vec3_t org = muzzle;
 
   vec3_t forward;
-  Vec3_Vectors(ent->angles, &forward, NULL, NULL);
+  Vec3_Vectors(angles, &forward, NULL, NULL);
 
   Cg_AddLight(&(cg_light_t) {
     .origin = org,
@@ -879,8 +879,8 @@ static void Cg_QuakeSuperNailgunFlash(const cl_entity_t *ent) {
     .decay = 100,
   });
 
-  if (cgi.PointContents(ent->origin) & CONTENTS_MASK_LIQUID) {
-    Cg_BubbleTrail(NULL, org, Vec3_Fmaf(ent->origin, 30.f, forward), 2.f);
+  if (cgi.PointContents(origin) & CONTENTS_MASK_LIQUID) {
+    Cg_BubbleTrail(NULL, org, Vec3_Fmaf(origin, 30.f, forward), 2.f);
     return;
   }
 
@@ -910,8 +910,8 @@ static void Cg_QuakeSuperNailgunFlash(const cl_entity_t *ent) {
 /**
  * @brief FIXME: This should be a tentity instead; would make more sense.
  */
-static void Cg_LogoutFlash(const cl_entity_t *ent) {
-  Cg_GibEffect(ent->origin, 12);
+static void Cg_LogoutFlash(const vec3_t muzzle, const vec3_t origin, const vec3_t angles, const int32_t client) {
+  Cg_GibEffect(origin, 12);
 }
 
 /**
@@ -922,16 +922,32 @@ void Cg_ParseMuzzleFlash(void) {
   const int16_t entity = cgi.ReadShort();
   const uint8_t flash = cgi.ReadByte();
 
-  if (entity < 0 || entity >= MAX_ENTITIES) {
-    Cg_Warn("Bad entity %u\n", entity);
-    return;
-  }
+  vec3_t muzzle, origin, angles;
+  int32_t client;
+  const cl_entity_t *ent = NULL;
 
-  const cl_entity_t *ent = &cgi.client->entities[entity];
+  if (entity == MUZZLE_FLASH_WORLD) { // the world is shooting; the origin and dir follow
+    origin = muzzle = cgi.ReadPosition();
+    angles = Vec3_Euler(cgi.ReadDir());
+    client = MAX_CLIENTS;
+  } else {
 
-  if (ent->current.client >= MAX_CLIENTS) {
-    Cg_Warn("Bad client %u for entity %d\n", ent->current.client, entity);
-    return;
+    if (entity < 0 || entity >= MAX_ENTITIES) {
+      Cg_Warn("Bad entity %u\n", entity);
+      return;
+    }
+
+    ent = &cgi.client->entities[entity];
+
+    if (ent->current.client >= MAX_CLIENTS) {
+      Cg_Warn("Bad client %u for entity %d\n", ent->current.client, entity);
+      return;
+    }
+
+    client = ent->current.client;
+    muzzle = cg_state.clients[client].weapon_muzzle;
+    origin = ent->origin;
+    angles = ent->angles;
   }
 
   const s_sample_t *sample;
@@ -940,37 +956,37 @@ void Cg_ParseMuzzleFlash(void) {
   switch (flash) {
     case MZ_BLASTER:
       sample = cg_sample_blaster_fire;
-      Cg_BlasterFlash(ent);
+      Cg_BlasterFlash(muzzle, origin, angles, client);
       pitch = 5;
       break;
     case MZ_SHOTGUN:
       sample = cg_sample_shotgun_fire;
-      Cg_ShotgunFlash(ent);
+      Cg_ShotgunFlash(muzzle, origin, angles, client);
       pitch = 3;
       break;
     case MZ_SUPER_SHOTGUN:
       sample = cg_sample_supershotgun_fire;
-      Cg_SuperShotgunFlash(ent);
+      Cg_SuperShotgunFlash(muzzle, origin, angles, client);
       pitch = 3;
       break;
     case MZ_MACHINEGUN:
       sample = cg_sample_machinegun_fire[RandomRangeu(0, lengthof(cg_sample_machinegun_fire))];
-      Cg_MachinegunFlash(ent);
+      Cg_MachinegunFlash(muzzle, origin, angles, client);
       pitch = 5;
       break;
     case MZ_ROCKET_LAUNCHER:
       sample = cg_sample_rocketlauncher_fire;
-      Cg_RocketFlash(ent);
+      Cg_RocketFlash(muzzle, origin, angles, client);
       pitch = 3;
       break;
     case MZ_GRENADE_LAUNCHER:
       sample = cg_sample_grenadelauncher_fire;
-      Cg_GrenadeFlash(ent);
+      Cg_GrenadeFlash(muzzle, origin, angles, client);
       pitch = 3;
       break;
     case MZ_HYPERBLASTER:
       sample = cg_sample_hyperblaster_fire;
-      Cg_HyperblasterFlash(ent);
+      Cg_HyperblasterFlash(muzzle, origin, angles, client);
       pitch = 5;
       break;
     case MZ_LIGHTNING:
@@ -983,42 +999,42 @@ void Cg_ParseMuzzleFlash(void) {
       break;
     case MZ_BFG10K:
       sample = cg_sample_bfg_fire;
-      Cg_BfgFlash(ent);
+      Cg_BfgFlash(muzzle, origin, angles, client);
       pitch = 2;
       break;
     case MZ_LOGOUT:
       sample = cg_sample_teleport;
-      Cg_LogoutFlash(ent);
+      Cg_LogoutFlash(muzzle, origin, angles, client);
       pitch = 4;
       break;
     case MZ_QUAKE_SHOTGUN:
       sample = cg_sample_quake_shotgun_fire;
-      Cg_QuakeShotgunFlash(ent);
+      Cg_QuakeShotgunFlash(muzzle, origin, angles, client);
       pitch = 3;
       break;
     case MZ_QUAKE_SUPER_SHOTGUN:
       sample = cg_sample_quake_supershotgun_fire;
-      Cg_QuakeSuperShotgunFlash(ent);
+      Cg_QuakeSuperShotgunFlash(muzzle, origin, angles, client);
       pitch = 3;
       break;
     case MZ_QUAKE_NAILGUN:
       sample = cg_sample_quake_nailgun_fire;
-      Cg_QuakeNailgunFlash(ent);
+      Cg_QuakeNailgunFlash(muzzle, origin, angles, client);
       pitch = 5;
       break;
     case MZ_QUAKE_SUPER_NAILGUN:
       sample = cg_sample_quake_supernailgun_fire;
-      Cg_QuakeSuperNailgunFlash(ent);
+      Cg_QuakeSuperNailgunFlash(muzzle, origin, angles, client);
       pitch = 5;
       break;
     case MZ_QUAKE_GRENADE_LAUNCHER:
       sample = cg_sample_quake_grenadelauncher_fire;
-      Cg_QuakeGrenadeFlash(ent);
+      Cg_QuakeGrenadeFlash(muzzle, origin, angles, client);
       pitch = 3;
       break;
     case MZ_QUAKE_ROCKET_LAUNCHER:
       sample = cg_sample_quake_rocketlauncher_fire;
-      Cg_QuakeRocketFlash(ent);
+      Cg_QuakeRocketFlash(muzzle, origin, angles, client);
       pitch = 3;
       break;
     default:
@@ -1027,7 +1043,7 @@ void Cg_ParseMuzzleFlash(void) {
   }
 
   Cg_AddSample(cgi.stage, &(const s_play_sample_t) {
-    .origin = ent->current.origin,
+    .origin = ent ? ent->current.origin : origin,
     .sample = sample,
     .entity = ent,
     .pitch = RandomRangei(-pitch, pitch + 1)

--- a/src/game/common/g_ballistics.c
+++ b/src/game/common/g_ballistics.c
@@ -171,7 +171,7 @@ static void G_BlasterProjectile_Touch(g_entity_t *ent, g_entity_t *other, const 
       .damage = ent->damage,
       .knockback = ent->knockback,
       .flags = DMG_ENERGY,
-      .mod = MOD_BLASTER
+      .mod = ent->mod ?: MOD_BLASTER
     });
 
     if (G_IsStructural(trace)) {
@@ -190,13 +190,16 @@ static void G_BlasterProjectile_Touch(g_entity_t *ent, g_entity_t *other, const 
 
 /**
  * @brief Fires a blaster projectile from the specified entity in the given direction.
+ * @param ent The entity the projectile leaves, providing its origin and effect color.
+ * @param attacker The entity credited with any damage the projectile inflicts.
  */
-void G_BlasterProjectile(g_entity_t *ent, const vec3_t start, const vec3_t dir, int32_t speed, int32_t damage, int32_t knockback) {
+void G_BlasterProjectile(g_entity_t *ent, g_entity_t *attacker, const vec3_t start, const vec3_t dir, int32_t speed, int32_t damage, int32_t knockback, uint32_t mod) {
 
   const box3_t bounds = Box3f(2.f, 2.f, 2.f);
 
   g_entity_t *projectile = G_AllocEntity(__func__);
-  projectile->owner = ent;
+  projectile->owner = attacker;
+  projectile->mod = mod;
 
   projectile->s.origin = start;
   projectile->bounds = bounds;
@@ -249,7 +252,7 @@ static void G_NailProjectile_Touch(g_entity_t *ent, g_entity_t *other, const cm_
       .normal = trace->plane.normal,
       .damage = ent->damage,
       .knockback = ent->knockback,
-      .mod = ent->spawn_flags ?: MOD_QUAKE_NAILGUN
+      .mod = ent->mod ?: MOD_QUAKE_NAILGUN
     });
 
     if (G_IsStructural(trace)) {
@@ -266,14 +269,16 @@ static void G_NailProjectile_Touch(g_entity_t *ent, g_entity_t *other, const cm_
 
 /**
  * @brief Fires a nail projectile from the specified entity in the given direction.
+ * @param ent The entity the projectile leaves, providing its origin and effect color.
+ * @param attacker The entity credited with any damage the projectile inflicts.
  */
-void G_NailProjectile(g_entity_t *ent, const vec3_t start, const vec3_t dir, int32_t speed, int32_t damage, int32_t knockback, int32_t mod) {
+void G_NailProjectile(g_entity_t *ent, g_entity_t *attacker, const vec3_t start, const vec3_t dir, int32_t speed, int32_t damage, int32_t knockback, uint32_t mod) {
 
   const box3_t bounds = Box3f(1.f, 1.f, 1.f);
 
   g_entity_t *projectile = G_AllocEntity(__func__);
-  projectile->owner = ent;
-  projectile->spawn_flags = mod;
+  projectile->owner = attacker;
+  projectile->mod = mod;
 
   projectile->s.origin = start;
   projectile->bounds = bounds;
@@ -367,11 +372,13 @@ void G_ShotgunProjectiles(g_entity_t *ent, const vec3_t start, const vec3_t dir,
  * @brief Detonates a grenade projectile, dealing direct and splash radius damage.
  */
 static void G_GrenadeProjectile_Explode(g_entity_t *ent) {
-  int32_t mod;
+  uint32_t mod;
 
   if (ent->enemy) { // direct hit
 
-    if (ent->spawn_flags & HAND_GRENADE) {
+    if (ent->mod) {
+      mod = ent->mod;
+    } else if (ent->spawn_flags & HAND_GRENADE) {
       mod = MOD_HANDGRENADE;
     } else if (ent->spawn_flags & QUAKE_GRENADE) {
       mod = MOD_QUAKE_GRENADE;
@@ -393,7 +400,9 @@ static void G_GrenadeProjectile_Explode(g_entity_t *ent) {
     });
   }
 
-  if (ent->spawn_flags & HAND_GRENADE) {
+  if (ent->mod) {
+    mod = ent->mod;
+  } else if (ent->spawn_flags & HAND_GRENADE) {
     if (ent->spawn_flags & HAND_GRENADE_HELD) {
       mod = MOD_HANDGRENADE_KAMIKAZE;
     } else {
@@ -495,15 +504,18 @@ static void G_QuakeGrenadeProjectile_Touch(g_entity_t *ent, g_entity_t *other, c
 
 /**
  * @brief Fires a grenade projectile with bounce physics and a timed fuse.
+ * @param ent The entity the projectile leaves, providing its origin and effect color.
+ * @param attacker The entity credited with any damage the projectile inflicts.
  */
-void G_GrenadeProjectile(g_entity_t *ent, const vec3_t start, const vec3_t dir, int32_t speed, int32_t damage, int32_t knockback, float damage_radius, uint32_t timer) {
+void G_GrenadeProjectile(g_entity_t *ent, g_entity_t *attacker, const vec3_t start, const vec3_t dir, int32_t speed, int32_t damage, int32_t knockback, float damage_radius, uint32_t timer, uint32_t mod) {
 
   const box3_t bounds = Box3f(6.f, 6.f, 6.f);
 
   vec3_t forward, right, up;
 
   g_entity_t *projectile = G_AllocEntity(__func__);
-  projectile->owner = ent;
+  projectile->owner = attacker;
+  projectile->mod = mod;
   projectile->spawn_flags = QUAKE_GRENADE;
 
   projectile->s.origin = start;
@@ -649,8 +661,8 @@ void G_HandGrenadeProjectile(g_entity_t *ent, g_entity_t *projectile, vec3_t con
 
 static void G_RocketProjectile_Touch(g_entity_t *ent, g_entity_t *other, const cm_trace_t *trace) {
   const bool quake_rocket = (ent->spawn_flags & QUAKE_ROCKET) != 0;
-  const g_means_of_death direct_mod = quake_rocket ? MOD_QUAKE_ROCKET : MOD_ROCKET;
-  const g_means_of_death splash_mod = quake_rocket ? MOD_QUAKE_ROCKET_SPLASH : MOD_ROCKET_SPLASH;
+  const uint32_t direct_mod = ent->mod ?: (quake_rocket ? MOD_QUAKE_ROCKET : MOD_ROCKET);
+  const uint32_t splash_mod = ent->mod ?: (quake_rocket ? MOD_QUAKE_ROCKET_SPLASH : MOD_ROCKET_SPLASH);
 
   if (other == ent->owner) {
     return;
@@ -696,13 +708,16 @@ static void G_RocketProjectile_Touch(g_entity_t *ent, g_entity_t *other, const c
 
 /**
  * @brief Fires a rocket projectile that explodes with radius damage on impact.
+ * @param ent The entity the projectile leaves, providing its origin and effect color.
+ * @param attacker The entity credited with any damage the projectile inflicts.
  */
-void G_RocketProjectile(g_entity_t *ent, const vec3_t start, const vec3_t dir, int32_t speed, int32_t damage, int32_t knockback, float damage_radius) {
+void G_RocketProjectile(g_entity_t *ent, g_entity_t *attacker, const vec3_t start, const vec3_t dir, int32_t speed, int32_t damage, int32_t knockback, float damage_radius, uint32_t mod) {
 
   const box3_t bounds = Box3f(8.f, 8.f, 8.f);
 
   g_entity_t *projectile = G_AllocEntity(__func__);
-  projectile->owner = ent;
+  projectile->owner = attacker;
+  projectile->mod = mod;
   projectile->spawn_flags = QUAKE_ROCKET;
 
   projectile->s.origin = start;
@@ -1018,7 +1033,7 @@ static void G_LightningProjectile_Think(g_entity_t *ent) {
         .damage = ent->damage,
         .knockback = ent->knockback,
         .flags = DMG_ENERGY,
-        .mod = ent->spawn_flags ? ent->spawn_flags : MOD_LIGHTNING
+        .mod = ent->mod ?: MOD_LIGHTNING
       });
       ent->damage = 0;
     } else { // or leave a mark
@@ -1082,15 +1097,17 @@ void G_LightningProjectile(g_entity_t *ent, const vec3_t start, const vec3_t dir
   projectile->next_think = g_level.time + 1;
   projectile->timestamp = g_level.time;
   projectile->water_level = WATER_NONE;
-  projectile->spawn_flags = mod;
+  projectile->mod = mod;
   projectile->count = discharge_mod;
 }
 
 /**
  * @brief Fires a railgun slug that traces through multiple targets, dealing damage to each.
+ * @param ent The entity the slug leaves, providing its origin and effect color.
+ * @param attacker The entity credited with any damage the slug inflicts.
  */
-void G_RailgunProjectile(g_entity_t *ent, const vec3_t start, const vec3_t dir, int32_t damage,
-             int32_t knockback) {
+void G_RailgunProjectile(g_entity_t *ent, g_entity_t *attacker, const vec3_t start, const vec3_t dir, int32_t damage,
+             int32_t knockback, uint32_t mod) {
   vec3_t pos, end;
 
   pos = start;
@@ -1146,14 +1163,14 @@ void G_RailgunProjectile(g_entity_t *ent, const vec3_t start, const vec3_t dir, 
       G_Damage(&(g_damage_t) {
         .target = tr.ent,
         .inflictor = ent,
-        .attacker = ent,
+        .attacker = attacker,
         .dir = dir,
         .point = tr.end,
         .normal = tr.plane.normal,
         .damage = damage,
         .knockback = knockback,
         .flags = 0,
-        .mod = MOD_RAILGUN
+        .mod = mod ?: MOD_RAILGUN
       });
     }
 

--- a/src/game/common/g_ballistics.c
+++ b/src/game/common/g_ballistics.c
@@ -1159,7 +1159,7 @@ void G_RailgunProjectile(g_entity_t *ent, g_entity_t *attacker, const vec3_t sta
     }
 
     // we've hit something, so damage it
-    if ((tr.ent != ent) && G_TakesDamage(tr.ent)) {
+    if ((tr.ent != ent) && (tr.ent != attacker) && G_TakesDamage(tr.ent)) {
       G_Damage(&(g_damage_t) {
         .target = tr.ent,
         .inflictor = ent,

--- a/src/game/common/g_ballistics.h
+++ b/src/game/common/g_ballistics.h
@@ -24,17 +24,17 @@
 #include "g_types.h"
 
 #if defined(__G_LOCAL_H__)
-void G_BlasterProjectile(g_entity_t *ent, const vec3_t start, const vec3_t dir, int32_t speed, int32_t damage, int32_t knockback);
+void G_BlasterProjectile(g_entity_t *ent, g_entity_t *attacker, const vec3_t start, const vec3_t dir, int32_t speed, int32_t damage, int32_t knockback, uint32_t mod);
 void G_BulletProjectile(g_entity_t *ent, const vec3_t start, const vec3_t dir, int32_t damage, int32_t knockback, int32_t hspread, int32_t vspread, int32_t mod);
-void G_NailProjectile(g_entity_t *ent, const vec3_t start, const vec3_t dir, int32_t speed, int32_t damage, int32_t knockback, int32_t mod);
+void G_NailProjectile(g_entity_t *ent, g_entity_t *attacker, const vec3_t start, const vec3_t dir, int32_t speed, int32_t damage, int32_t knockback, uint32_t mod);
 void G_ShotgunProjectiles(g_entity_t *ent, const vec3_t start, const vec3_t dir, int32_t damage, int32_t knockback, int32_t hspread, int32_t vspread, int32_t count, int32_t mod);
 void G_HyperblasterProjectile(g_entity_t *ent, const vec3_t start, const vec3_t dir, int32_t speed, int32_t damage, int32_t knockback);
-void G_GrenadeProjectile(g_entity_t *ent, const vec3_t start, const vec3_t dir, int32_t speed, int32_t damage, int32_t knockback, float damage_radius, uint32_t timer);
+void G_GrenadeProjectile(g_entity_t *ent, g_entity_t *attacker, const vec3_t start, const vec3_t dir, int32_t speed, int32_t damage, int32_t knockback, float damage_radius, uint32_t timer, uint32_t mod);
 void G_QuakeGrenadeProjectile(g_entity_t *ent, const vec3_t start, const vec3_t dir, int32_t speed, int32_t damage, int32_t knockback, float damage_radius, uint32_t timer);
-void G_RocketProjectile(g_entity_t *ent, const vec3_t start, const vec3_t dir, int32_t speed, int32_t damage, int32_t knockback, float damage_radius);
+void G_RocketProjectile(g_entity_t *ent, g_entity_t *attacker, const vec3_t start, const vec3_t dir, int32_t speed, int32_t damage, int32_t knockback, float damage_radius, uint32_t mod);
 void G_QuakeRocketProjectile(g_entity_t *ent, const vec3_t start, const vec3_t dir, int32_t speed, int32_t damage, int32_t knockback, float damage_radius);
 void G_LightningProjectile(g_entity_t *ent, const vec3_t start, const vec3_t dir, int32_t damage, int32_t knockback, int32_t mod, int32_t discharge_mod);
-void G_RailgunProjectile(g_entity_t *ent, const vec3_t start, const vec3_t dir, int32_t damage, int32_t knockback);
+void G_RailgunProjectile(g_entity_t *ent, g_entity_t *attacker, const vec3_t start, const vec3_t dir, int32_t damage, int32_t knockback, uint32_t mod);
 void G_BfgProjectile(g_entity_t *ent, const vec3_t start, const vec3_t dir, int32_t speed, int32_t damage, int32_t knockback, float damage_radius);
 void G_HandGrenadeProjectile(g_entity_t *ent, g_entity_t *projectile, const vec3_t start, const vec3_t dir, int32_t speed, int32_t damage, int32_t knockback, float damage_radius, uint32_t timer);
 void G_GrenadeProjectile_Touch(g_entity_t *ent, g_entity_t *other, const cm_trace_t *trace);

--- a/src/game/common/g_client.c
+++ b/src/game/common/g_client.c
@@ -356,7 +356,7 @@ static void G_ClientObituary(g_client_t *cl, g_entity_t *attacker, uint32_t mod)
 static void G_ClientGiblet_Touch(g_entity_t *ent, g_entity_t *other, const cm_trace_t *trace) {
 
   // G_TouchOccupy passes no trace, and is the only way a giblet reaches a player
-  if (ent->damage && other != ent->owner && other->take_damage) {
+  if (ent->damage && other->client && other != ent->owner && other->take_damage) {
     if ((uint32_t) ent->count <= g_level.time) {
       ent->count = g_level.time + 500;
 
@@ -556,13 +556,6 @@ void G_Giblets(const g_giblets_t *giblets) {
  */
 static void G_ClientCorpse_Die(g_entity_t *ent, g_entity_t *attacker, uint32_t mod) {
 
-  const box3_t bounds[NUM_GIB_MODELS] = {
-    Box3f(12.f, 12.f, 12.f),
-    Box3f(12.f, 12.f, 12.f),
-    Box3f(8.f, 8.f, 8.f),
-    Box3f(16.f, 16.f, 16.f),
-  };
-
   G_Giblets(&(const g_giblets_t) {
     .origin = ent->s.origin,
     .velocity = ent->velocity,
@@ -572,7 +565,7 @@ static void G_ClientCorpse_Die(g_entity_t *ent, g_entity_t *attacker, uint32_t m
   });
 
   if (ent->client) {
-    ent->bounds = bounds[2];
+    ent->bounds = Box3f(8.f, 8.f, 8.f);
 
     const int32_t h = Clampf(-5.0 * ent->health, 100, 500);
     

--- a/src/game/common/g_client.c
+++ b/src/game/common/g_client.c
@@ -56,6 +56,12 @@ static bool G_IsDeathCamMod(uint32_t mod) {
     case MOD_FIREBALL:
     case MOD_ACT_OF_GOD:
     case MOD_BOB:
+    case MOD_TRAP_BLASTER:
+    case MOD_TRAP_NAIL:
+    case MOD_TRAP_ROCKET:
+    case MOD_TRAP_GRENADE:
+    case MOD_TRAP_LASER:
+    case MOD_TRAP_GIBLETS:
       return true;
     default:
       return false;
@@ -163,6 +169,24 @@ static void G_ClientObituary(g_client_t *cl, g_entity_t *attacker, uint32_t mod)
       case MOD_QUAKE_THUNDERBOLT_DISCHARGE:
         msg = "%s accepts %s's discharge :lightning:";
         break;
+      case MOD_TURRET_BLASTER:
+        msg = "%s was lit up by %s's turret :blaster:";
+        break;
+      case MOD_TURRET_NAIL:
+        msg = "%s was stapled down by %s's turret :nailgun:";
+        break;
+      case MOD_TURRET_ROCKET:
+        msg = "%s was shelled by %s's turret :rocket:";
+        break;
+      case MOD_TURRET_GRENADE:
+        msg = "%s caught %s's care package :grenade:";
+        break;
+      case MOD_TURRET_LASER:
+        msg = "%s was traced by %s's turret :railgun:";
+        break;
+      case MOD_TURRET_GIBLETS:
+        msg = "%s was fed %s's leftovers :death:";
+        break;
       case MOD_TELEFRAG:
         msg = "%s tried to invade %s's personal space :telefrag:";
         break;
@@ -213,6 +237,24 @@ static void G_ClientObituary(g_client_t *cl, g_entity_t *attacker, uint32_t mod)
         break;
       case MOD_TRIGGER_HURT:
         msg = "%s was in the wrong place :actofgod:";
+        break;
+      case MOD_TRAP_BLASTER:
+        msg = "%s got a face full of trap :blaster:";
+        break;
+      case MOD_TRAP_NAIL:
+        msg = "%s was nailed to the wall :nailgun:";
+        break;
+      case MOD_TRAP_ROCKET:
+        msg = "%s should have taken the other tunnel :rocket:";
+        break;
+      case MOD_TRAP_GRENADE:
+        msg = "%s stepped on it :grenade:";
+        break;
+      case MOD_TRAP_LASER:
+        msg = "%s was cut down to size :railgun:";
+        break;
+      case MOD_TRAP_GIBLETS:
+        msg = "%s was pelted to death with meat :death:";
         break;
       case MOD_ACT_OF_GOD:
         msg = "%s was killed by an act of god :actofgod:";
@@ -312,6 +354,25 @@ static void G_ClientObituary(g_client_t *cl, g_entity_t *attacker, uint32_t mod)
  * @brief Play a sloppy sound when impacting the world.
  */
 static void G_ClientGiblet_Touch(g_entity_t *ent, g_entity_t *other, const cm_trace_t *trace) {
+
+  // G_TouchOccupy passes no trace, and is the only way a giblet reaches a player
+  if (ent->damage && other != ent->owner && other->take_damage) {
+    if ((uint32_t) ent->count <= g_level.time) {
+      ent->count = g_level.time + 500;
+
+      G_Damage(&(g_damage_t) {
+        .target = other,
+        .inflictor = ent,
+        .attacker = ent->owner,
+        .dir = ent->velocity,
+        .point = ent->s.origin,
+        .normal = trace ? trace->plane.normal : Vec3_Zero(),
+        .damage = ent->damage,
+        .knockback = ent->damage,
+        .mod = ent->mod
+      });
+    }
+  }
 
   if (trace == NULL) {
     return;
@@ -419,6 +480,76 @@ static void G_ClientCorpse_Pain(g_entity_t *ent, g_entity_t *attacker, int16_t d
 }
 
 /**
+ * @brief Scatters a burst of giblets from the given origin, inheriting the given velocity.
+ * Giblets bounce when damaged, and eventually sink through the floor and disappear. When
+ * `damage` is set they also injure whatever they strike, credited to `attacker`.
+ */
+void G_Giblets(const g_giblets_t *giblets) {
+
+  const box3_t bounds[NUM_GIB_MODELS] = {
+    Box3f(12.f, 12.f, 12.f),
+    Box3f(12.f, 12.f, 12.f),
+    Box3f(8.f, 8.f, 8.f),
+    Box3f(16.f, 16.f, 16.f),
+  };
+
+  for (int32_t i = 0; i < giblets->count; i++) {
+
+    int32_t gib_index;
+    if (i == 0) { // 0 is always chest
+      gib_index = (NUM_GIB_MODELS - 1);
+    } else if (i == 1 && giblets->head) {
+      gib_index = 2;
+    } else { // pick forearm/femur
+      gib_index = RandomRangei(0, NUM_GIB_MODELS - 2);
+    }
+
+    g_entity_t *gib = G_AllocEntity(__func__);
+
+    gib->s.origin = giblets->origin;
+
+    gib->bounds = bounds[gib_index];
+
+    gib->solid = giblets->damage ? SOLID_TRIGGER : SOLID_DEAD;
+
+    gib->s.model1 = g_media.models.gibs[gib_index];
+    gib->sound = g_media.sounds.gib_hits[i % NUM_GIB_SOUNDS];
+
+    gib->velocity = giblets->velocity;
+
+    const int32_t h = Clampf(-5.0 * gib->health, 100, 500);
+
+    gib->velocity.x += RandomRangef(-h, h);
+    gib->velocity.y += RandomRangef(-h, h);
+    gib->velocity.z += RandomRangef(giblets->lift, giblets->lift + h);
+
+    for (int32_t i = 0; i < 3; ++i) {
+      gib->avelocity.xyz[i] = RandomRangef(-100.f, 100.f);
+      gib->s.angles.xyz[i] = RandomRangef(0, 360.f);
+    }
+
+    gib->clip_mask = CONTENTS_MASK_CLIP_CORPSE;
+    gib->dead = true;
+    gib->mass = (gib_index + 1) * 20.0;
+    gib->move_type = MOVE_TYPE_BOUNCE;
+    gib->next_think = g_level.time + QUETOO_TICK_MILLIS;
+    gib->take_damage = true;
+    gib->owner = giblets->attacker;
+    gib->damage = giblets->damage;
+    gib->mod = giblets->mod;
+    gib->Think = G_ClientCorpse_Think;
+    gib->Touch = G_ClientGiblet_Touch;
+
+    gi.LinkEntity(gib);
+  }
+
+  gi.WriteByte(SV_CMD_TEMP_ENTITY);
+  gi.WriteByte(TE_GIB);
+  gi.WritePosition(giblets->origin);
+  gi.Multicast(giblets->origin, MULTICAST_PVS);
+}
+
+/**
  * @brief Corpses explode into giblets when killed. Giblets receive the
  * velocity of the corpse, and bounce when damaged. They eventually sink
  * through the floor and disappear.
@@ -432,58 +563,13 @@ static void G_ClientCorpse_Die(g_entity_t *ent, g_entity_t *attacker, uint32_t m
     Box3f(16.f, 16.f, 16.f),
   };
 
-  const int32_t count = RandomRangei(4, 8);
-  for (int32_t i = 0; i < count; i++) {
-
-    int32_t gib_index;
-    if (i == 0) { // 0 is always chest
-      gib_index = (NUM_GIB_MODELS - 1);
-    } else if (i == 1 && !ent->client) { // if we're not client, drop a head
-      gib_index = 2;
-    } else { // pick forearm/femur
-      gib_index = RandomRangei(0, NUM_GIB_MODELS - 2);
-    }
-
-    g_entity_t *gib = G_AllocEntity(__func__);
-
-    gib->s.origin = ent->s.origin;
-
-    gib->bounds = bounds[gib_index];
-
-    gib->solid = SOLID_DEAD;
-
-    gib->s.model1 = g_media.models.gibs[gib_index];
-    gib->sound = g_media.sounds.gib_hits[i % NUM_GIB_SOUNDS];
-
-    gib->velocity = ent->velocity;
-
-    const int32_t h = Clampf(-5.0 * gib->health, 100, 500);
-
-    gib->velocity.x += RandomRangef(-h, h);
-    gib->velocity.y += RandomRangef(-h, h);
-    gib->velocity.z += RandomRangef(100.f, 100.f + h);
-
-    for (int32_t i = 0; i < 3; ++i) {
-      gib->avelocity.xyz[i] = RandomRangef(-100.f, 100.f);
-      gib->s.angles.xyz[i] = RandomRangef(0, 360.f);
-    }
-
-    gib->clip_mask = CONTENTS_MASK_CLIP_CORPSE;
-    gib->dead = true;
-    gib->mass = (gib_index + 1) * 20.0;
-    gib->move_type = MOVE_TYPE_BOUNCE;
-    gib->next_think = g_level.time + QUETOO_TICK_MILLIS;
-    gib->take_damage = true;
-    gib->Think = G_ClientCorpse_Think;
-    gib->Touch = G_ClientGiblet_Touch;
-
-    gi.LinkEntity(gib);
-  }
-
-  gi.WriteByte(SV_CMD_TEMP_ENTITY);
-  gi.WriteByte(TE_GIB);
-  gi.WritePosition(ent->s.origin);
-  gi.Multicast(ent->s.origin, MULTICAST_PVS);
+  G_Giblets(&(const g_giblets_t) {
+    .origin = ent->s.origin,
+    .velocity = ent->velocity,
+    .count = RandomRangei(4, 8),
+    .head = ent->client == NULL,
+    .lift = 100.f,
+  });
 
   if (ent->client) {
     ent->bounds = bounds[2];

--- a/src/game/common/g_client.c
+++ b/src/game/common/g_client.c
@@ -368,7 +368,7 @@ static void G_ClientGiblet_Touch(g_entity_t *ent, g_entity_t *other, const cm_tr
         .point = ent->s.origin,
         .normal = trace ? trace->plane.normal : Vec3_Zero(),
         .damage = ent->damage,
-        .knockback = ent->damage,
+        .knockback = ent->knockback,
         .mod = ent->mod
       });
     }
@@ -532,13 +532,20 @@ void G_Giblets(const g_giblets_t *giblets) {
     gib->dead = true;
     gib->mass = (gib_index + 1) * 20.0;
     gib->move_type = MOVE_TYPE_BOUNCE;
-    gib->next_think = g_level.time + QUETOO_TICK_MILLIS;
     gib->take_damage = true;
     gib->owner = giblets->attacker;
     gib->damage = giblets->damage;
+    gib->knockback = giblets->knockback;
     gib->mod = giblets->mod;
-    gib->Think = G_ClientCorpse_Think;
     gib->Touch = G_ClientGiblet_Touch;
+
+    if (giblets->lifetime) {
+      gib->Think = G_FreeEntity;
+      gib->next_think = g_level.time + giblets->lifetime;
+    } else {
+      gib->Think = G_ClientCorpse_Think;
+      gib->next_think = g_level.time + QUETOO_TICK_MILLIS;
+    }
 
     gi.LinkEntity(gib);
   }

--- a/src/game/common/g_client.h
+++ b/src/game/common/g_client.h
@@ -31,4 +31,5 @@ void G_ClientDisconnect(g_client_t *cl);
 void G_ClientRespawn(g_client_t *cl, bool voluntary);
 void G_ClientThink(g_client_t *cl, pm_cmd_t *cmd);
 void G_ClientUserInfoChanged(g_client_t *cl, const char *user_info);
+void G_Giblets(const g_giblets_t *giblets);
 #endif

--- a/src/game/common/g_combat.c
+++ b/src/game/common/g_combat.c
@@ -98,6 +98,24 @@ static const char *G_WeaponNameForMod(g_means_of_death mod) {
       return "Quake Thunderbolt";
     case MOD_FIREBALL:
       return "Fireball";
+    case MOD_TRAP_BLASTER:
+    case MOD_TURRET_BLASTER:
+      return "Blaster";
+    case MOD_TRAP_NAIL:
+    case MOD_TURRET_NAIL:
+      return "Nailgun";
+    case MOD_TRAP_ROCKET:
+    case MOD_TURRET_ROCKET:
+      return "Rocket Launcher";
+    case MOD_TRAP_GRENADE:
+    case MOD_TURRET_GRENADE:
+      return "Grenade Launcher";
+    case MOD_TRAP_LASER:
+    case MOD_TURRET_LASER:
+      return "Railgun";
+    case MOD_TRAP_GIBLETS:
+    case MOD_TURRET_GIBLETS:
+      return "Giblets";
 #if defined(G_HOOK)
     case MOD_HOOK:
       return "Hook";

--- a/src/game/common/g_entity.c
+++ b/src/game/common/g_entity.c
@@ -74,9 +74,11 @@ static const g_entity_class_t g_entity_classes[] = {
 
   { "path_corner", G_info_notnull },
 
+  { "target_ballistics", G_target_ballistics },
   { "target_light", G_target_light },
   { "target_speaker", G_target_speaker },
   { "target_string", G_target_string },
+  { "target_turret", G_target_turret },
 
   { "trigger_always", G_trigger_always },
   { "trigger_exec", G_trigger_exec },

--- a/src/game/common/g_entity_target.c
+++ b/src/game/common/g_entity_target.c
@@ -181,3 +181,391 @@ void G_target_string(g_entity_t *ent) {
 
   // the rest is handled by G_UseTargets
 }
+
+#define BALLISTICS_START_ON 0x1
+#define BALLISTICS_TOGGLE   0x2
+#define BALLISTICS_BLASTER  0x4
+#define BALLISTICS_NAIL     0x8
+#define BALLISTICS_ROCKET   0x10
+#define BALLISTICS_GRENADE  0x20
+#define BALLISTICS_LASER    0x40
+#define BALLISTICS_GIBLETS  0x80
+
+#define BALLISTICS_PROJECTILE (BALLISTICS_BLASTER | BALLISTICS_NAIL | BALLISTICS_ROCKET | \
+                               BALLISTICS_GRENADE | BALLISTICS_LASER | BALLISTICS_GIBLETS)
+
+/**
+ * @brief Fires a blaster bolt from a `target_ballistics` or `target_turret`.
+ */
+static void G_target_ballistics_Blaster(g_entity_t *ent, g_entity_t *attacker, const vec3_t start, const vec3_t dir, uint32_t mod) {
+  G_BlasterProjectile(ent, attacker, start, dir, ent->speed, ent->damage, ent->knockback, mod);
+}
+
+/**
+ * @brief Fires a spike from a `target_ballistics` or `target_turret`.
+ */
+static void G_target_ballistics_Nail(g_entity_t *ent, g_entity_t *attacker, const vec3_t start, const vec3_t dir, uint32_t mod) {
+  G_NailProjectile(ent, attacker, start, dir, ent->speed, ent->damage, ent->knockback, mod);
+}
+
+/**
+ * @brief Fires a rocket from a `target_ballistics` or `target_turret`.
+ */
+static void G_target_ballistics_Rocket(g_entity_t *ent, g_entity_t *attacker, const vec3_t start, const vec3_t dir, uint32_t mod) {
+  G_RocketProjectile(ent, attacker, start, dir, ent->speed, ent->damage, ent->knockback, ent->damage_radius, mod);
+}
+
+/**
+ * @brief Fires a grenade from a `target_ballistics` or `target_turret`.
+ */
+static void G_target_ballistics_Grenade(g_entity_t *ent, g_entity_t *attacker, const vec3_t start, const vec3_t dir, uint32_t mod) {
+  G_GrenadeProjectile(ent, attacker, start, dir, ent->speed, ent->damage, ent->knockback,
+    ent->damage_radius, SECONDS_TO_MILLIS(g_balance_grenadelauncher_timer->value), mod);
+}
+
+/**
+ * @brief Fires an instant traced beam from a `target_ballistics` or `target_turret`.
+ */
+static void G_target_ballistics_Laser(g_entity_t *ent, g_entity_t *attacker, const vec3_t start, const vec3_t dir, uint32_t mod) {
+  G_RailgunProjectile(ent, attacker, start, dir, ent->damage, ent->knockback, mod);
+}
+
+/**
+ * @brief Scatters giblets from a `target_ballistics` or `target_turret`.
+ */
+static void G_target_ballistics_Giblets(g_entity_t *ent, g_entity_t *attacker, const vec3_t start, const vec3_t dir, uint32_t mod) {
+
+  G_Giblets(&(const g_giblets_t) {
+    .origin = start,
+    .velocity = Vec3_Scale(dir, ent->speed),
+    .count = RandomRangei(2, 5),
+    .head = true,
+    .damage = ent->damage,
+    .attacker = attacker,
+    .mod = mod
+  });
+}
+
+typedef struct {
+  uint32_t spawn_flag;
+  void (*Fire)(g_entity_t *ent, g_entity_t *attacker, const vec3_t start, const vec3_t dir, uint32_t mod);
+  g_muzzle_flash_t flash;
+  uint32_t trap_mod;
+  uint32_t turret_mod;
+  cvar_t **damage;
+  cvar_t **knockback;
+  cvar_t **speed;
+  cvar_t **radius;
+  int32_t default_damage;
+  int32_t default_speed;
+} g_ballistics_type_t;
+
+static const g_ballistics_type_t g_ballistics_types[] = {
+  {
+    .spawn_flag = BALLISTICS_BLASTER,
+    .Fire = G_target_ballistics_Blaster,
+    .flash = MZ_BLASTER,
+    .trap_mod = MOD_TRAP_BLASTER,
+    .turret_mod = MOD_TURRET_BLASTER,
+    .damage = &g_balance_blaster_damage,
+    .knockback = &g_balance_blaster_knockback,
+    .speed = &g_balance_blaster_speed,
+  }, {
+    .spawn_flag = BALLISTICS_NAIL,
+    .Fire = G_target_ballistics_Nail,
+    .flash = MZ_QUAKE_NAILGUN,
+    .trap_mod = MOD_TRAP_NAIL,
+    .turret_mod = MOD_TURRET_NAIL,
+    .damage = &g_balance_quake_nailgun_damage,
+    .knockback = &g_balance_quake_nailgun_knockback,
+    .speed = &g_balance_quake_nailgun_speed,
+  }, {
+    .spawn_flag = BALLISTICS_ROCKET,
+    .Fire = G_target_ballistics_Rocket,
+    .flash = MZ_ROCKET_LAUNCHER,
+    .trap_mod = MOD_TRAP_ROCKET,
+    .turret_mod = MOD_TURRET_ROCKET,
+    .damage = &g_balance_rocketlauncher_damage,
+    .knockback = &g_balance_rocketlauncher_knockback,
+    .speed = &g_balance_rocketlauncher_speed,
+    .radius = &g_balance_rocketlauncher_radius,
+  }, {
+    .spawn_flag = BALLISTICS_GRENADE,
+    .Fire = G_target_ballistics_Grenade,
+    .flash = MZ_GRENADE_LAUNCHER,
+    .trap_mod = MOD_TRAP_GRENADE,
+    .turret_mod = MOD_TURRET_GRENADE,
+    .damage = &g_balance_grenadelauncher_damage,
+    .knockback = &g_balance_grenadelauncher_knockback,
+    .speed = &g_balance_grenadelauncher_speed,
+    .radius = &g_balance_grenadelauncher_radius,
+  }, {
+    .spawn_flag = BALLISTICS_LASER,
+    .Fire = G_target_ballistics_Laser,
+    .flash = MZ_RAILGUN,
+    .trap_mod = MOD_TRAP_LASER,
+    .turret_mod = MOD_TURRET_LASER,
+    .damage = &g_balance_railgun_damage,
+    .knockback = &g_balance_railgun_knockback,
+  }, {
+    .spawn_flag = BALLISTICS_GIBLETS,
+    .Fire = G_target_ballistics_Giblets,
+    .flash = MZ_LOGOUT,
+    .trap_mod = MOD_TRAP_GIBLETS,
+    .turret_mod = MOD_TURRET_GIBLETS,
+    .default_damage = 10,
+    .default_speed = 500,
+  }
+};
+
+/**
+ * @brief Resolves the projectile the entity was configured to fire, defaulting to the blaster.
+ */
+static const g_ballistics_type_t *G_target_ballistics_Type(const g_entity_t *ent) {
+
+  for (size_t i = 0; i < lengthof(g_ballistics_types); i++) {
+    if (ent->spawn_flags & g_ballistics_types[i].spawn_flag) {
+      return &g_ballistics_types[i];
+    }
+  }
+
+  return &g_ballistics_types[0];
+}
+
+/**
+ * @brief Emits a single projectile along the given direction, with the muzzle pushed clear of the
+ * brushwork the entity is typically embedded in.
+ */
+static void G_target_ballistics_Fire(g_entity_t *ent, g_entity_t *attacker, const vec3_t dir, uint32_t mod) {
+
+  const g_ballistics_type_t *type = G_target_ballistics_Type(ent);
+
+  const vec3_t aim = Vec3_RandomizeDir(dir, ent->accel);
+  const vec3_t start = Vec3_Fmaf(ent->s.origin, 8.f, aim);
+
+  type->Fire(ent, attacker, start, aim, mod);
+
+  G_WorldMuzzleFlash(start, aim, type->flash);
+}
+
+/**
+ * @brief Resolves the direction a trap fires in, tracking its target entity if it has one.
+ */
+static vec3_t G_target_ballistics_Dir(g_entity_t *ent) {
+
+  if (ent->target && ent->enemy == NULL) {
+    ent->enemy = G_PickTarget(ent->target);
+
+    if (ent->enemy == NULL) {
+      G_Warn("%s has invalid target %s\n", etos(ent), ent->target);
+      ent->target = NULL;
+    }
+  }
+
+  if (ent->enemy) {
+    return Vec3_Normalize(Vec3_Subtract(Box3_Center(ent->enemy->abs_bounds), ent->s.origin));
+  }
+
+  return ent->move_dir;
+}
+
+/**
+ * @brief Think callback for a free-running trap; fires and re-arms itself.
+ */
+static void G_target_ballistics_Think(g_entity_t *ent) {
+
+  G_target_ballistics_Fire(ent, ent, G_target_ballistics_Dir(ent), G_target_ballistics_Type(ent)->trap_mod);
+
+  if (ent->count) {
+    const float wait = ent->wait * 1000.f + ent->random * 1000.f * RandomRangef(-1.f, 1.f);
+    ent->next_think = g_level.time + (uint32_t) Maxf(wait, QUETOO_TICK_MILLIS);
+  } else {
+    ent->next_think = 0;
+  }
+}
+
+/**
+ * @brief Handles use activation of a `target_ballistics`, toggling a free-running trap or firing a
+ * single shot after an optional delay.
+ */
+static void G_target_ballistics_Use(g_entity_t *ent, g_entity_t *other, g_entity_t *activator) {
+
+  if (ent->spawn_flags & BALLISTICS_TOGGLE) {
+
+    ent->count = !ent->count;
+
+    if (ent->count) {
+      ent->next_think = g_level.time + (uint32_t) Maxf(ent->delay * 1000.f, QUETOO_TICK_MILLIS);
+    } else {
+      ent->next_think = 0;
+    }
+
+    return;
+  }
+
+  if (ent->timestamp > g_level.time) {
+    return;
+  }
+
+  ent->timestamp = g_level.time + ent->wait * 1000.f;
+
+  if (ent->delay) {
+    ent->next_think = g_level.time + (uint32_t) Maxf(ent->delay * 1000.f, QUETOO_TICK_MILLIS);
+  } else {
+    G_target_ballistics_Fire(ent, ent, G_target_ballistics_Dir(ent), G_target_ballistics_Type(ent)->trap_mod);
+  }
+}
+
+/**
+ * @brief Handles use activation of a `target_turret`, firing along the activator's view and
+ * crediting them with any damage.
+ */
+static void G_target_turret_Use(g_entity_t *ent, g_entity_t *other, g_entity_t *activator) {
+
+  if (ent->timestamp > g_level.time) {
+    return;
+  }
+
+  ent->timestamp = g_level.time + ent->wait * 1000.0;
+
+  if (activator && activator->client) {
+    ent->s.client = activator->s.client;
+    G_target_ballistics_Fire(ent, activator, activator->client->forward, G_target_ballistics_Type(ent)->turret_mod);
+  } else {
+    ent->s.client = MAX_CLIENTS;
+    G_target_ballistics_Fire(ent, ent, ent->move_dir, G_target_ballistics_Type(ent)->trap_mod);
+  }
+}
+
+/**
+ * @brief Common initialization for the ballistics entities, resolving the projectile and applying
+ * the balance defaults the mapper did not override.
+ */
+static void G_target_ballistics_Init(g_entity_t *ent) {
+
+  const uint32_t projectile = ent->spawn_flags & BALLISTICS_PROJECTILE;
+  if (projectile & (projectile - 1)) {
+    G_Warn("%s has more than one projectile flag set\n", etos(ent));
+  }
+
+  const g_ballistics_type_t *type = G_target_ballistics_Type(ent);
+
+  if (ent->damage == 0 && type->damage) {
+    ent->damage = (*type->damage)->integer;
+  }
+
+  if (ent->speed == 0.f) {
+    ent->speed = type->speed ? (*type->speed)->integer : type->default_speed;
+  }
+
+  if (ent->damage == 0 && type->damage == NULL) {
+    ent->damage = type->default_damage;
+  }
+
+  if (type->radius) {
+    ent->damage_radius = (*type->radius)->value;
+  }
+
+  ent->knockback = gi.EntityValue(ent->def, "knockback")->integer;
+  if (ent->knockback == 0 && type->knockback) {
+    ent->knockback = (*type->knockback)->integer;
+  }
+
+  ent->accel = Clampf(gi.EntityValue(ent->def, "spread")->value, 0.f, 1.f);
+
+  if (!(gi.EntityValue(ent->def, "wait")->parsed & ENTITY_FLOAT)) {
+    ent->wait = 1.f;
+  }
+
+  ent->s.client = MAX_CLIENTS;
+
+  G_SetMoveDir(ent);
+
+  gi.LinkEntity(ent);
+}
+
+/*QUAKED target_ballistics (1 .3 .3) (-8 -8 -8) (8 8 8) start_on toggle blaster nail rocket grenade laser giblets
+ Fires projectiles at an interval, or each time it is used. Use these to build wall traps,
+ spike shooters and lasers.
+
+ -------- Keys --------
+ angles : The angles at which projectiles are fired. Use -1 for up, -2 for down.
+ delay : The delay in seconds between being used and firing (default 0).
+ dmg : The damage inflicted by each projectile (default varies by projectile).
+ knockback : The knockback applied by each projectile (default varies by projectile).
+ random : Random time variance in seconds added to "wait" (default 0).
+ speed : The projectile speed in units per second (default varies by projectile).
+ spread : The cone of fire, from 0.0 for pinpoint to 1.0 for wild (default 0).
+ target : An entity to aim at, re-evaluated on every shot. Overrides "angles".
+ targetname : The target name of this entity.
+ wait : The interval in seconds between shots (default 1.0).
+
+ -------- Spawn flags --------
+ start_on : Fires on its own from level start, without being used.
+ toggle : Using this entity toggles it on and off, rather than firing one shot.
+ blaster : Fires blaster bolts. This is the default.
+ nail : Fires spikes.
+ rocket : Fires rockets.
+ grenade : Fires grenades.
+ laser : Fires an instant traced beam. Set "wait" to 0 for a continuous laser.
+ giblets : Fires giblets.
+
+ -------- Notes --------
+ Place this entity in open air, in front of the brushwork that represents it, not embedded
+ within it. Projectiles that would spawn inside a wall are pulled back to the entity origin.
+
+ Set exactly one projectile flag. Traps do not spare whoever triggered them. For a version
+ players can aim and take credit for, use target_turret.
+*/
+void G_target_ballistics(g_entity_t *ent) {
+
+  G_target_ballistics_Init(ent);
+
+  ent->Use = G_target_ballistics_Use;
+  ent->Think = G_target_ballistics_Think;
+
+  if (ent->spawn_flags & BALLISTICS_START_ON) {
+    ent->count = 1;
+    ent->next_think = g_level.time + RandomRangeu(1, 1000);
+  }
+}
+
+/*QUAKED target_turret (1 .6 .2) (-8 -8 -8) (8 8 8) x x blaster nail rocket grenade laser giblets
+ Fires a projectile along the view of whoever uses it, and credits them with the kill.
+ Surround it with a trigger_multiple that targets it, and players who step in behind it
+ will operate it.
+
+ -------- Keys --------
+ angles : The angles to fire at when used by something other than a player.
+ dmg : The damage inflicted by each projectile (default varies by projectile).
+ knockback : The knockback applied by each projectile (default varies by projectile).
+ speed : The projectile speed in units per second (default varies by projectile).
+ spread : The cone of fire, from 0.0 for pinpoint to 1.0 for wild (default 0).
+ targetname : The target name of this entity.
+ wait : The minimum interval in seconds between shots (default 1.0).
+
+ -------- Spawn flags --------
+ x
+ x
+ blaster : Fires blaster bolts. This is the default.
+ nail : Fires spikes.
+ rocket : Fires rockets.
+ grenade : Fires grenades.
+ laser : Fires an instant traced beam.
+ giblets : Fires giblets.
+
+ -------- Notes --------
+ Projectiles leave the turret, not the player, but carry the player's colors and are
+ credited to them. The muzzle flash uses the weapon's own colors.
+
+ The operator cannot be struck by their own projectiles, but the rocket and grenade
+ types still splash them, so leave room behind the turret.
+
+ Give the trigger_multiple a short "wait" for sustained fire while the player stands in it.
+*/
+void G_target_turret(g_entity_t *ent) {
+
+  G_target_ballistics_Init(ent);
+
+  ent->Use = G_target_turret_Use;
+}

--- a/src/game/common/g_entity_target.c
+++ b/src/game/common/g_entity_target.c
@@ -243,8 +243,10 @@ static void G_target_ballistics_Giblets(g_entity_t *ent, g_entity_t *attacker, c
     .count = RandomRangei(2, 5),
     .head = true,
     .damage = ent->damage,
+    .knockback = ent->knockback,
     .attacker = attacker,
-    .mod = mod
+    .mod = mod,
+    .lifetime = 3000
   });
 }
 
@@ -254,6 +256,7 @@ typedef struct {
   g_muzzle_flash_t flash;
   uint32_t trap_mod;
   uint32_t turret_mod;
+  float min_wait;
   cvar_t **damage;
   cvar_t **knockback;
   cvar_t **speed;
@@ -265,6 +268,7 @@ typedef struct {
 static const g_ballistics_type_t g_ballistics_types[] = {
   {
     .spawn_flag = BALLISTICS_BLASTER,
+    .min_wait = .1f,
     .Fire = G_target_ballistics_Blaster,
     .flash = MZ_BLASTER,
     .trap_mod = MOD_TRAP_BLASTER,
@@ -274,6 +278,7 @@ static const g_ballistics_type_t g_ballistics_types[] = {
     .speed = &g_balance_blaster_speed,
   }, {
     .spawn_flag = BALLISTICS_NAIL,
+    .min_wait = .1f,
     .Fire = G_target_ballistics_Nail,
     .flash = MZ_QUAKE_NAILGUN,
     .trap_mod = MOD_TRAP_NAIL,
@@ -283,6 +288,7 @@ static const g_ballistics_type_t g_ballistics_types[] = {
     .speed = &g_balance_quake_nailgun_speed,
   }, {
     .spawn_flag = BALLISTICS_ROCKET,
+    .min_wait = .1f,
     .Fire = G_target_ballistics_Rocket,
     .flash = MZ_ROCKET_LAUNCHER,
     .trap_mod = MOD_TRAP_ROCKET,
@@ -293,6 +299,7 @@ static const g_ballistics_type_t g_ballistics_types[] = {
     .radius = &g_balance_rocketlauncher_radius,
   }, {
     .spawn_flag = BALLISTICS_GRENADE,
+    .min_wait = .1f,
     .Fire = G_target_ballistics_Grenade,
     .flash = MZ_GRENADE_LAUNCHER,
     .trap_mod = MOD_TRAP_GRENADE,
@@ -315,6 +322,7 @@ static const g_ballistics_type_t g_ballistics_types[] = {
     .flash = MZ_LOGOUT,
     .trap_mod = MOD_TRAP_GIBLETS,
     .turret_mod = MOD_TURRET_GIBLETS,
+    .min_wait = .25f,
     .default_damage = 10,
     .default_speed = 500,
   }
@@ -478,7 +486,7 @@ static void G_target_ballistics_Init(g_entity_t *ent) {
   }
 
   // only the laser is hitscan; the rest would exhaust the entity pool at zero
-  ent->wait = Maxf(ent->wait, type->Fire == G_target_ballistics_Laser ? 0.f : .1f);
+  ent->wait = Maxf(ent->wait, type->min_wait);
   ent->random = Maxf(ent->random, 0.f);
   ent->delay = Maxf(ent->delay, 0.f);
 

--- a/src/game/common/g_entity_target.c
+++ b/src/game/common/g_entity_target.c
@@ -235,8 +235,10 @@ static void G_target_ballistics_Laser(g_entity_t *ent, g_entity_t *attacker, con
  */
 static void G_target_ballistics_Giblets(g_entity_t *ent, g_entity_t *attacker, const vec3_t start, const vec3_t dir, uint32_t mod) {
 
+  const cm_trace_t tr = gi.Trace(ent->s.origin, start, Box3_Zero(), ent, CONTENTS_MASK_SOLID);
+
   G_Giblets(&(const g_giblets_t) {
-    .origin = start,
+    .origin = tr.fraction < 1.f ? ent->s.origin : start,
     .velocity = Vec3_Scale(dir, ent->speed),
     .count = RandomRangei(2, 5),
     .head = true,
@@ -353,17 +355,15 @@ static void G_target_ballistics_Fire(g_entity_t *ent, g_entity_t *attacker, cons
  */
 static vec3_t G_target_ballistics_Dir(g_entity_t *ent) {
 
-  if (ent->target && ent->enemy == NULL) {
-    ent->enemy = G_PickTarget(ent->target);
+  if (ent->target) {
+    const g_entity_t *target = G_PickTarget(ent->target);
 
-    if (ent->enemy == NULL) {
-      G_Warn("%s has invalid target %s\n", etos(ent), ent->target);
-      ent->target = NULL;
+    if (target) {
+      return Vec3_Normalize(Vec3_Subtract(Box3_Center(target->abs_bounds), ent->s.origin));
     }
-  }
 
-  if (ent->enemy) {
-    return Vec3_Normalize(Vec3_Subtract(Box3_Center(ent->enemy->abs_bounds), ent->s.origin));
+    G_Warn("%s has invalid target %s\n", etos(ent), ent->target);
+    ent->target = NULL;
   }
 
   return ent->move_dir;
@@ -477,6 +477,12 @@ static void G_target_ballistics_Init(g_entity_t *ent) {
     ent->wait = 1.f;
   }
 
+  // only the laser is hitscan; the rest would exhaust the entity pool at zero
+  ent->wait = Maxf(ent->wait, type->Fire == G_target_ballistics_Laser ? 0.f : .1f);
+  ent->random = Maxf(ent->random, 0.f);
+  ent->delay = Maxf(ent->delay, 0.f);
+
+  ent->count = 0;
   ent->s.client = MAX_CLIENTS;
 
   G_SetMoveDir(ent);
@@ -498,7 +504,7 @@ static void G_target_ballistics_Init(g_entity_t *ent) {
  spread : The cone of fire, from 0.0 for pinpoint to 1.0 for wild (default 0).
  target : An entity to aim at, re-evaluated on every shot. Overrides "angles".
  targetname : The target name of this entity.
- wait : The interval in seconds between shots (default 1.0).
+ wait : The interval in seconds between shots (default 1.0). Only the laser may set 0.
 
  -------- Spawn flags --------
  start_on : Fires on its own from level start, without being used.

--- a/src/game/common/g_entity_target.h
+++ b/src/game/common/g_entity_target.h
@@ -24,7 +24,9 @@
 #include "g_types.h"
 
 #if defined(__G_LOCAL_H__)
+void G_target_ballistics(g_entity_t *ent);
 void G_target_light(g_entity_t *ent);
 void G_target_speaker(g_entity_t *ent);
 void G_target_string(g_entity_t *ent);
+void G_target_turret(g_entity_t *ent);
 #endif

--- a/src/game/common/g_weapon.c
+++ b/src/game/common/g_weapon.c
@@ -406,13 +406,29 @@ void G_ClientWeaponThink(g_client_t *cl) {
 /**
  * @brief Broadcasts a muzzle flash event for the entity's current weapon.
  */
-static void G_MuzzleFlash(g_entity_t *ent, g_muzzle_flash_t flash) {
+static void G_ClientMuzzleFlash(g_entity_t *ent, g_muzzle_flash_t flash) {
 
   gi.WriteByte(SV_CMD_MUZZLE_FLASH);
   gi.WriteShort(ent->s.number);
   gi.WriteByte(flash);
 
   gi.Multicast(ent->s.origin, MULTICAST_PHS);
+}
+
+/**
+ * @brief Broadcasts a muzzle flash for a shooter the server does not transmit, such as a
+ * `target_ballistics`. The origin and direction accompany the flash, as there is no entity
+ * for the client to infer them from.
+ */
+void G_WorldMuzzleFlash(const vec3_t org, const vec3_t dir, g_muzzle_flash_t flash) {
+
+  gi.WriteByte(SV_CMD_MUZZLE_FLASH);
+  gi.WriteShort(MUZZLE_FLASH_WORLD);
+  gi.WriteByte(flash);
+  gi.WritePosition(org);
+  gi.WriteDir(dir);
+
+  gi.Multicast(org, MULTICAST_PHS);
 }
 
 /**
@@ -425,10 +441,10 @@ void G_FireBlaster(g_client_t *cl) {
 
     G_ClientProjectile(cl, &forward, &right, &up, &org, 1.0);
 
-    G_BlasterProjectile(cl->entity, org, forward, g_balance_blaster_speed->integer,
-      g_balance_blaster_damage->integer, g_balance_blaster_knockback->integer);
+    G_BlasterProjectile(cl->entity, cl->entity, org, forward, g_balance_blaster_speed->integer,
+      g_balance_blaster_damage->integer, g_balance_blaster_knockback->integer, MOD_BLASTER);
 
-    G_MuzzleFlash(cl->entity, MZ_BLASTER);
+    G_ClientMuzzleFlash(cl->entity, MZ_BLASTER);
 
     G_WeaponFired(cl, SECONDS_TO_MILLIS(g_balance_blaster_refire->value), cl->weapon->def.quantity);
   }
@@ -448,7 +464,7 @@ void G_FireShotgun(g_client_t *cl) {
       g_balance_shotgun_knockback->integer, g_balance_shotgun_spread_x->integer,
       g_balance_shotgun_spread_y->integer, g_balance_shotgun_pellets->integer, MOD_SHOTGUN);
 
-    G_MuzzleFlash(cl->entity, MZ_SHOTGUN);
+    G_ClientMuzzleFlash(cl->entity, MZ_SHOTGUN);
 
     G_WeaponFired(cl, SECONDS_TO_MILLIS(g_balance_shotgun_refire->value), cl->weapon->def.quantity);
   }
@@ -468,7 +484,7 @@ void G_FireSuperShotgun(g_client_t *cl) {
       g_balance_supershotgun_knockback->integer, g_balance_supershotgun_spread_x->integer,
       g_balance_supershotgun_spread_y->integer, g_balance_supershotgun_pellets->integer, MOD_SUPER_SHOTGUN);
 
-    G_MuzzleFlash(cl->entity, MZ_SUPER_SHOTGUN);
+    G_ClientMuzzleFlash(cl->entity, MZ_SUPER_SHOTGUN);
 
     G_WeaponFired(cl, SECONDS_TO_MILLIS(g_balance_supershotgun_refire->value), cl->weapon->def.quantity);
   }
@@ -488,7 +504,7 @@ void G_FireMachinegun(g_client_t *cl) {
       g_balance_machinegun_knockback->integer, g_balance_machinegun_spread_x->integer,
       g_balance_machinegun_spread_y->integer, MOD_MACHINEGUN);
 
-    G_MuzzleFlash(cl->entity, MZ_MACHINEGUN);
+    G_ClientMuzzleFlash(cl->entity, MZ_MACHINEGUN);
 
     G_WeaponFired(cl, SECONDS_TO_MILLIS(g_balance_machinegun_refire->value), cl->weapon->def.quantity);
   }
@@ -665,11 +681,11 @@ void G_FireGrenadeLauncher(g_client_t *cl) {
 
     G_ClientProjectile(cl, &forward, &right, &up, &org, 1.0);
 
-    G_GrenadeProjectile(cl->entity, org, forward, g_balance_grenadelauncher_speed->integer,
+    G_GrenadeProjectile(cl->entity, cl->entity, org, forward, g_balance_grenadelauncher_speed->integer,
       g_balance_grenadelauncher_damage->integer, g_balance_grenadelauncher_knockback->integer,
-      g_balance_grenadelauncher_radius->value, SECONDS_TO_MILLIS(g_balance_grenadelauncher_timer->value));
+      g_balance_grenadelauncher_radius->value, SECONDS_TO_MILLIS(g_balance_grenadelauncher_timer->value), 0);
 
-    G_MuzzleFlash(cl->entity, MZ_GRENADE_LAUNCHER);
+    G_ClientMuzzleFlash(cl->entity, MZ_GRENADE_LAUNCHER);
 
     G_WeaponFired(cl, SECONDS_TO_MILLIS(g_balance_grenadelauncher_refire->value), cl->weapon->def.quantity);
   }
@@ -685,11 +701,11 @@ void G_FireRocketLauncher(g_client_t *cl) {
 
     G_ClientProjectile(cl, &forward, &right, &up, &org, 1.0);
 
-    G_RocketProjectile(cl->entity, org, forward, g_balance_rocketlauncher_speed->integer,
+    G_RocketProjectile(cl->entity, cl->entity, org, forward, g_balance_rocketlauncher_speed->integer,
       g_balance_rocketlauncher_damage->integer, g_balance_rocketlauncher_knockback->integer,
-      g_balance_rocketlauncher_radius->value);
+      g_balance_rocketlauncher_radius->value, 0);
 
-    G_MuzzleFlash(cl->entity, MZ_ROCKET_LAUNCHER);
+    G_ClientMuzzleFlash(cl->entity, MZ_ROCKET_LAUNCHER);
 
     G_WeaponFired(cl, SECONDS_TO_MILLIS(g_balance_rocketlauncher_refire->value), cl->weapon->def.quantity);
   }
@@ -708,7 +724,7 @@ void G_FireHyperblaster(g_client_t *cl) {
     G_HyperblasterProjectile(cl->entity, org, forward, g_balance_hyperblaster_speed->integer,
       g_balance_hyperblaster_damage->integer, g_balance_hyperblaster_knockback->value);
 
-    G_MuzzleFlash(cl->entity, MZ_HYPERBLASTER);
+    G_ClientMuzzleFlash(cl->entity, MZ_HYPERBLASTER);
 
     G_WeaponFired(cl, SECONDS_TO_MILLIS(g_balance_hyperblaster_refire->value), cl->weapon->def.quantity);
   }
@@ -731,7 +747,7 @@ void G_FireLightning(g_client_t *cl) {
     }
 
     if (projectile == NULL) {
-      G_MuzzleFlash(cl->entity, MZ_LIGHTNING);
+      G_ClientMuzzleFlash(cl->entity, MZ_LIGHTNING);
     }
 
     G_ClientProjectile(cl, &forward, &right, &up, &org, 1.0);
@@ -755,9 +771,9 @@ void G_FireRailgun(g_client_t *cl) {
 
     const int16_t damage = ((g_level.gameplay & ~GAMEPLAY_TEAMS) == GAMEPLAY_INSTAGIB) ? 999 : g_balance_railgun_damage->integer;
 
-    G_RailgunProjectile(cl->entity, org, forward, damage, g_balance_railgun_knockback->integer);
+    G_RailgunProjectile(cl->entity, cl->entity, org, forward, damage, g_balance_railgun_knockback->integer, MOD_RAILGUN);
 
-    G_MuzzleFlash(cl->entity, MZ_RAILGUN);
+    G_ClientMuzzleFlash(cl->entity, MZ_RAILGUN);
 
     G_WeaponFired(cl, SECONDS_TO_MILLIS(g_balance_railgun_refire->value), cl->weapon->def.quantity);
   }
@@ -781,7 +797,7 @@ void G_FireQuakeShotgun(g_client_t *cl) {
       g_balance_quake_shotgun_spread_y->integer, g_balance_quake_shotgun_pellets->integer,
       MOD_QUAKE_SHOTGUN);
 
-    G_MuzzleFlash(cl->entity, MZ_QUAKE_SHOTGUN);
+    G_ClientMuzzleFlash(cl->entity, MZ_QUAKE_SHOTGUN);
 
     G_WeaponFired(cl, SECONDS_TO_MILLIS(g_balance_quake_shotgun_refire->value), cl->weapon->def.quantity);
   }
@@ -802,7 +818,7 @@ void G_FireQuakeSuperShotgun(g_client_t *cl) {
       g_balance_quake_supershotgun_spread_y->integer, g_balance_quake_supershotgun_pellets->integer,
       MOD_QUAKE_SUPER_SHOTGUN);
 
-    G_MuzzleFlash(cl->entity, MZ_QUAKE_SUPER_SHOTGUN);
+    G_ClientMuzzleFlash(cl->entity, MZ_QUAKE_SUPER_SHOTGUN);
 
     G_WeaponFired(cl, SECONDS_TO_MILLIS(g_balance_quake_supershotgun_refire->value), cl->weapon->def.quantity);
   }
@@ -822,10 +838,10 @@ void G_FireQuakeNailgun(g_client_t *cl) {
     org = Vec3_Fmaf(org, barrel_offset, right);
     cl->quake_nailgun_barrel++;
 
-    G_NailProjectile(cl->entity, org, forward, g_balance_quake_nailgun_speed->integer,
+    G_NailProjectile(cl->entity, cl->entity, org, forward, g_balance_quake_nailgun_speed->integer,
       g_balance_quake_nailgun_damage->integer, g_balance_quake_nailgun_knockback->integer, MOD_QUAKE_NAILGUN);
 
-    G_MuzzleFlash(cl->entity, MZ_QUAKE_NAILGUN);
+    G_ClientMuzzleFlash(cl->entity, MZ_QUAKE_NAILGUN);
 
     G_WeaponFired(cl, SECONDS_TO_MILLIS(g_balance_quake_nailgun_refire->value), cl->weapon->def.quantity);
   }
@@ -850,11 +866,11 @@ void G_FireQuakeSuperNailgun(g_client_t *cl) {
     }
     cl->quake_nailgun_barrel++;
 
-    G_NailProjectile(cl->entity, org, forward,
+    G_NailProjectile(cl->entity, cl->entity, org, forward,
       g_balance_quake_supernailgun_speed->integer, g_balance_quake_supernailgun_damage->integer,
       g_balance_quake_supernailgun_knockback->integer, MOD_QUAKE_SUPER_NAILGUN);
 
-    G_MuzzleFlash(cl->entity, MZ_QUAKE_SUPER_NAILGUN);
+    G_ClientMuzzleFlash(cl->entity, MZ_QUAKE_SUPER_NAILGUN);
 
     G_WeaponFired(cl, SECONDS_TO_MILLIS(g_balance_quake_supernailgun_refire->value), cl->weapon->def.quantity);
   }
@@ -874,7 +890,7 @@ void G_FireQuakeGrenadeLauncher(g_client_t *cl) {
       g_balance_quake_grenadelauncher_damage->integer, g_balance_quake_grenadelauncher_knockback->integer,
       g_balance_quake_grenadelauncher_radius->value, SECONDS_TO_MILLIS(g_balance_quake_grenadelauncher_timer->value));
 
-    G_MuzzleFlash(cl->entity, MZ_QUAKE_GRENADE_LAUNCHER);
+    G_ClientMuzzleFlash(cl->entity, MZ_QUAKE_GRENADE_LAUNCHER);
 
     G_WeaponFired(cl, SECONDS_TO_MILLIS(g_balance_quake_grenadelauncher_refire->value), cl->weapon->def.quantity);
   }
@@ -894,7 +910,7 @@ void G_FireQuakeRocketLauncher(g_client_t *cl) {
       g_balance_quake_rocketlauncher_damage->integer, g_balance_quake_rocketlauncher_knockback->integer,
       g_balance_quake_rocketlauncher_radius->value);
 
-    G_MuzzleFlash(cl->entity, MZ_QUAKE_ROCKET_LAUNCHER);
+    G_ClientMuzzleFlash(cl->entity, MZ_QUAKE_ROCKET_LAUNCHER);
 
     G_WeaponFired(cl, SECONDS_TO_MILLIS(g_balance_quake_rocketlauncher_refire->value), cl->weapon->def.quantity);
   }
@@ -917,7 +933,7 @@ void G_FireQuakeThunderbolt(g_client_t *cl) {
     }
 
     if (projectile == NULL) {
-      G_MuzzleFlash(cl->entity, MZ_LIGHTNING);
+      G_ClientMuzzleFlash(cl->entity, MZ_LIGHTNING);
     }
 
     G_ClientProjectile(cl, &forward, &right, &up, &org, 0.0);
@@ -946,7 +962,7 @@ static void G_FireBfg_(g_entity_t *ent) {
         g_balance_bfg_damage->integer, g_balance_bfg_knockback->integer,
         g_balance_bfg_radius->value);
 
-      G_MuzzleFlash(ent->owner, MZ_BFG10K);
+      G_ClientMuzzleFlash(ent->owner, MZ_BFG10K);
 
       G_WeaponFired(cl, SECONDS_TO_MILLIS(g_balance_bfg_refire->value), cl->weapon->def.quantity);
     }

--- a/src/game/common/g_weapon.h
+++ b/src/game/common/g_weapon.h
@@ -47,5 +47,6 @@ void G_FireQuakeSuperNailgun(g_client_t *cl);
 void G_FireQuakeGrenadeLauncher(g_client_t *cl);
 void G_FireQuakeRocketLauncher(g_client_t *cl);
 void G_FireQuakeThunderbolt(g_client_t *cl);
+void G_WorldMuzzleFlash(const vec3_t org, const vec3_t dir, g_muzzle_flash_t flash);
 void G_ClientWeaponThink(g_client_t *cl);
 #endif

--- a/src/game/ctf/g_types.h
+++ b/src/game/ctf/g_types.h
@@ -41,7 +41,7 @@
  * @brief Game protocol version (protocol minor version). To be incremented
  * whenever the game protocol changes.
  */
-#define PROTOCOL_MINOR 1045
+#define PROTOCOL_MINOR 1046
 
 /**
  * @brief Game-specific server protocol commands. These are parsed directly by
@@ -117,7 +117,14 @@ typedef enum {
 /**
  * @brief Muzzle flashes are bound to the entity that created them. This allows
  * the protocol to forego sending the origin and angles for the effect, as they
- * can be inferred from the referenced entity.
+ * can be inferred from the referenced entity. Entities that the server does not
+ * transmit send `MUZZLE_FLASH_WORLD` in place of an entity number, followed by
+ * the origin and direction of the flash.
+ */
+#define MUZZLE_FLASH_WORLD -1
+
+/**
+ * @brief The muzzle flash effects the client game can render.
  */
 typedef enum {
   MZ_BLASTER,
@@ -923,6 +930,18 @@ typedef struct {
   MOD_HOOK,
   MOD_ACT_OF_GOD,
   MOD_BOB,
+  MOD_TRAP_BLASTER,
+  MOD_TRAP_NAIL,
+  MOD_TRAP_ROCKET,
+  MOD_TRAP_GRENADE,
+  MOD_TRAP_LASER,
+  MOD_TRAP_GIBLETS,
+  MOD_TURRET_BLASTER,
+  MOD_TURRET_NAIL,
+  MOD_TURRET_ROCKET,
+  MOD_TURRET_GRENADE,
+  MOD_TURRET_LASER,
+  MOD_TURRET_GIBLETS,
   MOD_FRIENDLY_FIRE = 0x8000000
 } g_means_of_death;
 
@@ -990,6 +1009,54 @@ typedef struct {
   */
 	g_means_of_death mod;
 } g_damage_t;
+
+/**
+ * @brief Parameters for a burst of giblets, as scattered by a dying corpse or a
+ * `target_ballistics`.
+ */
+typedef struct {
+
+  /**
+   * @brief The origin the giblets are scattered from.
+   */
+  vec3_t origin;
+
+  /**
+   * @brief The velocity the giblets inherit, before randomization.
+   */
+  vec3_t velocity;
+
+  /**
+   * @brief The number of giblets to scatter.
+   */
+  int32_t count;
+
+  /**
+   * @brief Upward velocity added to each giblet.
+   */
+  float lift;
+
+  /**
+   * @brief True to include a head among the giblets.
+   */
+  bool head;
+
+  /**
+   * @brief Damage each giblet inflicts on contact, or zero for harmless giblets.
+   */
+  int32_t damage;
+
+  /**
+   * @brief The entity credited with damage the giblets inflict.
+   */
+  g_entity_t *attacker;
+
+  /**
+   * @brief The means of death the giblets inflict.
+   */
+  uint32_t mod;
+
+} g_giblets_t;
 
 /**
  * @brief The name for the CTF skin used in team games.
@@ -1527,6 +1594,11 @@ struct g_entity_s {
    * @brief Spawn flags (`SF_ITEM_HOVER`, etc.).
    */
   uint32_t spawn_flags;
+
+  /**
+   * @brief Means of death this entity inflicts, for projectiles and other inflictors.
+   */
+  uint32_t mod;
 
   /**
    * @brief Entity flags (`FL_GOD_MODE`, etc.).

--- a/src/game/ctf/g_types.h
+++ b/src/game/ctf/g_types.h
@@ -1047,6 +1047,11 @@ typedef struct {
   int32_t damage;
 
   /**
+   * @brief Knockback each giblet applies on contact.
+   */
+  int32_t knockback;
+
+  /**
    * @brief The entity credited with damage the giblets inflict.
    */
   g_entity_t *attacker;
@@ -1055,6 +1060,12 @@ typedef struct {
    * @brief The means of death the giblets inflict.
    */
   uint32_t mod;
+
+  /**
+   * @brief Milliseconds until each giblet is removed, or zero to linger and sink
+   * through the floor as a corpse's giblets do.
+   */
+  uint32_t lifetime;
 
 } g_giblets_t;
 

--- a/src/game/default/g_types.h
+++ b/src/game/default/g_types.h
@@ -39,7 +39,7 @@
  * @brief Game protocol version (protocol minor version). To be incremented
  * whenever the game protocol changes.
  */
-#define PROTOCOL_MINOR 1045
+#define PROTOCOL_MINOR 1046
 
 /**
  * @brief Game-specific server protocol commands. These are parsed directly by
@@ -111,7 +111,14 @@ typedef enum {
 /**
  * @brief Muzzle flashes are bound to the entity that created them. This allows
  * the protocol to forego sending the origin and angles for the effect, as they
- * can be inferred from the referenced entity.
+ * can be inferred from the referenced entity. Entities that the server does not
+ * transmit send `MUZZLE_FLASH_WORLD` in place of an entity number, followed by
+ * the origin and direction of the flash.
+ */
+#define MUZZLE_FLASH_WORLD -1
+
+/**
+ * @brief The muzzle flash effects the client game can render.
  */
 typedef enum {
   MZ_BLASTER,
@@ -894,6 +901,18 @@ typedef struct {
   MOD_FIREBALL,
   MOD_ACT_OF_GOD,
   MOD_BOB,
+  MOD_TRAP_BLASTER,
+  MOD_TRAP_NAIL,
+  MOD_TRAP_ROCKET,
+  MOD_TRAP_GRENADE,
+  MOD_TRAP_LASER,
+  MOD_TRAP_GIBLETS,
+  MOD_TURRET_BLASTER,
+  MOD_TURRET_NAIL,
+  MOD_TURRET_ROCKET,
+  MOD_TURRET_GRENADE,
+  MOD_TURRET_LASER,
+  MOD_TURRET_GIBLETS,
   MOD_FRIENDLY_FIRE = 0x8000000
 } g_means_of_death;
 
@@ -961,6 +980,54 @@ typedef struct {
   */
 	g_means_of_death mod;
 } g_damage_t;
+
+/**
+ * @brief Parameters for a burst of giblets, as scattered by a dying corpse or a
+ * `target_ballistics`.
+ */
+typedef struct {
+
+  /**
+   * @brief The origin the giblets are scattered from.
+   */
+  vec3_t origin;
+
+  /**
+   * @brief The velocity the giblets inherit, before randomization.
+   */
+  vec3_t velocity;
+
+  /**
+   * @brief The number of giblets to scatter.
+   */
+  int32_t count;
+
+  /**
+   * @brief Upward velocity added to each giblet.
+   */
+  float lift;
+
+  /**
+   * @brief True to include a head among the giblets.
+   */
+  bool head;
+
+  /**
+   * @brief Damage each giblet inflicts on contact, or zero for harmless giblets.
+   */
+  int32_t damage;
+
+  /**
+   * @brief The entity credited with damage the giblets inflict.
+   */
+  g_entity_t *attacker;
+
+  /**
+   * @brief The means of death the giblets inflict.
+   */
+  uint32_t mod;
+
+} g_giblets_t;
 
 /**
  * @brief The name for the CTF skin used in team games.
@@ -1460,6 +1527,11 @@ struct g_entity_s {
    * @brief Spawn flags (`SF_ITEM_HOVER`, etc.).
    */
   uint32_t spawn_flags;
+
+  /**
+   * @brief Means of death this entity inflicts, for projectiles and other inflictors.
+   */
+  uint32_t mod;
 
   /**
    * @brief Entity flags (`FL_GOD_MODE`, etc.).

--- a/src/game/default/g_types.h
+++ b/src/game/default/g_types.h
@@ -1018,6 +1018,11 @@ typedef struct {
   int32_t damage;
 
   /**
+   * @brief Knockback each giblet applies on contact.
+   */
+  int32_t knockback;
+
+  /**
    * @brief The entity credited with damage the giblets inflict.
    */
   g_entity_t *attacker;
@@ -1026,6 +1031,12 @@ typedef struct {
    * @brief The means of death the giblets inflict.
    */
   uint32_t mod;
+
+  /**
+   * @brief Milliseconds until each giblet is removed, or zero to linger and sink
+   * through the floor as a corpse's giblets do.
+   */
+  uint32_t lifetime;
 
 } g_giblets_t;
 

--- a/src/game/lithium/g_types.h
+++ b/src/game/lithium/g_types.h
@@ -1025,6 +1025,11 @@ typedef struct {
   int32_t damage;
 
   /**
+   * @brief Knockback each giblet applies on contact.
+   */
+  int32_t knockback;
+
+  /**
    * @brief The entity credited with damage the giblets inflict.
    */
   g_entity_t *attacker;
@@ -1033,6 +1038,12 @@ typedef struct {
    * @brief The means of death the giblets inflict.
    */
   uint32_t mod;
+
+  /**
+   * @brief Milliseconds until each giblet is removed, or zero to linger and sink
+   * through the floor as a corpse's giblets do.
+   */
+  uint32_t lifetime;
 
 } g_giblets_t;
 

--- a/src/game/lithium/g_types.h
+++ b/src/game/lithium/g_types.h
@@ -41,7 +41,7 @@
  * @brief Game protocol version (protocol minor version). To be incremented
  * whenever the game protocol changes.
  */
-#define PROTOCOL_MINOR 1045
+#define PROTOCOL_MINOR 1046
 
 /**
  * @brief Game-specific server protocol commands. These are parsed directly by
@@ -115,7 +115,14 @@ typedef enum {
 /**
  * @brief Muzzle flashes are bound to the entity that created them. This allows
  * the protocol to forego sending the origin and angles for the effect, as they
- * can be inferred from the referenced entity.
+ * can be inferred from the referenced entity. Entities that the server does not
+ * transmit send `MUZZLE_FLASH_WORLD` in place of an entity number, followed by
+ * the origin and direction of the flash.
+ */
+#define MUZZLE_FLASH_WORLD -1
+
+/**
+ * @brief The muzzle flash effects the client game can render.
  */
 typedef enum {
   MZ_BLASTER,
@@ -901,6 +908,18 @@ typedef struct {
   MOD_FIREBALL,
   MOD_ACT_OF_GOD,
   MOD_BOB,
+  MOD_TRAP_BLASTER,
+  MOD_TRAP_NAIL,
+  MOD_TRAP_ROCKET,
+  MOD_TRAP_GRENADE,
+  MOD_TRAP_LASER,
+  MOD_TRAP_GIBLETS,
+  MOD_TURRET_BLASTER,
+  MOD_TURRET_NAIL,
+  MOD_TURRET_ROCKET,
+  MOD_TURRET_GRENADE,
+  MOD_TURRET_LASER,
+  MOD_TURRET_GIBLETS,
   MOD_FRIENDLY_FIRE = 0x8000000
 } g_means_of_death;
 
@@ -968,6 +987,54 @@ typedef struct {
   */
 	g_means_of_death mod;
 } g_damage_t;
+
+/**
+ * @brief Parameters for a burst of giblets, as scattered by a dying corpse or a
+ * `target_ballistics`.
+ */
+typedef struct {
+
+  /**
+   * @brief The origin the giblets are scattered from.
+   */
+  vec3_t origin;
+
+  /**
+   * @brief The velocity the giblets inherit, before randomization.
+   */
+  vec3_t velocity;
+
+  /**
+   * @brief The number of giblets to scatter.
+   */
+  int32_t count;
+
+  /**
+   * @brief Upward velocity added to each giblet.
+   */
+  float lift;
+
+  /**
+   * @brief True to include a head among the giblets.
+   */
+  bool head;
+
+  /**
+   * @brief Damage each giblet inflicts on contact, or zero for harmless giblets.
+   */
+  int32_t damage;
+
+  /**
+   * @brief The entity credited with damage the giblets inflict.
+   */
+  g_entity_t *attacker;
+
+  /**
+   * @brief The means of death the giblets inflict.
+   */
+  uint32_t mod;
+
+} g_giblets_t;
 
 /**
  * @brief The name for the CTF skin used in team games.
@@ -1482,6 +1549,11 @@ struct g_entity_s {
    * @brief Spawn flags (`SF_ITEM_HOVER`, etc.).
    */
   uint32_t spawn_flags;
+
+  /**
+   * @brief Means of death this entity inflicts, for projectiles and other inflictors.
+   */
+  uint32_t mod;
 
   /**
    * @brief Entity flags (`FL_GOD_MODE`, etc.).


### PR DESCRIPTION
## Summary

Adds a pair of projectile-firing map entities, per #940.

`target_ballistics` is a trap: it fires on an interval with `start_on`, or once each time it is used, and `toggle` switches it on and off. `target_turret` is the player-operated counterpart — it fires along its operator's view, credits them with the frag, and spares them from its own projectiles. Both pick one of six projectiles by spawnflag: `blaster`, `nail` (Q1 spikes), `rocket`, `grenade`, `laser` (hitscan, `wait 0` for a continuous beam) and `giblets`. Damage, knockback and speed default from each module's own `g_balance_*` cvars, so the entities follow a module's tuning rather than carrying their own.

Twelve means of death and obituaries come with them, one per projectile for each entity, so a trap death and a turret frag each read as what actually killed you.

Three enabling changes:

**Muzzle flashes no longer assume a client.** The 15 flash effects take an origin, angles and a client number rather than an entity, and the server may address a flash by position instead of entity number. That is required because a point entity with no model, effect or sound is never transmitted (`sv_entity.c:180`), so there is no entity for the client to infer the flash from. The new message variant is not backwards compatible, so `PROTOCOL_MINOR` goes to 1046.

**Projectiles take an explicit attacker**, separate from the entity they leave, so a turret credits its operator while the projectile still originates at and is colored by the turret. They also take an explicit means of death, which retires the overloading of `spawn_flags` as a mod in the nail and lightning paths.

**`G_Giblets` is lifted out of the corpse death handler** and shared. Giblets carrying damage are `SOLID_TRIGGER`, since `BOX_OCCUPY` is the only way they reach a player; harmless corpse giblets are unchanged.

Separately, world-owned effects now use the `>= MAX_CLIENTS` sentinel that `cg_sound.c` and `cg_muzzle_flash.c` already used, so they fall back to their own default hue instead of being tinted with player 0's team color.

## Testing

- [x] Builds clean on macOS — all three game modules, zero warnings
- [x] `make check` — this tree is not configured with `--enable-tests`, so it runs zero tests; not a pass
- [x] Exercised on `quetoo-dedicated` with bots on purpose-built test maps:
  - all six projectile types kill and print their own obituary
  - turret frags credit the operator and name both players
  - a laser turret does not injure the operator standing at its muzzle
  - a trap with `random` far exceeding `wait` keeps firing (this underflowed `uint32_t` before)
  - delayed one-shot fires once per use rather than free-running
- [ ] **Client-side rendering is unverified** — effect colors, muzzle flash placement and the rail beam still need a real client. The client does not link in my environment: `src/common/installer.c` and the cgame UI files fail against the installed ObjectivelyMVC, reproducibly on a clean `main`.

## Notes

Found but deliberately **not** fixed here, as it predates this branch: `G_GrenadeProjectile` sets `spawn_flags = QUAKE_GRENADE` and `G_RocketProjectile` sets `QUAKE_ROCKET`, while the actual Quake variants set neither. Standard launcher kills therefore report as the Quake ones and vice versa, affecting obituaries and weapon stats.

Fixes #940

🤖 Generated with [Claude Code](https://claude.com/claude-code)