### PR TITLE
Drain cg_lights free list in editor mode

### DIFF
--- a/src/cgame/common/cg_editor.c
+++ b/src/cgame/common/cg_editor.c
@@ -263,6 +263,8 @@ void Cg_PopulateEditorScene(const cl_frame_t *frame) {
   Cg_AddFlares();
 
   Cg_AddSprites();
+
+  Cg_AddDynamicLights();
 }
 
 /**

--- a/src/cgame/common/cg_light.c
+++ b/src/cgame/common/cg_light.c
@@ -191,11 +191,9 @@ static void Cg_AddBspLights(void) {
 }
 
 /**
- * @brief Adds all BSP and allocated dynamic lights to the current view.
+ * @brief Adds all allocated dynamic lights to the current view, draining those that have decayed.
  */
-void Cg_AddLights(void) {
-
-  Cg_AddBspLights();
+void Cg_AddDynamicLights(void) {
 
   for (ListNode *node = cg_lights.allocated->head; node; ) {
     ListNode *next = node->next;
@@ -226,6 +224,16 @@ void Cg_AddLights(void) {
 
     node = next;
   }
+}
+
+/**
+ * @brief Adds all BSP and allocated dynamic lights to the current view.
+ */
+void Cg_AddLights(void) {
+
+  Cg_AddBspLights();
+
+  Cg_AddDynamicLights();
 }
 
 /**

--- a/src/cgame/common/cg_light.h
+++ b/src/cgame/common/cg_light.h
@@ -78,6 +78,7 @@ typedef struct {
 
 float Cg_AnimateLight(float intensity, const char *style, float drift);
 void Cg_AddLight(const cg_light_t *s);
+void Cg_AddDynamicLights(void);
 void Cg_AddLights(void);
 void Cg_InitLights(void);
 void Cg_FreeLights(void);

--- a/src/cgame/common/ui/play/PlayerModelView.c
+++ b/src/cgame/common/ui/play/PlayerModelView.c
@@ -34,6 +34,9 @@ static void dealloc(Object *self) {
 
   PlayerModelView *this = (PlayerModelView *) self;
 
+  cgi.DestroyFramebuffer(this->framebuffer);
+  this->framebuffer = NULL;
+
   release(this->modelView);
   release(this->iconView);
 


### PR DESCRIPTION
## Summary
- `Cl_UpdateScene` runs `PopulateEditorScene` instead of `PopulateScene`, and the drain loop that returns decayed lights to the free list lived only inside `Cg_AddLights`, so any light added via `Cg_AddLight` (temp entities, trails, muzzle flashes) leaked its `cg_light_t` and list node for the life of an editor session. Split the drain/render loop out as `Cg_AddDynamicLights` and call it from the editor scene, without also calling `Cg_AddBspLights`: the editor already synthesizes a live `r_light_t` per `light`-classname entity straight from the editable entity list, so also adding the compiled BSP lights would double-light every static light entity.
- `PlayerModelView::dealloc` released `modelView`/`iconView` but never destroyed `this->framebuffer`. The framebuffer was only torn down in `renderDeviceWillReset`, which fires on pixel-density changes, but `r_restart`'s `Ui_Shutdown()` tears down the view hierarchy via plain `release()`/`dealloc()`, which never emits that notification. So any `PlayerModelView` live in the UI tree during `r_restart` leaked its entire framebuffer (HDR color target, depth-copy target, D32 depth target) — likely the source of the ~82 MB residue per `r_restart` recorded in the ticket.
- The third leak recorded in the ticket (`EntityBrushes` vectors in `misc_dust`/`misc_weather`) was already fixed prior to filing (2026-06-21); no action needed here.

Closes #956.

## Test plan
- [x] `make -C src` rebuilds `cgame.la` for default/ctf/lithium cleanly
- [ ] Manual: open in-game editor, trigger effects that call `Cg_AddLight` (e.g. muzzle flashes, temp entities), verify no unbounded growth of `cg_lights.allocated` over an extended editor session
- [ ] Manual: settled-state footprint over ten `r_restart`s (per the ticket's diagnostic protocol) with a `PlayerModelView` on screen, confirm the ~82 MB/restart residue is gone