### PR TITLE
Release level stat vectors on map change and shutdown

### DIFF
--- a/src/game/common/g_entity.c
+++ b/src/game/common/g_entity.c
@@ -568,6 +568,12 @@ void G_SpawnEntities(const char *name, const cm_entity_t *props, cm_entity_t *co
     }
   });
 
+  g_level.frags = release(g_level.frags);
+
+#if defined(G_CTF)
+  g_level.captures = release(g_level.captures);
+#endif
+
   gi.FreeTag(MEM_TAG_GAME_LEVEL);
 
   memset(&g_level, 0, sizeof(g_level));

--- a/src/game/common/g_main.c
+++ b/src/game/common/g_main.c
@@ -1122,6 +1122,12 @@ void G_Shutdown(void) {
 
   G_Ai_Shutdown();
 
+  g_level.frags = release(g_level.frags);
+
+#if defined(G_CTF)
+  g_level.captures = release(g_level.captures);
+#endif
+
   gi.FreeTag(MEM_TAG_GAME_LEVEL);
   gi.FreeTag(MEM_TAG_GAME);
 }


### PR DESCRIPTION
## Summary

`g_level.frags` and `g_level.captures` are Objectively `Vector`s, not tagged memory, so `gi.FreeTag(MEM_TAG_GAME_LEVEL)` never frees them. `G_PostStats` releases them when an intermission begins, but a level that changes without one (`map`, restart) reaches `G_SpawnEntities` with both still live and the `memset` of `g_level` drops the pointers. `G_Shutdown` mid-level leaks them the same way.

Both are now released before the level is reset and before shutdown. `release()` is NULL-safe, so the intermission path is unchanged.

Pre-existing and out of scope: the `add` calls at `g_combat.c:514` and `g_ctf.c:303` dereference the vectors unconditionally, so a frag landing after `G_PostStats` NULLs them during intermission would crash. Not introduced here.

Phase 0 of #963.

## Test plan

- [x] `default`, `ctf`, `lithium` game modules build with no warnings
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)