### PR TITLE
Give the ballistics and turret entities a classname per weapon (#940)

### DIFF
--- a/src/cgame/common/cg_entity_trail.c
+++ b/src/cgame/common/cg_entity_trail.c
@@ -1017,6 +1017,45 @@ static void Cg_GibTrail(cl_entity_t *ent, const vec3_t start, const vec3_t end) 
 }
 
 /**
+ * @brief Renders a laser beam between its emitter and whatever it lands on, in the color the
+ * entity carries, with a light and a scorch mark at the far end.
+ */
+static void Cg_LaserTrail(cl_entity_t *ent, const vec3_t start, const vec3_t end) {
+
+  const vec3_t color = Color32_Vec4(ent->current.color).xyz;
+
+  cgi.AddBeam(cgi.view, &(const r_beam_t) {
+    .start = start,
+    .end = end,
+    .color = color,
+    .image = cg_beam_rail,
+    .size = 4.f,
+    .lighting = .5f,
+  });
+
+  Cg_AddLight(&(cg_light_t) {
+    .origin = end,
+    .radius = 100.f,
+    .color = color,
+    .intensity = 2.f,
+    .decay = 50,
+  });
+
+  if (Cg_TrailCount(end, 24.f, ent, TRAIL_PRIMARY, NULL, NULL)) {
+
+    Cg_AddSprite(&(cg_sprite_t) {
+      .atlas_image = cg_sprite_particle,
+      .lifetime = 300,
+      .size = RandomRangef(4.f, 8.f),
+      .rotation = RandomRadian(),
+      .origin = end,
+      .velocity = Vec3_RandomRange(-20.f, 20.f),
+      .color = color,
+    });
+  }
+}
+
+/**
  * @brief Renders the nail projectile trail as a thin metallic streak.
  */
 static void Cg_NailTrail(cl_entity_t *ent, const vec3_t start, const vec3_t end) {
@@ -1236,6 +1275,9 @@ void Cg_EntityTrail(cl_entity_t *ent) {
       break;
     case TRAIL_QUAKE_GRENADE:
       Cg_QuakeGrenadeTrail(ent, start, end);
+      break;
+    case TRAIL_LASER:
+      Cg_LaserTrail(ent, start, end);
       break;
     case TRAIL_ROCKET:
       Cg_RocketTrail(ent, start, end);

--- a/src/cgame/common/cg_muzzle_flash.c
+++ b/src/cgame/common/cg_muzzle_flash.c
@@ -926,10 +926,15 @@ void Cg_ParseMuzzleFlash(void) {
   int32_t client;
   const cl_entity_t *ent = NULL;
 
-  if (entity == MUZZLE_FLASH_WORLD) { // the world is shooting; the origin and dir follow
+  if (entity == MUZZLE_FLASH_WORLD) { // the world is shooting; the origin, dir and client follow
     origin = muzzle = cgi.ReadPosition();
     angles = Vec3_Euler(cgi.ReadDir());
-    client = MAX_CLIENTS;
+    client = cgi.ReadByte();
+
+    if (client > MAX_CLIENTS) {
+      Cg_Warn("Bad client %d for world muzzle flash\n", client);
+      client = MAX_CLIENTS;
+    }
   } else {
 
     if (entity < 0 || entity >= MAX_ENTITIES) {

--- a/src/game/common/g_ballistics.c
+++ b/src/game/common/g_ballistics.c
@@ -190,10 +190,10 @@ static void G_BlasterProjectile_Touch(g_entity_t *ent, g_entity_t *other, const 
 
 /**
  * @brief Fires a blaster projectile from the specified entity in the given direction.
- * @param ent The entity the projectile leaves, providing its origin and effect color.
+ * @param emitter The entity the projectile leaves, providing its origin and effect color.
  * @param attacker The entity credited with any damage the projectile inflicts.
  */
-void G_BlasterProjectile(g_entity_t *ent, g_entity_t *attacker, const vec3_t start, const vec3_t dir, int32_t speed, int32_t damage, int32_t knockback, uint32_t mod) {
+void G_BlasterProjectile(g_entity_t *emitter, g_entity_t *attacker, const vec3_t start, const vec3_t dir, int32_t speed, int32_t damage, int32_t knockback, uint32_t mod) {
 
   const box3_t bounds = Box3f(2.f, 2.f, 2.f);
 
@@ -206,8 +206,8 @@ void G_BlasterProjectile(g_entity_t *ent, g_entity_t *attacker, const vec3_t sta
   projectile->s.angles = Vec3_Euler(dir);
   projectile->velocity = Vec3_Scale(dir, speed);
 
-  if (G_ImmediateWall(ent, projectile)) {
-    projectile->s.origin = ent->s.origin;
+  if (G_ImmediateWall(emitter, projectile)) {
+    projectile->s.origin = emitter->s.origin;
   }
 
   projectile->solid = SOLID_PROJECTILE;
@@ -218,7 +218,7 @@ void G_BlasterProjectile(g_entity_t *ent, g_entity_t *attacker, const vec3_t sta
   projectile->next_think = g_level.time + 8000;
   projectile->Think = G_FreeEntity;
   projectile->Touch = G_BlasterProjectile_Touch;
-  projectile->s.client = ent->s.client;
+  projectile->s.client = emitter->s.client;
   projectile->s.trail = TRAIL_BLASTER;
 
   gi.LinkEntity(projectile);
@@ -269,10 +269,10 @@ static void G_NailProjectile_Touch(g_entity_t *ent, g_entity_t *other, const cm_
 
 /**
  * @brief Fires a nail projectile from the specified entity in the given direction.
- * @param ent The entity the projectile leaves, providing its origin and effect color.
+ * @param emitter The entity the projectile leaves, providing its origin and effect color.
  * @param attacker The entity credited with any damage the projectile inflicts.
  */
-void G_NailProjectile(g_entity_t *ent, g_entity_t *attacker, const vec3_t start, const vec3_t dir, int32_t speed, int32_t damage, int32_t knockback, uint32_t mod) {
+void G_NailProjectile(g_entity_t *emitter, g_entity_t *attacker, const vec3_t start, const vec3_t dir, int32_t speed, int32_t damage, int32_t knockback, uint32_t mod) {
 
   const box3_t bounds = Box3f(1.f, 1.f, 1.f);
 
@@ -285,8 +285,8 @@ void G_NailProjectile(g_entity_t *ent, g_entity_t *attacker, const vec3_t start,
   projectile->s.angles = Vec3_Euler(dir);
   projectile->velocity = Vec3_Scale(dir, speed);
 
-  if (G_ImmediateWall(ent, projectile)) {
-    projectile->s.origin = ent->s.origin;
+  if (G_ImmediateWall(emitter, projectile)) {
+    projectile->s.origin = emitter->s.origin;
   }
 
   projectile->solid = SOLID_PROJECTILE;
@@ -297,7 +297,7 @@ void G_NailProjectile(g_entity_t *ent, g_entity_t *attacker, const vec3_t start,
   projectile->next_think = g_level.time + 8000;
   projectile->Think = G_FreeEntity;
   projectile->Touch = G_NailProjectile_Touch;
-  projectile->s.client = ent->s.client;
+  projectile->s.client = emitter->s.client;
   projectile->s.model1 = g_media.models.quake_nail;
   projectile->s.trail = TRAIL_QUAKE_NAIL;
 
@@ -307,9 +307,9 @@ void G_NailProjectile(g_entity_t *ent, g_entity_t *attacker, const vec3_t start,
 /**
  * @brief Fires a single bullet projectile with randomized spread, dealing damage and emitting impact effects.
  */
-void G_BulletProjectile(g_entity_t *ent, const vec3_t start, const vec3_t dir, int32_t damage, int32_t knockback, int32_t hspread, int32_t vspread, int32_t mod) {
+void G_BulletProjectile(g_entity_t *emitter, g_entity_t *attacker, const vec3_t start, const vec3_t dir, int32_t damage, int32_t knockback, int32_t hspread, int32_t vspread, int32_t mod) {
 
-  cm_trace_t tr = gi.Trace(ent->s.origin, start, Box3f(1.f, 1.f, 1.f), ent, CONTENTS_MASK_CLIP_PROJECTILE);
+  cm_trace_t tr = gi.Trace(emitter->s.origin, start, Box3f(1.f, 1.f, 1.f), emitter, CONTENTS_MASK_CLIP_PROJECTILE);
   if (tr.fraction == 1.0) {
     vec3_t angles, forward, right, up, end;
 
@@ -320,7 +320,7 @@ void G_BulletProjectile(g_entity_t *ent, const vec3_t start, const vec3_t dir, i
     end = Vec3_Fmaf(end, RandomRangef(-hspread, hspread), right);
     end = Vec3_Fmaf(end, RandomRangef(-vspread, vspread), up);
 
-    tr = gi.Trace(start, end, Box3_Zero(), ent, CONTENTS_MASK_CLIP_PROJECTILE);
+    tr = gi.Trace(start, end, Box3_Zero(), emitter, CONTENTS_MASK_CLIP_PROJECTILE);
 
     G_Tracer(start, tr.end);
   }
@@ -329,8 +329,8 @@ void G_BulletProjectile(g_entity_t *ent, const vec3_t start, const vec3_t dir, i
 
     G_Damage(&(g_damage_t) {
       .target = tr.ent,
-      .inflictor = ent,
-      .attacker = ent,
+      .inflictor = emitter,
+      .attacker = attacker,
       .dir = dir,
       .point = tr.end,
       .normal = tr.plane.normal,
@@ -357,10 +357,10 @@ void G_BulletProjectile(g_entity_t *ent, const vec3_t start, const vec3_t dir, i
 /**
  * @brief Fires multiple bullet projectiles to simulate shotgun pellet spread.
  */
-void G_ShotgunProjectiles(g_entity_t *ent, const vec3_t start, const vec3_t dir, int32_t damage, int32_t knockback, int32_t hspread, int32_t vspread, int32_t count, int32_t mod) {
+void G_ShotgunProjectiles(g_entity_t *emitter, g_entity_t *attacker, const vec3_t start, const vec3_t dir, int32_t damage, int32_t knockback, int32_t hspread, int32_t vspread, int32_t count, int32_t mod) {
 
   for (int32_t i = 0; i < count; i++) {
-    G_BulletProjectile(ent, start, dir, damage, knockback, hspread, vspread, mod);
+    G_BulletProjectile(emitter, attacker, start, dir, damage, knockback, hspread, vspread, mod);
   }
 }
 
@@ -504,10 +504,10 @@ static void G_QuakeGrenadeProjectile_Touch(g_entity_t *ent, g_entity_t *other, c
 
 /**
  * @brief Fires a grenade projectile with bounce physics and a timed fuse.
- * @param ent The entity the projectile leaves, providing its origin and effect color.
+ * @param emitter The entity the projectile leaves, providing its origin and effect color.
  * @param attacker The entity credited with any damage the projectile inflicts.
  */
-void G_GrenadeProjectile(g_entity_t *ent, g_entity_t *attacker, const vec3_t start, const vec3_t dir, int32_t speed, int32_t damage, int32_t knockback, float damage_radius, uint32_t timer, uint32_t mod) {
+void G_GrenadeProjectile(g_entity_t *emitter, g_entity_t *attacker, const vec3_t start, const vec3_t dir, int32_t speed, int32_t damage, int32_t knockback, float damage_radius, uint32_t timer, uint32_t mod) {
 
   const box3_t bounds = Box3f(6.f, 6.f, 6.f);
 
@@ -548,7 +548,7 @@ void G_GrenadeProjectile(g_entity_t *ent, g_entity_t *attacker, const vec3_t sta
   projectile->s.trail = TRAIL_GRENADE;
   projectile->s.model1 = g_media.models.grenade;
 
-  if (G_ImmediateImpact(ent, projectile)) {
+  if (G_ImmediateImpact(emitter, projectile)) {
     return;
   }
 
@@ -558,14 +558,14 @@ void G_GrenadeProjectile(g_entity_t *ent, g_entity_t *attacker, const vec3_t sta
 /**
  * @brief Fires a Quake grenade projectile with bounce physics and a timed fuse.
  */
-void G_QuakeGrenadeProjectile(g_entity_t *ent, const vec3_t start, const vec3_t dir, int32_t speed, int32_t damage, int32_t knockback, float damage_radius, uint32_t timer) {
+void G_QuakeGrenadeProjectile(g_entity_t *emitter, g_entity_t *attacker, const vec3_t start, const vec3_t dir, int32_t speed, int32_t damage, int32_t knockback, float damage_radius, uint32_t timer) {
 
   const box3_t bounds = Box3f(6.f, 6.f, 3.f);
 
   vec3_t forward, right, up;
 
   g_entity_t *projectile = G_AllocEntity(__func__);
-  projectile->owner = ent;
+  projectile->owner = attacker;
   projectile->spawn_flags = QUAKE_GRENADE;
 
   projectile->s.origin = start;
@@ -580,8 +580,8 @@ void G_QuakeGrenadeProjectile(g_entity_t *ent, const vec3_t start, const vec3_t 
 
   G_PlayerProjectile(projectile, 0.33);
 
-  if (G_ImmediateWall(ent, projectile)) {
-    projectile->s.origin = ent->s.origin;
+  if (G_ImmediateWall(emitter, projectile)) {
+    projectile->s.origin = emitter->s.origin;
   }
 
   projectile->solid = SOLID_PROJECTILE;
@@ -708,10 +708,10 @@ static void G_RocketProjectile_Touch(g_entity_t *ent, g_entity_t *other, const c
 
 /**
  * @brief Fires a rocket projectile that explodes with radius damage on impact.
- * @param ent The entity the projectile leaves, providing its origin and effect color.
+ * @param emitter The entity the projectile leaves, providing its origin and effect color.
  * @param attacker The entity credited with any damage the projectile inflicts.
  */
-void G_RocketProjectile(g_entity_t *ent, g_entity_t *attacker, const vec3_t start, const vec3_t dir, int32_t speed, int32_t damage, int32_t knockback, float damage_radius, uint32_t mod) {
+void G_RocketProjectile(g_entity_t *emitter, g_entity_t *attacker, const vec3_t start, const vec3_t dir, int32_t speed, int32_t damage, int32_t knockback, float damage_radius, uint32_t mod) {
 
   const box3_t bounds = Box3f(8.f, 8.f, 8.f);
 
@@ -739,7 +739,7 @@ void G_RocketProjectile(g_entity_t *ent, g_entity_t *attacker, const vec3_t star
   projectile->s.sound = g_media.sounds.rocket_fly;
   projectile->s.trail = TRAIL_ROCKET;
 
-  if (G_ImmediateImpact(ent, projectile)) {
+  if (G_ImmediateImpact(emitter, projectile)) {
     return;
   }
 
@@ -749,12 +749,12 @@ void G_RocketProjectile(g_entity_t *ent, g_entity_t *attacker, const vec3_t star
 /**
  * @brief Fires a Quake rocket projectile that explodes with radius damage on impact.
  */
-void G_QuakeRocketProjectile(g_entity_t *ent, const vec3_t start, const vec3_t dir, int32_t speed, int32_t damage, int32_t knockback, float damage_radius) {
+void G_QuakeRocketProjectile(g_entity_t *emitter, g_entity_t *attacker, const vec3_t start, const vec3_t dir, int32_t speed, int32_t damage, int32_t knockback, float damage_radius) {
 
   const box3_t bounds = Box3f(8.f, 8.f, 8.f);
 
   g_entity_t *projectile = G_AllocEntity(__func__);
-  projectile->owner = ent;
+  projectile->owner = attacker;
   projectile->spawn_flags = QUAKE_ROCKET;
 
   projectile->s.origin = start;
@@ -777,7 +777,7 @@ void G_QuakeRocketProjectile(g_entity_t *ent, const vec3_t start, const vec3_t d
   projectile->s.sound = g_media.sounds.rocket_fly;
   projectile->s.trail = TRAIL_ROCKET;
 
-  if (G_ImmediateImpact(ent, projectile)) {
+  if (G_ImmediateImpact(emitter, projectile)) {
     return;
   }
 
@@ -855,20 +855,20 @@ static void G_HyperblasterProjectile_Touch(g_entity_t *ent, g_entity_t *other, c
 /**
  * @brief Fires a hyperblaster energy projectile in the given direction.
  */
-void G_HyperblasterProjectile(g_entity_t *ent, const vec3_t start, const vec3_t dir, int32_t speed, int32_t damage, int32_t knockback) {
+void G_HyperblasterProjectile(g_entity_t *emitter, g_entity_t *attacker, const vec3_t start, const vec3_t dir, int32_t speed, int32_t damage, int32_t knockback) {
 
   const box3_t bounds = Box3f(6.f, 6.f, 6.f);
 
   g_entity_t *projectile = G_AllocEntity(__func__);
-  projectile->owner = ent;
+  projectile->owner = attacker;
 
   projectile->s.origin = start;
   projectile->bounds = bounds;
   projectile->s.angles = Vec3_Euler(dir);
   projectile->velocity = Vec3_Scale(dir, speed);
 
-  if (G_ImmediateWall(ent, projectile)) {
-    projectile->s.origin = ent->s.origin;
+  if (G_ImmediateWall(emitter, projectile)) {
+    projectile->s.origin = emitter->s.origin;
   }
 
   projectile->solid = SOLID_PROJECTILE;
@@ -1102,19 +1102,117 @@ void G_LightningProjectile(g_entity_t *ent, const vec3_t start, const vec3_t dir
 }
 
 /**
+ * @brief Locates the sustained beam belonging to the given owner, if it has one.
+ */
+static g_entity_t *G_BeamProjectile_Find(const g_entity_t *ent) {
+
+  g_entity_t *projectile = NULL;
+
+  while ((projectile = G_Find(projectile, EOFS(classname), "G_BeamProjectile"))) {
+    if (projectile->owner == ent) {
+      return projectile;
+    }
+  }
+
+  return NULL;
+}
+
+/**
+ * @brief Creates or refreshes the sustained beam belonging to the given owner, tracing it to
+ * whatever it lands on and burning what it finds there.
+ * @param emitter The entity the beam emanates from, providing its color and damage interval.
+ * @param attacker The entity credited with any damage the beam inflicts.
+ * @param trail The trail the client renders the beam with, which is what distinguishes a laser
+ * from lightning; the two differ in appearance and in nothing else here.
+ * @remarks The beam is a persistent entity rather than an effect repeated per shot, so it costs a
+ * delta only on the ticks its endpoint actually moves. It expires shortly after its owner stops
+ * refreshing it, which is what lets a turret's operator simply walk away from it.
+ * @remarks `G_LightningProjectile` cannot serve here: its think resolves the muzzle through
+ * `emitter->owner->client`, which a trap does not have.
+ */
+void G_BeamProjectile(g_entity_t *emitter, g_entity_t *attacker, const vec3_t start, const vec3_t dir,
+             int32_t damage, int32_t knockback, uint32_t mod, uint8_t trail) {
+
+  g_entity_t *projectile = G_BeamProjectile_Find(emitter);
+
+  if (!projectile) {
+    projectile = G_AllocEntity(__func__);
+
+    projectile->owner = emitter;
+    projectile->solid = SOLID_NOT;
+    projectile->clip_mask = CONTENTS_MASK_CLIP_PROJECTILE;
+    projectile->move_type = MOVE_TYPE_THINK;
+    projectile->Think = G_FreeEntity;
+    projectile->s.effects = EF_BEAM;
+    projectile->s.trail = trail;
+    projectile->s.color = emitter->s.color;
+
+    // the beam leaves its emitter, never a player, so it must not be attributed to one;
+    // Cg_EntityTrail anchors an owned beam to that client's muzzle
+    projectile->s.client = MAX_CLIENTS;
+
+    projectile->timestamp = 0;
+  }
+
+  const vec3_t end = Vec3_Fmaf(start, MAX_WORLD_DIST, dir);
+
+  const cm_trace_t tr = gi.Trace(start, end, Box3_Zero(), projectile, CONTENTS_MASK_CLIP_PROJECTILE);
+
+  if (g_level.time >= projectile->timestamp && G_TakesDamage(tr.ent)) {
+
+    projectile->timestamp = g_level.time + (uint32_t) Maxf(emitter->wait * 1000.f, QUETOO_TICK_MILLIS);
+
+    G_Damage(&(g_damage_t) {
+      .target = tr.ent,
+      .inflictor = projectile,
+      .attacker = attacker,
+      .dir = dir,
+      .point = tr.end,
+      .normal = tr.plane.normal,
+      .damage = damage,
+      .knockback = knockback,
+      .flags = DMG_ENERGY,
+      .mod = mod
+    });
+  }
+
+  projectile->s.origin = start;
+  projectile->s.termination = tr.end;
+
+  gi.LinkEntity(projectile);
+
+  // Expire unless refreshed, so that a beam outlives neither its owner nor its operator. This
+  // must comfortably exceed the interval its refresher runs at: a trap refreshes every tick, but
+  // a turret only as often as the trigger_multiple behind it fires.
+  projectile->next_think = g_level.time + 250;
+}
+
+/**
+ * @brief Frees the sustained beam belonging to the given owner, if it has one.
+ */
+void G_FreeBeamProjectile(g_entity_t *emitter) {
+
+  g_entity_t *projectile = G_BeamProjectile_Find(emitter);
+
+  if (projectile) {
+    G_FreeEntity(projectile);
+  }
+}
+
+/**
  * @brief Fires a railgun slug that traces through multiple targets, dealing damage to each.
- * @param ent The entity the slug leaves, providing its origin and effect color.
+ * @param emitter The entity the slug leaves, providing its origin and effect color.
  * @param attacker The entity credited with any damage the slug inflicts.
  */
-void G_RailgunProjectile(g_entity_t *ent, g_entity_t *attacker, const vec3_t start, const vec3_t dir, int32_t damage,
+void G_RailgunProjectile(g_entity_t *emitter, g_entity_t *attacker, const vec3_t start, const vec3_t dir, int32_t damage,
              int32_t knockback, uint32_t mod) {
   vec3_t pos, end;
 
   pos = start;
 
-  cm_trace_t tr = gi.Trace(ent->s.origin, pos, Box3_Zero(), ent, CONTENTS_MASK_CLIP_PROJECTILE);
+  cm_trace_t tr = gi.Trace(emitter->s.origin, pos, Box3_Zero(), emitter, CONTENTS_MASK_CLIP_PROJECTILE);
   if (tr.fraction < 1.0) {
-    pos = ent->s.origin;
+    pos = emitter->s.origin;
   }
 
   int32_t content_mask = CONTENTS_MASK_CLIP_PROJECTILE | CONTENTS_MASK_LIQUID;
@@ -1130,7 +1228,7 @@ void G_RailgunProjectile(g_entity_t *ent, g_entity_t *attacker, const vec3_t sta
 
   G_Ripple(NULL, pos, end, 24.f, true);
 
-  g_entity_t *ignore = ent;
+  g_entity_t *ignore = emitter;
   while (ignore) {
     tr = gi.Trace(pos, end, Box3_Zero(), ignore, content_mask);
     if (!tr.ent) {
@@ -1147,7 +1245,7 @@ void G_RailgunProjectile(g_entity_t *ent, g_entity_t *attacker, const vec3_t sta
         .origin = &tr.end,
       }, MULTICAST_PHS);
 
-      ignore = ent;
+      ignore = emitter;
       continue;
     }
 
@@ -1159,10 +1257,10 @@ void G_RailgunProjectile(g_entity_t *ent, g_entity_t *attacker, const vec3_t sta
     }
 
     // we've hit something, so damage it
-    if ((tr.ent != ent) && (tr.ent != attacker) && G_TakesDamage(tr.ent)) {
+    if ((tr.ent != emitter) && (tr.ent != attacker) && G_TakesDamage(tr.ent)) {
       G_Damage(&(g_damage_t) {
         .target = tr.ent,
-        .inflictor = ent,
+        .inflictor = emitter,
         .attacker = attacker,
         .dir = dir,
         .point = tr.end,
@@ -1184,7 +1282,7 @@ void G_RailgunProjectile(g_entity_t *ent, g_entity_t *attacker, const vec3_t sta
   gi.WritePosition(tr.end);
   gi.WriteDir(tr.plane.normal);
   gi.WriteLong(tr.surface);
-  gi.WriteByte(ent->s.client);
+  gi.WriteByte(emitter->s.client);
 
   gi.Multicast(start, MULTICAST_PHS);
 }
@@ -1294,19 +1392,19 @@ static void G_BfgProjectile_Think(g_entity_t *ent) {
 /**
  * @brief Fires a BFG projectile with continuous area-effect damage and a large on-impact explosion.
  */
-void G_BfgProjectile(g_entity_t *ent, const vec3_t start, const vec3_t dir, int32_t speed, int32_t damage, int32_t knockback, float damage_radius) {
+void G_BfgProjectile(g_entity_t *emitter, g_entity_t *attacker, const vec3_t start, const vec3_t dir, int32_t speed, int32_t damage, int32_t knockback, float damage_radius) {
 
   const box3_t bounds = Box3f(24.f, 24.f, 24.f);
 
   g_entity_t *projectile = G_AllocEntity(__func__);
-  projectile->owner = ent;
+  projectile->owner = attacker;
 
   projectile->s.origin = start;
   projectile->bounds = bounds;
   projectile->velocity = Vec3_Scale(dir, speed);
 
-  if (G_ImmediateWall(ent, projectile)) {
-    projectile->s.origin = ent->s.origin;
+  if (G_ImmediateWall(emitter, projectile)) {
+    projectile->s.origin = emitter->s.origin;
   }
 
   projectile->solid = SOLID_PROJECTILE;

--- a/src/game/common/g_ballistics.h
+++ b/src/game/common/g_ballistics.h
@@ -24,18 +24,20 @@
 #include "g_types.h"
 
 #if defined(__G_LOCAL_H__)
-void G_BlasterProjectile(g_entity_t *ent, g_entity_t *attacker, const vec3_t start, const vec3_t dir, int32_t speed, int32_t damage, int32_t knockback, uint32_t mod);
-void G_BulletProjectile(g_entity_t *ent, const vec3_t start, const vec3_t dir, int32_t damage, int32_t knockback, int32_t hspread, int32_t vspread, int32_t mod);
-void G_NailProjectile(g_entity_t *ent, g_entity_t *attacker, const vec3_t start, const vec3_t dir, int32_t speed, int32_t damage, int32_t knockback, uint32_t mod);
-void G_ShotgunProjectiles(g_entity_t *ent, const vec3_t start, const vec3_t dir, int32_t damage, int32_t knockback, int32_t hspread, int32_t vspread, int32_t count, int32_t mod);
-void G_HyperblasterProjectile(g_entity_t *ent, const vec3_t start, const vec3_t dir, int32_t speed, int32_t damage, int32_t knockback);
-void G_GrenadeProjectile(g_entity_t *ent, g_entity_t *attacker, const vec3_t start, const vec3_t dir, int32_t speed, int32_t damage, int32_t knockback, float damage_radius, uint32_t timer, uint32_t mod);
-void G_QuakeGrenadeProjectile(g_entity_t *ent, const vec3_t start, const vec3_t dir, int32_t speed, int32_t damage, int32_t knockback, float damage_radius, uint32_t timer);
-void G_RocketProjectile(g_entity_t *ent, g_entity_t *attacker, const vec3_t start, const vec3_t dir, int32_t speed, int32_t damage, int32_t knockback, float damage_radius, uint32_t mod);
-void G_QuakeRocketProjectile(g_entity_t *ent, const vec3_t start, const vec3_t dir, int32_t speed, int32_t damage, int32_t knockback, float damage_radius);
+void G_BlasterProjectile(g_entity_t *emitter, g_entity_t *attacker, const vec3_t start, const vec3_t dir, int32_t speed, int32_t damage, int32_t knockback, uint32_t mod);
+void G_BulletProjectile(g_entity_t *emitter, g_entity_t *attacker, const vec3_t start, const vec3_t dir, int32_t damage, int32_t knockback, int32_t hspread, int32_t vspread, int32_t mod);
+void G_NailProjectile(g_entity_t *emitter, g_entity_t *attacker, const vec3_t start, const vec3_t dir, int32_t speed, int32_t damage, int32_t knockback, uint32_t mod);
+void G_ShotgunProjectiles(g_entity_t *emitter, g_entity_t *attacker, const vec3_t start, const vec3_t dir, int32_t damage, int32_t knockback, int32_t hspread, int32_t vspread, int32_t count, int32_t mod);
+void G_HyperblasterProjectile(g_entity_t *emitter, g_entity_t *attacker, const vec3_t start, const vec3_t dir, int32_t speed, int32_t damage, int32_t knockback);
+void G_GrenadeProjectile(g_entity_t *emitter, g_entity_t *attacker, const vec3_t start, const vec3_t dir, int32_t speed, int32_t damage, int32_t knockback, float damage_radius, uint32_t timer, uint32_t mod);
+void G_QuakeGrenadeProjectile(g_entity_t *emitter, g_entity_t *attacker, const vec3_t start, const vec3_t dir, int32_t speed, int32_t damage, int32_t knockback, float damage_radius, uint32_t timer);
+void G_RocketProjectile(g_entity_t *emitter, g_entity_t *attacker, const vec3_t start, const vec3_t dir, int32_t speed, int32_t damage, int32_t knockback, float damage_radius, uint32_t mod);
+void G_QuakeRocketProjectile(g_entity_t *emitter, g_entity_t *attacker, const vec3_t start, const vec3_t dir, int32_t speed, int32_t damage, int32_t knockback, float damage_radius);
 void G_LightningProjectile(g_entity_t *ent, const vec3_t start, const vec3_t dir, int32_t damage, int32_t knockback, int32_t mod, int32_t discharge_mod);
-void G_RailgunProjectile(g_entity_t *ent, g_entity_t *attacker, const vec3_t start, const vec3_t dir, int32_t damage, int32_t knockback, uint32_t mod);
-void G_BfgProjectile(g_entity_t *ent, const vec3_t start, const vec3_t dir, int32_t speed, int32_t damage, int32_t knockback, float damage_radius);
+void G_BeamProjectile(g_entity_t *emitter, g_entity_t *attacker, const vec3_t start, const vec3_t dir, int32_t damage, int32_t knockback, uint32_t mod, uint8_t trail);
+void G_FreeBeamProjectile(g_entity_t *emitter);
+void G_RailgunProjectile(g_entity_t *emitter, g_entity_t *attacker, const vec3_t start, const vec3_t dir, int32_t damage, int32_t knockback, uint32_t mod);
+void G_BfgProjectile(g_entity_t *emitter, g_entity_t *attacker, const vec3_t start, const vec3_t dir, int32_t speed, int32_t damage, int32_t knockback, float damage_radius);
 void G_HandGrenadeProjectile(g_entity_t *ent, g_entity_t *projectile, const vec3_t start, const vec3_t dir, int32_t speed, int32_t damage, int32_t knockback, float damage_radius, uint32_t timer);
 void G_GrenadeProjectile_Touch(g_entity_t *ent, g_entity_t *other, const cm_trace_t *trace);
 #endif

--- a/src/game/common/g_client.c
+++ b/src/game/common/g_client.c
@@ -56,12 +56,25 @@ static bool G_IsDeathCamMod(uint32_t mod) {
     case MOD_FIREBALL:
     case MOD_ACT_OF_GOD:
     case MOD_BOB:
-    case MOD_TRAP_BLASTER:
-    case MOD_TRAP_NAIL:
-    case MOD_TRAP_ROCKET:
-    case MOD_TRAP_GRENADE:
-    case MOD_TRAP_LASER:
-    case MOD_TRAP_GIBLETS:
+    case MOD_BALLISTICS_BLASTER:
+    case MOD_BALLISTICS_SHOTGUN:
+    case MOD_BALLISTICS_SUPER_SHOTGUN:
+    case MOD_BALLISTICS_MACHINEGUN:
+    case MOD_BALLISTICS_GRENADE:
+    case MOD_BALLISTICS_ROCKET:
+    case MOD_BALLISTICS_HYPERBLASTER:
+    case MOD_BALLISTICS_LIGHTNING:
+    case MOD_BALLISTICS_RAILGUN:
+    case MOD_BALLISTICS_BFG:
+    case MOD_BALLISTICS_QUAKE_SHOTGUN:
+    case MOD_BALLISTICS_QUAKE_SUPER_SHOTGUN:
+    case MOD_BALLISTICS_QUAKE_NAILGUN:
+    case MOD_BALLISTICS_QUAKE_SUPER_NAILGUN:
+    case MOD_BALLISTICS_QUAKE_GRENADE:
+    case MOD_BALLISTICS_QUAKE_ROCKET:
+    case MOD_BALLISTICS_QUAKE_THUNDERBOLT:
+    case MOD_BALLISTICS_LASER:
+    case MOD_BALLISTICS_GIBLETS:
       return true;
     default:
       return false;
@@ -172,17 +185,56 @@ static void G_ClientObituary(g_client_t *cl, g_entity_t *attacker, uint32_t mod)
       case MOD_TURRET_BLASTER:
         msg = "%s was lit up by %s's turret :blaster:";
         break;
-      case MOD_TURRET_NAIL:
-        msg = "%s was stapled down by %s's turret :nailgun:";
+      case MOD_TURRET_SHOTGUN:
+        msg = "%s was peppered by %s's turret :shotgun:";
         break;
-      case MOD_TURRET_ROCKET:
-        msg = "%s was shelled by %s's turret :rocket:";
+      case MOD_TURRET_SUPER_SHOTGUN:
+        msg = "%s was blown apart by %s's turret :sshotgun:";
+        break;
+      case MOD_TURRET_MACHINEGUN:
+        msg = "%s was mowed down by %s's turret :machinegun:";
         break;
       case MOD_TURRET_GRENADE:
         msg = "%s caught %s's care package :grenade:";
         break;
-      case MOD_TURRET_LASER:
+      case MOD_TURRET_ROCKET:
+        msg = "%s was shelled by %s's turret :rocket:";
+        break;
+      case MOD_TURRET_HYPERBLASTER:
+        msg = "%s was melted by %s's turret :hyperblaster:";
+        break;
+      case MOD_TURRET_LIGHTNING:
+        msg = "%s was electrified by %s's turret :lightning:";
+        break;
+      case MOD_TURRET_RAILGUN:
         msg = "%s was traced by %s's turret :railgun:";
+        break;
+      case MOD_TURRET_BFG:
+        msg = "%s was annihilated by %s's turret :bfg:";
+        break;
+      case MOD_TURRET_QUAKE_SHOTGUN:
+        msg = "%s ate buckshot from %s's turret :shotgun:";
+        break;
+      case MOD_TURRET_QUAKE_SUPER_SHOTGUN:
+        msg = "%s was torn open by %s's turret :sshotgun:";
+        break;
+      case MOD_TURRET_QUAKE_NAILGUN:
+        msg = "%s was stapled down by %s's turret :nailgun:";
+        break;
+      case MOD_TURRET_QUAKE_SUPER_NAILGUN:
+        msg = "%s was riddled by %s's turret :nailgun:";
+        break;
+      case MOD_TURRET_QUAKE_GRENADE:
+        msg = "%s was bounced a present by %s's turret :grenade:";
+        break;
+      case MOD_TURRET_QUAKE_ROCKET:
+        msg = "%s was launched by %s's turret :rocket:";
+        break;
+      case MOD_TURRET_QUAKE_THUNDERBOLT:
+        msg = "%s took the full charge of %s's turret :lightning:";
+        break;
+      case MOD_TURRET_LASER:
+        msg = "%s was burned through by %s's turret :bfg:";
         break;
       case MOD_TURRET_GIBLETS:
         msg = "%s was fed %s's leftovers :death:";
@@ -238,22 +290,61 @@ static void G_ClientObituary(g_client_t *cl, g_entity_t *attacker, uint32_t mod)
       case MOD_TRIGGER_HURT:
         msg = "%s was in the wrong place :actofgod:";
         break;
-      case MOD_TRAP_BLASTER:
+      case MOD_BALLISTICS_BLASTER:
         msg = "%s got a face full of trap :blaster:";
         break;
-      case MOD_TRAP_NAIL:
-        msg = "%s was nailed to the wall :nailgun:";
+      case MOD_BALLISTICS_SHOTGUN:
+        msg = "%s walked into the spray :shotgun:";
         break;
-      case MOD_TRAP_ROCKET:
-        msg = "%s should have taken the other tunnel :rocket:";
+      case MOD_BALLISTICS_SUPER_SHOTGUN:
+        msg = "%s was shredded at close range :sshotgun:";
         break;
-      case MOD_TRAP_GRENADE:
+      case MOD_BALLISTICS_MACHINEGUN:
+        msg = "%s was ventilated :machinegun:";
+        break;
+      case MOD_BALLISTICS_GRENADE:
         msg = "%s stepped on it :grenade:";
         break;
-      case MOD_TRAP_LASER:
+      case MOD_BALLISTICS_ROCKET:
+        msg = "%s should have taken the other tunnel :rocket:";
+        break;
+      case MOD_BALLISTICS_HYPERBLASTER:
+        msg = "%s was cooked in the corridor :hyperblaster:";
+        break;
+      case MOD_BALLISTICS_LIGHTNING:
+        msg = "%s completed the circuit :lightning:";
+        break;
+      case MOD_BALLISTICS_RAILGUN:
         msg = "%s was cut down to size :railgun:";
         break;
-      case MOD_TRAP_GIBLETS:
+      case MOD_BALLISTICS_BFG:
+        msg = "%s should not have opened that door :bfg:";
+        break;
+      case MOD_BALLISTICS_QUAKE_SHOTGUN:
+        msg = "%s was greeted with buckshot :shotgun:";
+        break;
+      case MOD_BALLISTICS_QUAKE_SUPER_SHOTGUN:
+        msg = "%s was met at the door :sshotgun:";
+        break;
+      case MOD_BALLISTICS_QUAKE_NAILGUN:
+        msg = "%s was nailed to the wall :nailgun:";
+        break;
+      case MOD_BALLISTICS_QUAKE_SUPER_NAILGUN:
+        msg = "%s was perforated :nailgun:";
+        break;
+      case MOD_BALLISTICS_QUAKE_GRENADE:
+        msg = "%s watched it bounce closer :grenade:";
+        break;
+      case MOD_BALLISTICS_QUAKE_ROCKET:
+        msg = "%s never heard it coming :rocket:";
+        break;
+      case MOD_BALLISTICS_QUAKE_THUNDERBOLT:
+        msg = "%s was left twitching :lightning:";
+        break;
+      case MOD_BALLISTICS_LASER:
+        msg = "%s walked into the beam :bfg:";
+        break;
+      case MOD_BALLISTICS_GIBLETS:
         msg = "%s was pelted to death with meat :death:";
         break;
       case MOD_ACT_OF_GOD:

--- a/src/game/common/g_client.c
+++ b/src/game/common/g_client.c
@@ -396,6 +396,24 @@ static void G_ClientGiblet_Touch(g_entity_t *ent, g_entity_t *other, const cm_tr
 }
 
 /**
+ * @brief Think for giblets spawned with an explicit lifetime, which do not linger and sink as a
+ * corpse's giblets do. Bleeds while in flight and frees itself at the deadline held in `timestamp`.
+ * @remarks Giblets only bleed while their think is running, so giblets given a lifetime would
+ * otherwise fly clean; the trail is assigned by `G_ClientCorpse_Think`, which they never run.
+ */
+static void G_Giblet_Think(g_entity_t *ent) {
+
+  if (g_level.time >= ent->timestamp) {
+    G_FreeEntity(ent);
+    return;
+  }
+
+  ent->s.trail = Vec3_Length(ent->velocity) > 30.f ? TRAIL_GIB : TRAIL_NONE;
+
+  ent->next_think = g_level.time + QUETOO_TICK_MILLIS;
+}
+
+/**
  * @brief Sink into the floor after a few seconds, providing a window of time for us to be made into
  * giblets or knocked around. This is called by corpses and giblets alike.
  */
@@ -540,8 +558,9 @@ void G_Giblets(const g_giblets_t *giblets) {
     gib->Touch = G_ClientGiblet_Touch;
 
     if (giblets->lifetime) {
-      gib->Think = G_FreeEntity;
-      gib->next_think = g_level.time + giblets->lifetime;
+      gib->timestamp = g_level.time + giblets->lifetime;
+      gib->Think = G_Giblet_Think;
+      gib->next_think = g_level.time + QUETOO_TICK_MILLIS;
     } else {
       gib->Think = G_ClientCorpse_Think;
       gib->next_think = g_level.time + QUETOO_TICK_MILLIS;

--- a/src/game/common/g_combat.c
+++ b/src/game/common/g_combat.c
@@ -98,22 +98,61 @@ static const char *G_WeaponNameForMod(g_means_of_death mod) {
       return "Quake Thunderbolt";
     case MOD_FIREBALL:
       return "Fireball";
-    case MOD_TRAP_BLASTER:
+    case MOD_BALLISTICS_BLASTER:
     case MOD_TURRET_BLASTER:
       return "Blaster";
-    case MOD_TRAP_NAIL:
-    case MOD_TURRET_NAIL:
-      return "Nailgun";
-    case MOD_TRAP_ROCKET:
-    case MOD_TURRET_ROCKET:
-      return "Rocket Launcher";
-    case MOD_TRAP_GRENADE:
+    case MOD_BALLISTICS_SHOTGUN:
+    case MOD_TURRET_SHOTGUN:
+      return "Shotgun";
+    case MOD_BALLISTICS_SUPER_SHOTGUN:
+    case MOD_TURRET_SUPER_SHOTGUN:
+      return "Super Shotgun";
+    case MOD_BALLISTICS_MACHINEGUN:
+    case MOD_TURRET_MACHINEGUN:
+      return "Machinegun";
+    case MOD_BALLISTICS_GRENADE:
     case MOD_TURRET_GRENADE:
       return "Grenade Launcher";
-    case MOD_TRAP_LASER:
-    case MOD_TURRET_LASER:
+    case MOD_BALLISTICS_ROCKET:
+    case MOD_TURRET_ROCKET:
+      return "Rocket Launcher";
+    case MOD_BALLISTICS_HYPERBLASTER:
+    case MOD_TURRET_HYPERBLASTER:
+      return "Hyperblaster";
+    case MOD_BALLISTICS_LIGHTNING:
+    case MOD_TURRET_LIGHTNING:
+      return "Lightning";
+    case MOD_BALLISTICS_RAILGUN:
+    case MOD_TURRET_RAILGUN:
       return "Railgun";
-    case MOD_TRAP_GIBLETS:
+    case MOD_BALLISTICS_BFG:
+    case MOD_TURRET_BFG:
+      return "BFG10K";
+    case MOD_BALLISTICS_QUAKE_SHOTGUN:
+    case MOD_TURRET_QUAKE_SHOTGUN:
+      return "Quake Shotgun";
+    case MOD_BALLISTICS_QUAKE_SUPER_SHOTGUN:
+    case MOD_TURRET_QUAKE_SUPER_SHOTGUN:
+      return "Quake Super Shotgun";
+    case MOD_BALLISTICS_QUAKE_NAILGUN:
+    case MOD_TURRET_QUAKE_NAILGUN:
+      return "Nailgun";
+    case MOD_BALLISTICS_QUAKE_SUPER_NAILGUN:
+    case MOD_TURRET_QUAKE_SUPER_NAILGUN:
+      return "Super Nailgun";
+    case MOD_BALLISTICS_QUAKE_GRENADE:
+    case MOD_TURRET_QUAKE_GRENADE:
+      return "Quake Grenade Launcher";
+    case MOD_BALLISTICS_QUAKE_ROCKET:
+    case MOD_TURRET_QUAKE_ROCKET:
+      return "Quake Rocket Launcher";
+    case MOD_BALLISTICS_QUAKE_THUNDERBOLT:
+    case MOD_TURRET_QUAKE_THUNDERBOLT:
+      return "Quake Thunderbolt";
+    case MOD_BALLISTICS_LASER:
+    case MOD_TURRET_LASER:
+      return "Laser";
+    case MOD_BALLISTICS_GIBLETS:
     case MOD_TURRET_GIBLETS:
       return "Giblets";
 #if defined(G_HOOK)

--- a/src/game/common/g_entity.c
+++ b/src/game/common/g_entity.c
@@ -74,11 +74,9 @@ static const g_entity_class_t g_entity_classes[] = {
 
   { "path_corner", G_info_notnull },
 
-  { "target_ballistics", G_target_ballistics },
   { "target_light", G_target_light },
   { "target_speaker", G_target_speaker },
   { "target_string", G_target_string },
-  { "target_turret", G_target_turret },
 
   { "trigger_always", G_trigger_always },
   { "trigger_exec", G_trigger_exec },
@@ -167,6 +165,11 @@ static void G_SpawnEntity(cm_entity_t *def) {
   const g_item_t *it = G_FindItemByClassName(ent->classname);
   if (it) {
     G_SpawnItem(ent, it);
+    return;
+  }
+
+  // check the ballistics entities, which are one classname per weapon
+  if (G_ballistics(ent)) {
     return;
   }
 

--- a/src/game/common/g_entity_target.c
+++ b/src/game/common/g_entity_target.c
@@ -181,59 +181,161 @@ void G_target_string(g_entity_t *ent) {
 
   // the rest is handled by G_UseTargets
 }
-
+/*
+ * One classname per weapon, `ballistics_$weapon` and `turret_$weapon`, resolved from the
+ * classname suffix. The weapon is a one-of-N choice, which spawnflags model badly: as flags they
+ * were eighteen mutually exclusive checkboxes that the spawn function had to police at runtime.
+ * Classnames make the invalid combinations unrepresentable, and editors group them by prefix.
+ * They are ordered as the weapons themselves are in `g_item_t` (`bg_item.h`).
+ */
 #define BALLISTICS_START_ON 0x1
 #define BALLISTICS_TOGGLE   0x2
-#define BALLISTICS_BLASTER  0x4
-#define BALLISTICS_NAIL     0x8
-#define BALLISTICS_ROCKET   0x10
-#define BALLISTICS_GRENADE  0x20
-#define BALLISTICS_LASER    0x40
-#define BALLISTICS_GIBLETS  0x80
 
-#define BALLISTICS_PROJECTILE (BALLISTICS_BLASTER | BALLISTICS_NAIL | BALLISTICS_ROCKET | \
-                               BALLISTICS_GRENADE | BALLISTICS_LASER | BALLISTICS_GIBLETS)
+#define BALLISTICS_CLASSNAME "ballistics_"
+#define TURRET_CLASSNAME     "turret_"
+
+typedef struct g_ballistics_type_s g_ballistics_type_t;
 
 /**
- * @brief Fires a blaster bolt from a `target_ballistics` or `target_turret`.
+ * @brief One projectile a `ballistics_*` or `turret_*` entity may fire.
  */
-static void G_target_ballistics_Blaster(g_entity_t *ent, g_entity_t *attacker, const vec3_t start, const vec3_t dir, uint32_t mod) {
+struct g_ballistics_type_s {
+
+  /**
+   * @brief The classname suffix that selects this projectile.
+   */
+  const char *name;
+
+  void (*Fire)(const g_ballistics_type_t *type, g_entity_t *ent, g_entity_t *attacker, const vec3_t start, const vec3_t dir, uint32_t mod);
+
+  g_muzzle_flash_t flash;
+  uint32_t ballistics_mod;
+  uint32_t turret_mod;
+  float min_wait;
+
+  /**
+   * @brief Milliseconds between muzzle flashes, throttling types that fire faster than their
+   * flash and its sample can be tolerated at. Zero flashes on every shot.
+   */
+  uint32_t flash_interval;
+
+  /**
+   * @brief True for a beam that persists between thinks rather than a discrete shot. Sustained
+   * types hold their beam for as long as they are on, and "wait" is the damage interval.
+   */
+  bool sustained;
+
+  cvar_t **damage;
+  cvar_t **knockback;
+  cvar_t **speed;
+  cvar_t **radius;
+  cvar_t **spread_x;
+  cvar_t **spread_y;
+  cvar_t **pellets;
+
+  int32_t default_damage;
+  int32_t default_speed;
+};
+
+/**
+ * @brief Fires a blaster bolt.
+ */
+static void G_ballistics_Blaster(const g_ballistics_type_t *type, g_entity_t *ent, g_entity_t *attacker, const vec3_t start, const vec3_t dir, uint32_t mod) {
   G_BlasterProjectile(ent, attacker, start, dir, ent->speed, ent->damage, ent->knockback, mod);
 }
 
 /**
- * @brief Fires a spike from a `target_ballistics` or `target_turret`.
+ * @brief Fires a burst of pellets.
  */
-static void G_target_ballistics_Nail(g_entity_t *ent, g_entity_t *attacker, const vec3_t start, const vec3_t dir, uint32_t mod) {
+static void G_ballistics_Shotgun(const g_ballistics_type_t *type, g_entity_t *ent, g_entity_t *attacker, const vec3_t start, const vec3_t dir, uint32_t mod) {
+  G_ShotgunProjectiles(ent, attacker, start, dir, ent->damage, ent->knockback,
+    (*type->spread_x)->integer, (*type->spread_y)->integer, (*type->pellets)->integer, mod);
+}
+
+/**
+ * @brief Fires a single bullet.
+ */
+static void G_ballistics_Machinegun(const g_ballistics_type_t *type, g_entity_t *ent, g_entity_t *attacker, const vec3_t start, const vec3_t dir, uint32_t mod) {
+  G_BulletProjectile(ent, attacker, start, dir, ent->damage, ent->knockback,
+    (*type->spread_x)->integer, (*type->spread_y)->integer, mod);
+}
+
+/**
+ * @brief Fires a spike.
+ */
+static void G_ballistics_Nail(const g_ballistics_type_t *type, g_entity_t *ent, g_entity_t *attacker, const vec3_t start, const vec3_t dir, uint32_t mod) {
   G_NailProjectile(ent, attacker, start, dir, ent->speed, ent->damage, ent->knockback, mod);
 }
 
 /**
- * @brief Fires a rocket from a `target_ballistics` or `target_turret`.
+ * @brief Fires a rocket.
  */
-static void G_target_ballistics_Rocket(g_entity_t *ent, g_entity_t *attacker, const vec3_t start, const vec3_t dir, uint32_t mod) {
+static void G_ballistics_Rocket(const g_ballistics_type_t *type, g_entity_t *ent, g_entity_t *attacker, const vec3_t start, const vec3_t dir, uint32_t mod) {
   G_RocketProjectile(ent, attacker, start, dir, ent->speed, ent->damage, ent->knockback, ent->damage_radius, mod);
 }
 
 /**
- * @brief Fires a grenade from a `target_ballistics` or `target_turret`.
+ * @brief Fires a Quake rocket.
  */
-static void G_target_ballistics_Grenade(g_entity_t *ent, g_entity_t *attacker, const vec3_t start, const vec3_t dir, uint32_t mod) {
+static void G_ballistics_QuakeRocket(const g_ballistics_type_t *type, g_entity_t *ent, g_entity_t *attacker, const vec3_t start, const vec3_t dir, uint32_t mod) {
+  G_QuakeRocketProjectile(ent, attacker, start, dir, ent->speed, ent->damage, ent->knockback, ent->damage_radius);
+}
+
+/**
+ * @brief Fires a grenade.
+ */
+static void G_ballistics_Grenade(const g_ballistics_type_t *type, g_entity_t *ent, g_entity_t *attacker, const vec3_t start, const vec3_t dir, uint32_t mod) {
   G_GrenadeProjectile(ent, attacker, start, dir, ent->speed, ent->damage, ent->knockback,
     ent->damage_radius, SECONDS_TO_MILLIS(g_balance_grenadelauncher_timer->value), mod);
 }
 
 /**
- * @brief Fires an instant traced beam from a `target_ballistics` or `target_turret`.
+ * @brief Fires a Quake grenade.
  */
-static void G_target_ballistics_Laser(g_entity_t *ent, g_entity_t *attacker, const vec3_t start, const vec3_t dir, uint32_t mod) {
+static void G_ballistics_QuakeGrenade(const g_ballistics_type_t *type, g_entity_t *ent, g_entity_t *attacker, const vec3_t start, const vec3_t dir, uint32_t mod) {
+  G_QuakeGrenadeProjectile(ent, attacker, start, dir, ent->speed, ent->damage, ent->knockback,
+    ent->damage_radius, SECONDS_TO_MILLIS(g_balance_quake_grenadelauncher_timer->value));
+}
+
+/**
+ * @brief Fires a hyperblaster bolt.
+ */
+static void G_ballistics_Hyperblaster(const g_ballistics_type_t *type, g_entity_t *ent, g_entity_t *attacker, const vec3_t start, const vec3_t dir, uint32_t mod) {
+  G_HyperblasterProjectile(ent, attacker, start, dir, ent->speed, ent->damage, ent->knockback);
+}
+
+/**
+ * @brief Fires a BFG orb.
+ */
+static void G_ballistics_Bfg(const g_ballistics_type_t *type, g_entity_t *ent, g_entity_t *attacker, const vec3_t start, const vec3_t dir, uint32_t mod) {
+  G_BfgProjectile(ent, attacker, start, dir, ent->speed, ent->damage, ent->knockback, ent->damage_radius);
+}
+
+/**
+ * @brief Fires a railgun slug.
+ */
+static void G_ballistics_Rail(const g_ballistics_type_t *type, g_entity_t *ent, g_entity_t *attacker, const vec3_t start, const vec3_t dir, uint32_t mod) {
   G_RailgunProjectile(ent, attacker, start, dir, ent->damage, ent->knockback, mod);
 }
 
 /**
- * @brief Scatters giblets from a `target_ballistics` or `target_turret`.
+ * @brief Creates or refreshes a laser beam.
  */
-static void G_target_ballistics_Giblets(g_entity_t *ent, g_entity_t *attacker, const vec3_t start, const vec3_t dir, uint32_t mod) {
+static void G_ballistics_Laser(const g_ballistics_type_t *type, g_entity_t *ent, g_entity_t *attacker, const vec3_t start, const vec3_t dir, uint32_t mod) {
+  G_BeamProjectile(ent, attacker, start, dir, ent->damage, ent->knockback, mod, TRAIL_LASER);
+}
+
+/**
+ * @brief Creates or refreshes a lightning beam.
+ */
+static void G_ballistics_Lightning(const g_ballistics_type_t *type, g_entity_t *ent, g_entity_t *attacker, const vec3_t start, const vec3_t dir, uint32_t mod) {
+  G_BeamProjectile(ent, attacker, start, dir, ent->damage, ent->knockback, mod, TRAIL_LIGHTNING);
+}
+
+/**
+ * @brief Scatters giblets.
+ */
+static void G_ballistics_Giblets(const g_ballistics_type_t *type, g_entity_t *ent, g_entity_t *attacker, const vec3_t start, const vec3_t dir, uint32_t mod) {
 
   const cm_trace_t tr = gi.Trace(ent->s.origin, start, Box3_Zero(), ent, CONTENTS_MASK_SOLID);
 
@@ -250,118 +352,226 @@ static void G_target_ballistics_Giblets(g_entity_t *ent, g_entity_t *attacker, c
   });
 }
 
-typedef struct {
-  uint32_t spawn_flag;
-  void (*Fire)(g_entity_t *ent, g_entity_t *attacker, const vec3_t start, const vec3_t dir, uint32_t mod);
-  g_muzzle_flash_t flash;
-  uint32_t trap_mod;
-  uint32_t turret_mod;
-  float min_wait;
-  cvar_t **damage;
-  cvar_t **knockback;
-  cvar_t **speed;
-  cvar_t **radius;
-  int32_t default_damage;
-  int32_t default_speed;
-} g_ballistics_type_t;
-
 static const g_ballistics_type_t g_ballistics_types[] = {
   {
-    .spawn_flag = BALLISTICS_BLASTER,
+    .name = "blaster",
     .min_wait = .1f,
-    .Fire = G_target_ballistics_Blaster,
+    .Fire = G_ballistics_Blaster,
     .flash = MZ_BLASTER,
-    .trap_mod = MOD_TRAP_BLASTER,
+    .ballistics_mod = MOD_BALLISTICS_BLASTER,
     .turret_mod = MOD_TURRET_BLASTER,
     .damage = &g_balance_blaster_damage,
     .knockback = &g_balance_blaster_knockback,
     .speed = &g_balance_blaster_speed,
   }, {
-    .spawn_flag = BALLISTICS_NAIL,
+    .name = "shotgun",
     .min_wait = .1f,
-    .Fire = G_target_ballistics_Nail,
-    .flash = MZ_QUAKE_NAILGUN,
-    .trap_mod = MOD_TRAP_NAIL,
-    .turret_mod = MOD_TURRET_NAIL,
-    .damage = &g_balance_quake_nailgun_damage,
-    .knockback = &g_balance_quake_nailgun_knockback,
-    .speed = &g_balance_quake_nailgun_speed,
+    .Fire = G_ballistics_Shotgun,
+    .flash = MZ_SHOTGUN,
+    .ballistics_mod = MOD_BALLISTICS_SHOTGUN,
+    .turret_mod = MOD_TURRET_SHOTGUN,
+    .damage = &g_balance_shotgun_damage,
+    .knockback = &g_balance_shotgun_knockback,
+    .spread_x = &g_balance_shotgun_spread_x,
+    .spread_y = &g_balance_shotgun_spread_y,
+    .pellets = &g_balance_shotgun_pellets,
   }, {
-    .spawn_flag = BALLISTICS_ROCKET,
+    .name = "supershotgun",
     .min_wait = .1f,
-    .Fire = G_target_ballistics_Rocket,
-    .flash = MZ_ROCKET_LAUNCHER,
-    .trap_mod = MOD_TRAP_ROCKET,
-    .turret_mod = MOD_TURRET_ROCKET,
-    .damage = &g_balance_rocketlauncher_damage,
-    .knockback = &g_balance_rocketlauncher_knockback,
-    .speed = &g_balance_rocketlauncher_speed,
-    .radius = &g_balance_rocketlauncher_radius,
+    .Fire = G_ballistics_Shotgun,
+    .flash = MZ_SUPER_SHOTGUN,
+    .ballistics_mod = MOD_BALLISTICS_SUPER_SHOTGUN,
+    .turret_mod = MOD_TURRET_SUPER_SHOTGUN,
+    .damage = &g_balance_supershotgun_damage,
+    .knockback = &g_balance_supershotgun_knockback,
+    .spread_x = &g_balance_supershotgun_spread_x,
+    .spread_y = &g_balance_supershotgun_spread_y,
+    .pellets = &g_balance_supershotgun_pellets,
   }, {
-    .spawn_flag = BALLISTICS_GRENADE,
+    .name = "machinegun",
     .min_wait = .1f,
-    .Fire = G_target_ballistics_Grenade,
+    .Fire = G_ballistics_Machinegun,
+    .flash = MZ_MACHINEGUN,
+    .ballistics_mod = MOD_BALLISTICS_MACHINEGUN,
+    .turret_mod = MOD_TURRET_MACHINEGUN,
+    .flash_interval = 100,
+    .damage = &g_balance_machinegun_damage,
+    .knockback = &g_balance_machinegun_knockback,
+    .spread_x = &g_balance_machinegun_spread_x,
+    .spread_y = &g_balance_machinegun_spread_y,
+  }, {
+    .name = "grenadelauncher",
+    .min_wait = .1f,
+    .Fire = G_ballistics_Grenade,
     .flash = MZ_GRENADE_LAUNCHER,
-    .trap_mod = MOD_TRAP_GRENADE,
+    .ballistics_mod = MOD_BALLISTICS_GRENADE,
     .turret_mod = MOD_TURRET_GRENADE,
     .damage = &g_balance_grenadelauncher_damage,
     .knockback = &g_balance_grenadelauncher_knockback,
     .speed = &g_balance_grenadelauncher_speed,
     .radius = &g_balance_grenadelauncher_radius,
   }, {
-    .spawn_flag = BALLISTICS_LASER,
-    .Fire = G_target_ballistics_Laser,
+    .name = "rocketlauncher",
+    .min_wait = .1f,
+    .Fire = G_ballistics_Rocket,
+    .flash = MZ_ROCKET_LAUNCHER,
+    .ballistics_mod = MOD_BALLISTICS_ROCKET,
+    .turret_mod = MOD_TURRET_ROCKET,
+    .damage = &g_balance_rocketlauncher_damage,
+    .knockback = &g_balance_rocketlauncher_knockback,
+    .speed = &g_balance_rocketlauncher_speed,
+    .radius = &g_balance_rocketlauncher_radius,
+  }, {
+    .name = "hyperblaster",
+    .min_wait = .1f,
+    .Fire = G_ballistics_Hyperblaster,
+    .flash = MZ_HYPERBLASTER,
+    .ballistics_mod = MOD_BALLISTICS_HYPERBLASTER,
+    .turret_mod = MOD_TURRET_HYPERBLASTER,
+    .flash_interval = 100,
+    .damage = &g_balance_hyperblaster_damage,
+    .knockback = &g_balance_hyperblaster_knockback,
+    .speed = &g_balance_hyperblaster_speed,
+  }, {
+    .name = "lightning",
+    .Fire = G_ballistics_Lightning,
+    .ballistics_mod = MOD_BALLISTICS_LIGHTNING,
+    .turret_mod = MOD_TURRET_LIGHTNING,
+    .sustained = true,
+    .damage = &g_balance_lightning_damage,
+    .knockback = &g_balance_lightning_knockback,
+  }, {
+    .name = "railgun",
+    .Fire = G_ballistics_Rail,
     .flash = MZ_RAILGUN,
-    .trap_mod = MOD_TRAP_LASER,
-    .turret_mod = MOD_TURRET_LASER,
+    .ballistics_mod = MOD_BALLISTICS_RAILGUN,
+    .turret_mod = MOD_TURRET_RAILGUN,
+    .flash_interval = 250,
     .damage = &g_balance_railgun_damage,
     .knockback = &g_balance_railgun_knockback,
   }, {
-    .spawn_flag = BALLISTICS_GIBLETS,
-    .Fire = G_target_ballistics_Giblets,
+    .name = "bfg",
+    .min_wait = .5f,
+    .Fire = G_ballistics_Bfg,
+    .flash = MZ_BFG10K,
+    .ballistics_mod = MOD_BALLISTICS_BFG,
+    .turret_mod = MOD_TURRET_BFG,
+    .damage = &g_balance_bfg_damage,
+    .knockback = &g_balance_bfg_knockback,
+    .speed = &g_balance_bfg_speed,
+    .radius = &g_balance_bfg_radius,
+  }, {
+    .name = "quake_shotgun",
+    .min_wait = .1f,
+    .Fire = G_ballistics_Shotgun,
+    .flash = MZ_QUAKE_SHOTGUN,
+    .ballistics_mod = MOD_BALLISTICS_QUAKE_SHOTGUN,
+    .turret_mod = MOD_TURRET_QUAKE_SHOTGUN,
+    .damage = &g_balance_quake_shotgun_damage,
+    .knockback = &g_balance_quake_shotgun_knockback,
+    .spread_x = &g_balance_quake_shotgun_spread_x,
+    .spread_y = &g_balance_quake_shotgun_spread_y,
+    .pellets = &g_balance_quake_shotgun_pellets,
+  }, {
+    .name = "quake_supershotgun",
+    .min_wait = .1f,
+    .Fire = G_ballistics_Shotgun,
+    .flash = MZ_QUAKE_SUPER_SHOTGUN,
+    .ballistics_mod = MOD_BALLISTICS_QUAKE_SUPER_SHOTGUN,
+    .turret_mod = MOD_TURRET_QUAKE_SUPER_SHOTGUN,
+    .damage = &g_balance_quake_supershotgun_damage,
+    .knockback = &g_balance_quake_supershotgun_knockback,
+    .spread_x = &g_balance_quake_supershotgun_spread_x,
+    .spread_y = &g_balance_quake_supershotgun_spread_y,
+    .pellets = &g_balance_quake_supershotgun_pellets,
+  }, {
+    .name = "quake_nailgun",
+    .min_wait = .1f,
+    .Fire = G_ballistics_Nail,
+    .flash = MZ_QUAKE_NAILGUN,
+    .ballistics_mod = MOD_BALLISTICS_QUAKE_NAILGUN,
+    .turret_mod = MOD_TURRET_QUAKE_NAILGUN,
+    .damage = &g_balance_quake_nailgun_damage,
+    .knockback = &g_balance_quake_nailgun_knockback,
+    .speed = &g_balance_quake_nailgun_speed,
+  }, {
+    .name = "quake_supernailgun",
+    .min_wait = .1f,
+    .Fire = G_ballistics_Nail,
+    .flash = MZ_QUAKE_SUPER_NAILGUN,
+    .ballistics_mod = MOD_BALLISTICS_QUAKE_SUPER_NAILGUN,
+    .turret_mod = MOD_TURRET_QUAKE_SUPER_NAILGUN,
+    .damage = &g_balance_quake_supernailgun_damage,
+    .knockback = &g_balance_quake_supernailgun_knockback,
+    .speed = &g_balance_quake_supernailgun_speed,
+  }, {
+    .name = "quake_grenadelauncher",
+    .min_wait = .1f,
+    .Fire = G_ballistics_QuakeGrenade,
+    .flash = MZ_QUAKE_GRENADE_LAUNCHER,
+    .ballistics_mod = MOD_BALLISTICS_QUAKE_GRENADE,
+    .turret_mod = MOD_TURRET_QUAKE_GRENADE,
+    .damage = &g_balance_quake_grenadelauncher_damage,
+    .knockback = &g_balance_quake_grenadelauncher_knockback,
+    .speed = &g_balance_quake_grenadelauncher_speed,
+    .radius = &g_balance_quake_grenadelauncher_radius,
+  }, {
+    .name = "quake_rocketlauncher",
+    .min_wait = .1f,
+    .Fire = G_ballistics_QuakeRocket,
+    .flash = MZ_QUAKE_ROCKET_LAUNCHER,
+    .ballistics_mod = MOD_BALLISTICS_QUAKE_ROCKET,
+    .turret_mod = MOD_TURRET_QUAKE_ROCKET,
+    .damage = &g_balance_quake_rocketlauncher_damage,
+    .knockback = &g_balance_quake_rocketlauncher_knockback,
+    .speed = &g_balance_quake_rocketlauncher_speed,
+    .radius = &g_balance_quake_rocketlauncher_radius,
+  }, {
+    .name = "quake_thunderbolt",
+    .Fire = G_ballistics_Lightning,
+    .ballistics_mod = MOD_BALLISTICS_QUAKE_THUNDERBOLT,
+    .turret_mod = MOD_TURRET_QUAKE_THUNDERBOLT,
+    .sustained = true,
+    .damage = &g_balance_quake_thunderbolt_damage,
+    .knockback = &g_balance_quake_thunderbolt_knockback,
+  }, {
+    .name = "laser",
+    .Fire = G_ballistics_Laser,
+    .ballistics_mod = MOD_BALLISTICS_LASER,
+    .turret_mod = MOD_TURRET_LASER,
+    .sustained = true,
+    .default_damage = 20,
+  }, {
+    .name = "giblets",
+    .Fire = G_ballistics_Giblets,
     .flash = MZ_LOGOUT,
-    .trap_mod = MOD_TRAP_GIBLETS,
+    .ballistics_mod = MOD_BALLISTICS_GIBLETS,
     .turret_mod = MOD_TURRET_GIBLETS,
     .min_wait = .25f,
+    .flash_interval = 400,
     .default_damage = 10,
     .default_speed = 500,
   }
 };
 
 /**
- * @brief Resolves the projectile the entity was configured to fire, defaulting to the blaster.
+ * @brief Resolves the projectile named by the suffix of a `ballistics_*` or `turret_*` classname.
  */
-static const g_ballistics_type_t *G_target_ballistics_Type(const g_entity_t *ent) {
+static const g_ballistics_type_t *G_ballistics_Type(const char *name) {
 
   for (size_t i = 0; i < lengthof(g_ballistics_types); i++) {
-    if (ent->spawn_flags & g_ballistics_types[i].spawn_flag) {
+    if (!q_strcmp(g_ballistics_types[i].name, name)) {
       return &g_ballistics_types[i];
     }
   }
 
-  return &g_ballistics_types[0];
-}
-
-/**
- * @brief Emits a single projectile along the given direction, with the muzzle pushed clear of the
- * brushwork the entity is typically embedded in.
- */
-static void G_target_ballistics_Fire(g_entity_t *ent, g_entity_t *attacker, const vec3_t dir, uint32_t mod) {
-
-  const g_ballistics_type_t *type = G_target_ballistics_Type(ent);
-
-  const vec3_t aim = Vec3_RandomizeDir(dir, ent->accel);
-  const vec3_t start = Vec3_Fmaf(ent->s.origin, 8.f, aim);
-
-  type->Fire(ent, attacker, start, aim, mod);
-
-  G_WorldMuzzleFlash(start, aim, type->flash);
+  return NULL;
 }
 
 /**
  * @brief Resolves the direction a trap fires in, tracking its target entity if it has one.
  */
-static vec3_t G_target_ballistics_Dir(g_entity_t *ent) {
+static vec3_t G_ballistics_Dir(g_entity_t *ent) {
 
   if (ent->target) {
     const g_entity_t *target = G_PickTarget(ent->target);
@@ -378,14 +588,46 @@ static vec3_t G_target_ballistics_Dir(g_entity_t *ent) {
 }
 
 /**
+ * @brief Emits a single projectile along the given direction, with the muzzle pushed clear of the
+ * brushwork the entity is typically embedded in.
+ * @remarks The muzzle flash is throttled per projectile type, independently of the fire rate. A
+ * hitscan type may legitimately fire on every tick, which no flash and its sample survive. A
+ * sustained beam is not a shot at all, so it never flashes.
+ */
+static void G_ballistics_Fire(g_entity_t *ent, g_entity_t *attacker, const vec3_t dir, uint32_t mod) {
+
+  const g_ballistics_type_t *type = ent->ballistics;
+
+  const vec3_t aim = Vec3_RandomizeDir(dir, ent->accel);
+  const vec3_t start = Vec3_Fmaf(ent->s.origin, 8.f, aim);
+
+  type->Fire(type, ent, attacker, start, aim, mod);
+
+  if (type->sustained) {
+    return;
+  }
+
+  if (g_level.time >= ent->flash_time) {
+    ent->flash_time = g_level.time + type->flash_interval;
+
+    G_WorldMuzzleFlash(start, aim, type->flash, ent->s.client);
+  }
+}
+
+/**
  * @brief Think callback for a free-running trap; fires and re-arms itself.
  */
-static void G_target_ballistics_Think(g_entity_t *ent) {
+static void G_ballistics_Think(g_entity_t *ent) {
 
-  G_target_ballistics_Fire(ent, ent, G_target_ballistics_Dir(ent), G_target_ballistics_Type(ent)->trap_mod);
+  const g_ballistics_type_t *type = ent->ballistics;
+
+  G_ballistics_Fire(ent, ent, G_ballistics_Dir(ent), type->ballistics_mod);
 
   if (ent->count) {
-    const float wait = ent->wait * 1000.f + ent->random * 1000.f * RandomRangef(-1.f, 1.f);
+    // a sustained type holds its beam, so it refreshes every tick rather than at "wait"
+    const float wait = type->sustained ? 0.f
+      : ent->wait * 1000.f + ent->random * 1000.f * RandomRangef(-1.f, 1.f);
+
     ent->next_think = g_level.time + (uint32_t) Maxf(wait, QUETOO_TICK_MILLIS);
   } else {
     ent->next_think = 0;
@@ -393,10 +635,10 @@ static void G_target_ballistics_Think(g_entity_t *ent) {
 }
 
 /**
- * @brief Handles use activation of a `target_ballistics`, toggling a free-running trap or firing a
- * single shot after an optional delay.
+ * @brief Handles use activation of a trap, toggling a free-running one or firing a single shot
+ * after an optional delay.
  */
-static void G_target_ballistics_Use(g_entity_t *ent, g_entity_t *other, g_entity_t *activator) {
+static void G_ballistics_Use(g_entity_t *ent, g_entity_t *other, g_entity_t *activator) {
 
   if (ent->spawn_flags & BALLISTICS_TOGGLE) {
 
@@ -406,6 +648,12 @@ static void G_target_ballistics_Use(g_entity_t *ent, g_entity_t *other, g_entity
       ent->next_think = g_level.time + (uint32_t) Maxf(ent->delay * 1000.f, QUETOO_TICK_MILLIS);
     } else {
       ent->next_think = 0;
+
+      const g_ballistics_type_t *type = ent->ballistics;
+
+      if (type->sustained) {
+        G_FreeBeamProjectile(ent);
+      }
     }
 
     return;
@@ -420,43 +668,47 @@ static void G_target_ballistics_Use(g_entity_t *ent, g_entity_t *other, g_entity
   if (ent->delay) {
     ent->next_think = g_level.time + (uint32_t) Maxf(ent->delay * 1000.f, QUETOO_TICK_MILLIS);
   } else {
-    G_target_ballistics_Fire(ent, ent, G_target_ballistics_Dir(ent), G_target_ballistics_Type(ent)->trap_mod);
+    const g_ballistics_type_t *type = ent->ballistics;
+
+    G_ballistics_Fire(ent, ent, G_ballistics_Dir(ent), type->ballistics_mod);
   }
 }
 
 /**
- * @brief Handles use activation of a `target_turret`, firing along the activator's view and
- * crediting them with any damage.
+ * @brief Handles use activation of a turret, firing along the activator's view and crediting them
+ * with any damage.
  */
-static void G_target_turret_Use(g_entity_t *ent, g_entity_t *other, g_entity_t *activator) {
+static void G_turret_Use(g_entity_t *ent, g_entity_t *other, g_entity_t *activator) {
 
-  if (ent->timestamp > g_level.time) {
-    return;
+  const g_ballistics_type_t *type = ent->ballistics;
+
+  // "wait" gates shots; a sustained beam must be refreshed far more often than that or it
+  // expires between uses, and its damage interval is enforced by the beam itself
+  if (!type->sustained) {
+
+    if (ent->timestamp > g_level.time) {
+      return;
+    }
+
+    ent->timestamp = g_level.time + ent->wait * 1000.0;
   }
-
-  ent->timestamp = g_level.time + ent->wait * 1000.0;
 
   if (activator && activator->client) {
     ent->s.client = activator->s.client;
-    G_target_ballistics_Fire(ent, activator, activator->client->forward, G_target_ballistics_Type(ent)->turret_mod);
+    G_ballistics_Fire(ent, activator, activator->client->forward, type->turret_mod);
   } else {
     ent->s.client = MAX_CLIENTS;
-    G_target_ballistics_Fire(ent, ent, ent->move_dir, G_target_ballistics_Type(ent)->trap_mod);
+    G_ballistics_Fire(ent, ent, ent->move_dir, type->ballistics_mod);
   }
 }
 
 /**
- * @brief Common initialization for the ballistics entities, resolving the projectile and applying
- * the balance defaults the mapper did not override.
+ * @brief Common initialization for both roles, applying the balance defaults the mapper did not
+ * override.
  */
-static void G_target_ballistics_Init(g_entity_t *ent) {
+static void G_ballistics_Init(g_entity_t *ent, const g_ballistics_type_t *type) {
 
-  const uint32_t projectile = ent->spawn_flags & BALLISTICS_PROJECTILE;
-  if (projectile & (projectile - 1)) {
-    G_Warn("%s has more than one projectile flag set\n", etos(ent));
-  }
-
-  const g_ballistics_type_t *type = G_target_ballistics_Type(ent);
+  ent->ballistics = type;
 
   if (ent->damage == 0 && type->damage) {
     ent->damage = (*type->damage)->integer;
@@ -485,7 +737,7 @@ static void G_target_ballistics_Init(g_entity_t *ent) {
     ent->wait = 1.f;
   }
 
-  // only the laser is hitscan; the rest would exhaust the entity pool at zero
+  // the hitscan and sustained types would otherwise exhaust the entity pool at zero
   ent->wait = Maxf(ent->wait, type->min_wait);
   ent->random = Maxf(ent->random, 0.f);
   ent->delay = Maxf(ent->delay, 0.f);
@@ -493,93 +745,90 @@ static void G_target_ballistics_Init(g_entity_t *ent) {
   ent->count = 0;
   ent->s.client = MAX_CLIENTS;
 
+  if (type->sustained) {
+    vec3_t color = gi.EntityValue(ent->def, "color")->vec3;
+    if (Vec3_Equal(color, Vec3_Zero())) {
+      color = Vec3_One();
+    }
+
+    ent->s.color = Color_Color32(Color3fv(color));
+  }
+
   G_SetMoveDir(ent);
 
   gi.LinkEntity(ent);
 }
 
-/*QUAKED target_ballistics (1 .3 .3) (-8 -8 -8) (8 8 8) start_on toggle blaster nail rocket grenade laser giblets
- Fires projectiles at an interval, or each time it is used. Use these to build wall traps,
- spike shooters and lasers.
+/*
+ * These entities are documented as data rather than as QUAKED blocks here, the way the items are.
+ * One block per classname would mean thirty-eight copies of the same nine keys; instead
+ * Quetoo.fgd carries a @BaseClass for each role, exactly as it does for `Item` and `Weapon`, and
+ * every classname costs one line. See quetoo-data/target/default/scripts.
+ *
+ * Keys, shared by every classname:
+ *
+ *   angles      the direction fired in; a turret uses this only when something other than a
+ *               player triggers it. -1 is up, -2 is down
+ *   color       the beam color of the sustained types, defaulting to white
+ *   delay       seconds between being used and firing
+ *   dmg         damage per projectile, defaulting to the weapon's own balance
+ *   knockback   knockback per projectile, likewise
+ *   random      seconds of variance added to "wait"
+ *   speed       projectile speed, likewise
+ *   spread      cone of fire, 0.0 for pinpoint through 1.0 for wild
+ *   target      an entity to aim at, re-evaluated every shot, overriding "angles"
+ *   targetname  the target name of this entity
+ *   wait        seconds between shots, or between damage for the sustained types
+ *
+ * Spawn flags:
+ *
+ *   start_on    fires from level start, without being used. `ballistics_*` only
+ *   toggle      using it toggles it on and off rather than firing one shot. `ballistics_*` only
+ */
 
- -------- Keys --------
- angles : The angles at which projectiles are fired. Use -1 for up, -2 for down.
- delay : The delay in seconds between being used and firing (default 0).
- dmg : The damage inflicted by each projectile (default varies by projectile).
- knockback : The knockback applied by each projectile (default varies by projectile).
- random : Random time variance in seconds added to "wait" (default 0).
- speed : The projectile speed in units per second (default varies by projectile).
- spread : The cone of fire, from 0.0 for pinpoint to 1.0 for wild (default 0).
- target : An entity to aim at, re-evaluated on every shot. Overrides "angles".
- targetname : The target name of this entity.
- wait : The interval in seconds between shots (default 1.0). Only the laser may set 0.
+/**
+ * @brief Spawns a `ballistics_*` or `turret_*` entity, resolving its projectile from the suffix
+ * of its classname.
+ * @return True if the classname named one of these entities, whether or not it could be spawned.
+ * @remarks The weapon is a classname rather than a spawnflag because it is a choice of one from
+ * nineteen, which flags model as nineteen independent checkboxes. Editors also group these by
+ * their prefix, and the mapper picks a `turret_railgun` rather than a turret plus a checkbox.
+ */
+bool G_ballistics(g_entity_t *ent) {
 
- -------- Spawn flags --------
- start_on : Fires on its own from level start, without being used.
- toggle : Using this entity toggles it on and off, rather than firing one shot.
- blaster : Fires blaster bolts. This is the default.
- nail : Fires spikes.
- rocket : Fires rockets.
- grenade : Fires grenades.
- laser : Fires an instant traced beam. Set "wait" to 0 for a continuous laser.
- giblets : Fires giblets.
+  const char *name;
+  bool turret;
 
- -------- Notes --------
- Place this entity in open air, in front of the brushwork that represents it, not embedded
- within it. Projectiles that would spawn inside a wall are pulled back to the entity origin.
-
- Set exactly one projectile flag. Traps do not spare whoever triggered them. For a version
- players can aim and take credit for, use target_turret.
-*/
-void G_target_ballistics(g_entity_t *ent) {
-
-  G_target_ballistics_Init(ent);
-
-  ent->Use = G_target_ballistics_Use;
-  ent->Think = G_target_ballistics_Think;
-
-  if (ent->spawn_flags & BALLISTICS_START_ON) {
-    ent->count = 1;
-    ent->next_think = g_level.time + RandomRangeu(1, 1000);
+  if (!strncmp(ent->classname, BALLISTICS_CLASSNAME, strlen(BALLISTICS_CLASSNAME))) {
+    name = ent->classname + strlen(BALLISTICS_CLASSNAME);
+    turret = false;
+  } else if (!strncmp(ent->classname, TURRET_CLASSNAME, strlen(TURRET_CLASSNAME))) {
+    name = ent->classname + strlen(TURRET_CLASSNAME);
+    turret = true;
+  } else {
+    return false;
   }
-}
 
-/*QUAKED target_turret (1 .6 .2) (-8 -8 -8) (8 8 8) x x blaster nail rocket grenade laser giblets
- Fires a projectile along the view of whoever uses it, and credits them with the kill.
- Surround it with a trigger_multiple that targets it, and players who step in behind it
- will operate it.
+  const g_ballistics_type_t *type = G_ballistics_Type(name);
+  if (type == NULL) {
+    G_Warn("%s has no such projectile \"%s\"\n", etos(ent), name);
+    G_FreeEntity(ent);
+    return true;
+  }
 
- -------- Keys --------
- angles : The angles to fire at when used by something other than a player.
- dmg : The damage inflicted by each projectile (default varies by projectile).
- knockback : The knockback applied by each projectile (default varies by projectile).
- speed : The projectile speed in units per second (default varies by projectile).
- spread : The cone of fire, from 0.0 for pinpoint to 1.0 for wild (default 0).
- targetname : The target name of this entity.
- wait : The minimum interval in seconds between shots (default 1.0).
+  G_ballistics_Init(ent, type);
 
- -------- Spawn flags --------
- x
- x
- blaster : Fires blaster bolts. This is the default.
- nail : Fires spikes.
- rocket : Fires rockets.
- grenade : Fires grenades.
- laser : Fires an instant traced beam.
- giblets : Fires giblets.
+  if (turret) {
+    ent->Use = G_turret_Use;
+  } else {
+    ent->Use = G_ballistics_Use;
+    ent->Think = G_ballistics_Think;
 
- -------- Notes --------
- Projectiles leave the turret, not the player, but carry the player's colors and are
- credited to them. The muzzle flash uses the weapon's own colors.
+    if (ent->spawn_flags & BALLISTICS_START_ON) {
+      ent->count = 1;
+      ent->next_think = g_level.time + RandomRangeu(1, 1000);
+    }
+  }
 
- The operator cannot be struck by their own projectiles, but the rocket and grenade
- types still splash them, so leave room behind the turret.
-
- Give the trigger_multiple a short "wait" for sustained fire while the player stands in it.
-*/
-void G_target_turret(g_entity_t *ent) {
-
-  G_target_ballistics_Init(ent);
-
-  ent->Use = G_target_turret_Use;
+  return true;
 }

--- a/src/game/common/g_entity_target.h
+++ b/src/game/common/g_entity_target.h
@@ -24,9 +24,8 @@
 #include "g_types.h"
 
 #if defined(__G_LOCAL_H__)
-void G_target_ballistics(g_entity_t *ent);
+bool G_ballistics(g_entity_t *ent);
 void G_target_light(g_entity_t *ent);
 void G_target_speaker(g_entity_t *ent);
 void G_target_string(g_entity_t *ent);
-void G_target_turret(g_entity_t *ent);
 #endif

--- a/src/game/common/g_weapon.c
+++ b/src/game/common/g_weapon.c
@@ -417,9 +417,10 @@ static void G_ClientMuzzleFlash(g_entity_t *ent, g_muzzle_flash_t flash) {
 
 /**
  * @brief Broadcasts a muzzle flash for a shooter the server does not transmit, such as a
- * `target_ballistics`. The origin and direction accompany the flash, as there is no entity
- * for the client to infer them from, as does the client to colorize it for, which is the
- * operator of a `target_turret` and `MAX_CLIENTS` for anything firing on its own account.
+ * `ballistics_*` entity. The origin and direction accompany the flash, as there is no entity for
+ * the client to infer them from.
+ * @param client The client whose colors the flash takes, being the operator of a `turret_*`
+ * entity, or `MAX_CLIENTS` for anything firing on its own account.
  */
 void G_WorldMuzzleFlash(const vec3_t org, const vec3_t dir, g_muzzle_flash_t flash, uint8_t client) {
 

--- a/src/game/common/g_weapon.c
+++ b/src/game/common/g_weapon.c
@@ -418,15 +418,17 @@ static void G_ClientMuzzleFlash(g_entity_t *ent, g_muzzle_flash_t flash) {
 /**
  * @brief Broadcasts a muzzle flash for a shooter the server does not transmit, such as a
  * `target_ballistics`. The origin and direction accompany the flash, as there is no entity
- * for the client to infer them from.
+ * for the client to infer them from, as does the client to colorize it for, which is the
+ * operator of a `target_turret` and `MAX_CLIENTS` for anything firing on its own account.
  */
-void G_WorldMuzzleFlash(const vec3_t org, const vec3_t dir, g_muzzle_flash_t flash) {
+void G_WorldMuzzleFlash(const vec3_t org, const vec3_t dir, g_muzzle_flash_t flash, uint8_t client) {
 
   gi.WriteByte(SV_CMD_MUZZLE_FLASH);
   gi.WriteShort(MUZZLE_FLASH_WORLD);
   gi.WriteByte(flash);
   gi.WritePosition(org);
   gi.WriteDir(dir);
+  gi.WriteByte(client);
 
   gi.Multicast(org, MULTICAST_PHS);
 }

--- a/src/game/common/g_weapon.c
+++ b/src/game/common/g_weapon.c
@@ -460,7 +460,7 @@ void G_FireShotgun(g_client_t *cl) {
 
     G_ClientProjectile(cl, &forward, &right, &up, &org, 1.0);
 
-    G_ShotgunProjectiles(cl->entity, org, forward, g_balance_shotgun_damage->integer,
+    G_ShotgunProjectiles(cl->entity, cl->entity, org, forward, g_balance_shotgun_damage->integer,
       g_balance_shotgun_knockback->integer, g_balance_shotgun_spread_x->integer,
       g_balance_shotgun_spread_y->integer, g_balance_shotgun_pellets->integer, MOD_SHOTGUN);
 
@@ -480,7 +480,7 @@ void G_FireSuperShotgun(g_client_t *cl) {
 
     G_ClientProjectile(cl, &forward, &right, &up, &org, 1.0);
 
-    G_ShotgunProjectiles(cl->entity, org, forward, g_balance_supershotgun_damage->integer,
+    G_ShotgunProjectiles(cl->entity, cl->entity, org, forward, g_balance_supershotgun_damage->integer,
       g_balance_supershotgun_knockback->integer, g_balance_supershotgun_spread_x->integer,
       g_balance_supershotgun_spread_y->integer, g_balance_supershotgun_pellets->integer, MOD_SUPER_SHOTGUN);
 
@@ -500,7 +500,7 @@ void G_FireMachinegun(g_client_t *cl) {
 
     G_ClientProjectile(cl, &forward, &right, &up, &org, 1.0);
 
-    G_BulletProjectile(cl->entity, org, forward, g_balance_machinegun_damage->integer,
+    G_BulletProjectile(cl->entity, cl->entity, org, forward, g_balance_machinegun_damage->integer,
       g_balance_machinegun_knockback->integer, g_balance_machinegun_spread_x->integer,
       g_balance_machinegun_spread_y->integer, MOD_MACHINEGUN);
 
@@ -721,7 +721,7 @@ void G_FireHyperblaster(g_client_t *cl) {
 
     G_ClientProjectile(cl, &forward, &right, &up, &org, 1.0);
 
-    G_HyperblasterProjectile(cl->entity, org, forward, g_balance_hyperblaster_speed->integer,
+    G_HyperblasterProjectile(cl->entity, cl->entity, org, forward, g_balance_hyperblaster_speed->integer,
       g_balance_hyperblaster_damage->integer, g_balance_hyperblaster_knockback->value);
 
     G_ClientMuzzleFlash(cl->entity, MZ_HYPERBLASTER);
@@ -792,7 +792,7 @@ void G_FireQuakeShotgun(g_client_t *cl) {
 
     G_ClientProjectile(cl, &forward, &right, &up, &org, 0.0);
 
-    G_ShotgunProjectiles(cl->entity, org, forward, g_balance_quake_shotgun_damage->integer,
+    G_ShotgunProjectiles(cl->entity, cl->entity, org, forward, g_balance_quake_shotgun_damage->integer,
       g_balance_quake_shotgun_knockback->integer, g_balance_quake_shotgun_spread_x->integer,
       g_balance_quake_shotgun_spread_y->integer, g_balance_quake_shotgun_pellets->integer,
       MOD_QUAKE_SHOTGUN);
@@ -813,7 +813,7 @@ void G_FireQuakeSuperShotgun(g_client_t *cl) {
 
     G_ClientProjectile(cl, &forward, &right, &up, &org, 0.0);
 
-    G_ShotgunProjectiles(cl->entity, org, forward, g_balance_quake_supershotgun_damage->integer,
+    G_ShotgunProjectiles(cl->entity, cl->entity, org, forward, g_balance_quake_supershotgun_damage->integer,
       g_balance_quake_supershotgun_knockback->integer, g_balance_quake_supershotgun_spread_x->integer,
       g_balance_quake_supershotgun_spread_y->integer, g_balance_quake_supershotgun_pellets->integer,
       MOD_QUAKE_SUPER_SHOTGUN);
@@ -886,7 +886,7 @@ void G_FireQuakeGrenadeLauncher(g_client_t *cl) {
 
     G_ClientProjectile(cl, &forward, &right, &up, &org, 0.0);
 
-    G_QuakeGrenadeProjectile(cl->entity, org, forward, g_balance_quake_grenadelauncher_speed->integer,
+    G_QuakeGrenadeProjectile(cl->entity, cl->entity, org, forward, g_balance_quake_grenadelauncher_speed->integer,
       g_balance_quake_grenadelauncher_damage->integer, g_balance_quake_grenadelauncher_knockback->integer,
       g_balance_quake_grenadelauncher_radius->value, SECONDS_TO_MILLIS(g_balance_quake_grenadelauncher_timer->value));
 
@@ -906,7 +906,7 @@ void G_FireQuakeRocketLauncher(g_client_t *cl) {
 
     G_ClientProjectile(cl, &forward, &right, &up, &org, 0.0);
 
-    G_QuakeRocketProjectile(cl->entity, org, forward, g_balance_quake_rocketlauncher_speed->integer,
+    G_QuakeRocketProjectile(cl->entity, cl->entity, org, forward, g_balance_quake_rocketlauncher_speed->integer,
       g_balance_quake_rocketlauncher_damage->integer, g_balance_quake_rocketlauncher_knockback->integer,
       g_balance_quake_rocketlauncher_radius->value);
 
@@ -958,7 +958,7 @@ static void G_FireBfg_(g_entity_t *ent) {
 
       G_ClientProjectile(cl, &forward, &right, &up, &org, 1.0);
 
-      G_BfgProjectile(ent->owner, org, forward, g_balance_bfg_speed->integer,
+      G_BfgProjectile(ent->owner, ent->owner, org, forward, g_balance_bfg_speed->integer,
         g_balance_bfg_damage->integer, g_balance_bfg_knockback->integer,
         g_balance_bfg_radius->value);
 

--- a/src/game/common/g_weapon.h
+++ b/src/game/common/g_weapon.h
@@ -47,6 +47,6 @@ void G_FireQuakeSuperNailgun(g_client_t *cl);
 void G_FireQuakeGrenadeLauncher(g_client_t *cl);
 void G_FireQuakeRocketLauncher(g_client_t *cl);
 void G_FireQuakeThunderbolt(g_client_t *cl);
-void G_WorldMuzzleFlash(const vec3_t org, const vec3_t dir, g_muzzle_flash_t flash);
+void G_WorldMuzzleFlash(const vec3_t org, const vec3_t dir, g_muzzle_flash_t flash, uint8_t client);
 void G_ClientWeaponThink(g_client_t *cl);
 #endif

--- a/src/game/ctf/g_types.h
+++ b/src/game/ctf/g_types.h
@@ -1039,7 +1039,7 @@ typedef struct {
 
 /**
  * @brief Parameters for a burst of giblets, as scattered by a dying corpse or a
- * `target_ballistics`.
+ * `ballistics_giblets`.
  */
 typedef struct {
 
@@ -1886,9 +1886,9 @@ struct g_entity_s {
 
   /**
    * @brief Projectile definition for `ballistics_*` and `turret_*` entities, resolved from their
-   * classname at spawn time. Opaque here; the definition is private to g_entity_target.c.
+   * classname at spawn time. Incomplete here; the definition is private to g_entity_target.c.
    */
-  const void *ballistics;
+  const struct g_ballistics_type_s *ballistics;
 
   /**
    * @brief AI navigation node for item path tracking.

--- a/src/game/ctf/g_types.h
+++ b/src/game/ctf/g_types.h
@@ -341,6 +341,7 @@ typedef enum {
   TRAIL_PLAYER_SPAWN,
   TRAIL_QUAKE_NAIL,
   TRAIL_QUAKE_GRENADE,
+  TRAIL_LASER,
 } g_entity_trail_t;
 
 /**
@@ -930,16 +931,42 @@ typedef struct {
   MOD_HOOK,
   MOD_ACT_OF_GOD,
   MOD_BOB,
-  MOD_TRAP_BLASTER,
-  MOD_TRAP_NAIL,
-  MOD_TRAP_ROCKET,
-  MOD_TRAP_GRENADE,
-  MOD_TRAP_LASER,
-  MOD_TRAP_GIBLETS,
+  MOD_BALLISTICS_BLASTER,
+  MOD_BALLISTICS_SHOTGUN,
+  MOD_BALLISTICS_SUPER_SHOTGUN,
+  MOD_BALLISTICS_MACHINEGUN,
+  MOD_BALLISTICS_GRENADE,
+  MOD_BALLISTICS_ROCKET,
+  MOD_BALLISTICS_HYPERBLASTER,
+  MOD_BALLISTICS_LIGHTNING,
+  MOD_BALLISTICS_RAILGUN,
+  MOD_BALLISTICS_BFG,
+  MOD_BALLISTICS_QUAKE_SHOTGUN,
+  MOD_BALLISTICS_QUAKE_SUPER_SHOTGUN,
+  MOD_BALLISTICS_QUAKE_NAILGUN,
+  MOD_BALLISTICS_QUAKE_SUPER_NAILGUN,
+  MOD_BALLISTICS_QUAKE_GRENADE,
+  MOD_BALLISTICS_QUAKE_ROCKET,
+  MOD_BALLISTICS_QUAKE_THUNDERBOLT,
+  MOD_BALLISTICS_LASER,
+  MOD_BALLISTICS_GIBLETS,
   MOD_TURRET_BLASTER,
-  MOD_TURRET_NAIL,
-  MOD_TURRET_ROCKET,
+  MOD_TURRET_SHOTGUN,
+  MOD_TURRET_SUPER_SHOTGUN,
+  MOD_TURRET_MACHINEGUN,
   MOD_TURRET_GRENADE,
+  MOD_TURRET_ROCKET,
+  MOD_TURRET_HYPERBLASTER,
+  MOD_TURRET_LIGHTNING,
+  MOD_TURRET_RAILGUN,
+  MOD_TURRET_BFG,
+  MOD_TURRET_QUAKE_SHOTGUN,
+  MOD_TURRET_QUAKE_SUPER_SHOTGUN,
+  MOD_TURRET_QUAKE_NAILGUN,
+  MOD_TURRET_QUAKE_SUPER_NAILGUN,
+  MOD_TURRET_QUAKE_GRENADE,
+  MOD_TURRET_QUAKE_ROCKET,
+  MOD_TURRET_QUAKE_THUNDERBOLT,
   MOD_TURRET_LASER,
   MOD_TURRET_GIBLETS,
   MOD_FRIENDLY_FIRE = 0x8000000
@@ -1637,6 +1664,12 @@ struct g_entity_s {
   uint32_t timestamp;
 
   /**
+   * @brief Time of the last muzzle flash, throttling the flash rate of rapid
+   * firing entities independently of how often they actually fire.
+   */
+  uint32_t flash_time;
+
+  /**
    * @brief Target name to fire when triggered.
    */
   const char *target;
@@ -1850,6 +1883,12 @@ struct g_entity_s {
    * @brief Item definition for bonus item entities.
    */
   const g_item_t *item;
+
+  /**
+   * @brief Projectile definition for `ballistics_*` and `turret_*` entities, resolved from their
+   * classname at spawn time. Opaque here; the definition is private to g_entity_target.c.
+   */
+  const void *ballistics;
 
   /**
    * @brief AI navigation node for item path tracking.

--- a/src/game/default/g_types.h
+++ b/src/game/default/g_types.h
@@ -1010,7 +1010,7 @@ typedef struct {
 
 /**
  * @brief Parameters for a burst of giblets, as scattered by a dying corpse or a
- * `target_ballistics`.
+ * `ballistics_giblets`.
  */
 typedef struct {
 
@@ -1819,9 +1819,9 @@ struct g_entity_s {
 
   /**
    * @brief Projectile definition for `ballistics_*` and `turret_*` entities, resolved from their
-   * classname at spawn time. Opaque here; the definition is private to g_entity_target.c.
+   * classname at spawn time. Incomplete here; the definition is private to g_entity_target.c.
    */
-  const void *ballistics;
+  const struct g_ballistics_type_s *ballistics;
 
   /**
    * @brief AI navigation node for item path tracking.

--- a/src/game/default/g_types.h
+++ b/src/game/default/g_types.h
@@ -319,6 +319,7 @@ typedef enum {
   TRAIL_PLAYER_SPAWN,
   TRAIL_QUAKE_NAIL,
   TRAIL_QUAKE_GRENADE,
+  TRAIL_LASER,
 } g_entity_trail_t;
 
 /**
@@ -901,16 +902,42 @@ typedef struct {
   MOD_FIREBALL,
   MOD_ACT_OF_GOD,
   MOD_BOB,
-  MOD_TRAP_BLASTER,
-  MOD_TRAP_NAIL,
-  MOD_TRAP_ROCKET,
-  MOD_TRAP_GRENADE,
-  MOD_TRAP_LASER,
-  MOD_TRAP_GIBLETS,
+  MOD_BALLISTICS_BLASTER,
+  MOD_BALLISTICS_SHOTGUN,
+  MOD_BALLISTICS_SUPER_SHOTGUN,
+  MOD_BALLISTICS_MACHINEGUN,
+  MOD_BALLISTICS_GRENADE,
+  MOD_BALLISTICS_ROCKET,
+  MOD_BALLISTICS_HYPERBLASTER,
+  MOD_BALLISTICS_LIGHTNING,
+  MOD_BALLISTICS_RAILGUN,
+  MOD_BALLISTICS_BFG,
+  MOD_BALLISTICS_QUAKE_SHOTGUN,
+  MOD_BALLISTICS_QUAKE_SUPER_SHOTGUN,
+  MOD_BALLISTICS_QUAKE_NAILGUN,
+  MOD_BALLISTICS_QUAKE_SUPER_NAILGUN,
+  MOD_BALLISTICS_QUAKE_GRENADE,
+  MOD_BALLISTICS_QUAKE_ROCKET,
+  MOD_BALLISTICS_QUAKE_THUNDERBOLT,
+  MOD_BALLISTICS_LASER,
+  MOD_BALLISTICS_GIBLETS,
   MOD_TURRET_BLASTER,
-  MOD_TURRET_NAIL,
-  MOD_TURRET_ROCKET,
+  MOD_TURRET_SHOTGUN,
+  MOD_TURRET_SUPER_SHOTGUN,
+  MOD_TURRET_MACHINEGUN,
   MOD_TURRET_GRENADE,
+  MOD_TURRET_ROCKET,
+  MOD_TURRET_HYPERBLASTER,
+  MOD_TURRET_LIGHTNING,
+  MOD_TURRET_RAILGUN,
+  MOD_TURRET_BFG,
+  MOD_TURRET_QUAKE_SHOTGUN,
+  MOD_TURRET_QUAKE_SUPER_SHOTGUN,
+  MOD_TURRET_QUAKE_NAILGUN,
+  MOD_TURRET_QUAKE_SUPER_NAILGUN,
+  MOD_TURRET_QUAKE_GRENADE,
+  MOD_TURRET_QUAKE_ROCKET,
+  MOD_TURRET_QUAKE_THUNDERBOLT,
   MOD_TURRET_LASER,
   MOD_TURRET_GIBLETS,
   MOD_FRIENDLY_FIRE = 0x8000000
@@ -1570,6 +1597,12 @@ struct g_entity_s {
   uint32_t timestamp;
 
   /**
+   * @brief Time of the last muzzle flash, throttling the flash rate of rapid
+   * firing entities independently of how often they actually fire.
+   */
+  uint32_t flash_time;
+
+  /**
    * @brief Target name to fire when triggered.
    */
   const char *target;
@@ -1783,6 +1816,12 @@ struct g_entity_s {
    * @brief Item definition for bonus item entities.
    */
   const g_item_t *item;
+
+  /**
+   * @brief Projectile definition for `ballistics_*` and `turret_*` entities, resolved from their
+   * classname at spawn time. Opaque here; the definition is private to g_entity_target.c.
+   */
+  const void *ballistics;
 
   /**
    * @brief AI navigation node for item path tracking.

--- a/src/game/lithium/g_types.h
+++ b/src/game/lithium/g_types.h
@@ -325,6 +325,7 @@ typedef enum {
   TRAIL_PLAYER_SPAWN,
   TRAIL_QUAKE_NAIL,
   TRAIL_QUAKE_GRENADE,
+  TRAIL_LASER,
 } g_entity_trail_t;
 
 /**
@@ -908,16 +909,42 @@ typedef struct {
   MOD_FIREBALL,
   MOD_ACT_OF_GOD,
   MOD_BOB,
-  MOD_TRAP_BLASTER,
-  MOD_TRAP_NAIL,
-  MOD_TRAP_ROCKET,
-  MOD_TRAP_GRENADE,
-  MOD_TRAP_LASER,
-  MOD_TRAP_GIBLETS,
+  MOD_BALLISTICS_BLASTER,
+  MOD_BALLISTICS_SHOTGUN,
+  MOD_BALLISTICS_SUPER_SHOTGUN,
+  MOD_BALLISTICS_MACHINEGUN,
+  MOD_BALLISTICS_GRENADE,
+  MOD_BALLISTICS_ROCKET,
+  MOD_BALLISTICS_HYPERBLASTER,
+  MOD_BALLISTICS_LIGHTNING,
+  MOD_BALLISTICS_RAILGUN,
+  MOD_BALLISTICS_BFG,
+  MOD_BALLISTICS_QUAKE_SHOTGUN,
+  MOD_BALLISTICS_QUAKE_SUPER_SHOTGUN,
+  MOD_BALLISTICS_QUAKE_NAILGUN,
+  MOD_BALLISTICS_QUAKE_SUPER_NAILGUN,
+  MOD_BALLISTICS_QUAKE_GRENADE,
+  MOD_BALLISTICS_QUAKE_ROCKET,
+  MOD_BALLISTICS_QUAKE_THUNDERBOLT,
+  MOD_BALLISTICS_LASER,
+  MOD_BALLISTICS_GIBLETS,
   MOD_TURRET_BLASTER,
-  MOD_TURRET_NAIL,
-  MOD_TURRET_ROCKET,
+  MOD_TURRET_SHOTGUN,
+  MOD_TURRET_SUPER_SHOTGUN,
+  MOD_TURRET_MACHINEGUN,
   MOD_TURRET_GRENADE,
+  MOD_TURRET_ROCKET,
+  MOD_TURRET_HYPERBLASTER,
+  MOD_TURRET_LIGHTNING,
+  MOD_TURRET_RAILGUN,
+  MOD_TURRET_BFG,
+  MOD_TURRET_QUAKE_SHOTGUN,
+  MOD_TURRET_QUAKE_SUPER_SHOTGUN,
+  MOD_TURRET_QUAKE_NAILGUN,
+  MOD_TURRET_QUAKE_SUPER_NAILGUN,
+  MOD_TURRET_QUAKE_GRENADE,
+  MOD_TURRET_QUAKE_ROCKET,
+  MOD_TURRET_QUAKE_THUNDERBOLT,
   MOD_TURRET_LASER,
   MOD_TURRET_GIBLETS,
   MOD_FRIENDLY_FIRE = 0x8000000
@@ -1592,6 +1619,12 @@ struct g_entity_s {
   uint32_t timestamp;
 
   /**
+   * @brief Time of the last muzzle flash, throttling the flash rate of rapid
+   * firing entities independently of how often they actually fire.
+   */
+  uint32_t flash_time;
+
+  /**
    * @brief Target name to fire when triggered.
    */
   const char *target;
@@ -1805,6 +1838,12 @@ struct g_entity_s {
    * @brief Item definition for bonus item entities.
    */
   const g_item_t *item;
+
+  /**
+   * @brief Projectile definition for `ballistics_*` and `turret_*` entities, resolved from their
+   * classname at spawn time. Opaque here; the definition is private to g_entity_target.c.
+   */
+  const void *ballistics;
 
   /**
    * @brief AI navigation node for item path tracking.

--- a/src/game/lithium/g_types.h
+++ b/src/game/lithium/g_types.h
@@ -1017,7 +1017,7 @@ typedef struct {
 
 /**
  * @brief Parameters for a burst of giblets, as scattered by a dying corpse or a
- * `target_ballistics`.
+ * `ballistics_giblets`.
  */
 typedef struct {
 
@@ -1841,9 +1841,9 @@ struct g_entity_s {
 
   /**
    * @brief Projectile definition for `ballistics_*` and `turret_*` entities, resolved from their
-   * classname at spawn time. Opaque here; the definition is private to g_entity_target.c.
+   * classname at spawn time. Incomplete here; the definition is private to g_entity_target.c.
    */
-  const void *ballistics;
+  const struct g_ballistics_type_s *ballistics;
 
   /**
    * @brief AI navigation node for item path tracking.


### PR DESCRIPTION
Addresses the fixups from testing in #940, and restructures how these entities pick their projectile.

## The fixups

- **Separate Quake nailgun and supernailgun**, each with its own flash and sample. They were one flag.
- **Turret muzzle flashes take the operator's colours.** `G_WorldMuzzleFlash` sent no client, so `Cg_ParseMuzzleFlash` fell back to `MAX_CLIENTS` and every colour downstream of `Cg_ClientEffectColor` came out the default hue for the weapon.
- **A real laser, and an honest railgun.** The `laser` flag fired a railgun. There is now a `railgun` that does, and a `laser` that emits a persistent beam with a colour of the mapper's choosing.
- **Muzzle flashes are throttled per projectile type.** Reported as the giblet trap repeating its squish; the same fault was far worse for a hitscan trap with `wait 0`, which the docs recommended for a continuous laser, and which fired, flashed and played its sample forty times a second.
- **Giblets given a lifetime now bleed.** The trail is assigned in `G_ClientCorpse_Think`, which those giblets never run. This affected every lifetime-bearing giblet, not just the trap's.

## The restructure

The projectile was a spawnflag. At six weapons that was tolerable; at nineteen it is nineteen mutually exclusive checkboxes that the spawn function has to police at runtime. They are now `ballistics_$weapon` and `turret_$weapon`, resolved from the classname suffix as the items already are, leaving `start_on` and `toggle` as the only flags.

Suffixes come from the `weapon_*` classnames, so `ballistics_supershotgun` sits beside `weapon_supershotgun` and `g_balance_supershotgun_damage`. Every weapon is covered but the hand grenades, plus `laser` and `giblets`, which have no weapon behind them — 38 classnames.

Both beam weapons needed different plumbing: `G_LightningProjectile` resolves its muzzle through `ent->owner->client`, which is null for a trap, so `lightning` and `quake_thunderbolt` use a new `G_BeamProjectile` instead. Six projectile helpers also had to start taking the attacker separately, or a machinegun turret would have credited every kill to itself.

Mapper documentation is in quetoo-data (jdolan/quetoo-data@c69dcc62): a base class per role in the fgd, so each classname costs one line, and flat blocks in `entities.def`.

## Not yet settled

`min_wait` and `flash_interval` are guesses per type and want tuning by ear. Also, a turret kill and a hand-held kill both report the same weapon name to the stats service, so they aggregate into one row; splitting them would be a one-line change in `G_MeansOfDeath`.

## Testing

Builds clean, each commit independently. Not yet played beyond the author's own testing of the earlier fixups; the new weapons and both beams are unexercised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)