### PR TITLE
Guard the large-winding warning for node volumes

### DIFF
--- a/src/quemap/brush.c
+++ b/src/quemap/brush.c
@@ -363,7 +363,11 @@ void SplitBrush(const csg_brush_t *brush, int32_t plane, csg_brush_t **front, cs
   }
 
   if (WindingIsLarge(w)) {
-    Com_Warn("Splitting entity %d brush %d created a large winding\n", brush->original->entity, brush->original->brush);
+    if (brush->original) {
+      Com_Warn("Splitting entity %d brush %d created a large winding\n", brush->original->entity, brush->original->brush);
+    } else {
+      Com_Warn("Splitting a node volume created a large winding\n");
+    }
   }
 
   cm_winding_t *mid_winding = w;


### PR DESCRIPTION
## Summary

`BrushFromBounds` (`brush.c:149`) creates node volumes without an `original` brush, and `tree.c:242`/`:362` pass those volumes to `SplitBrush`. When such a split produced a large winding, the warning at `brush.c:366` dereferenced `brush->original` to name the entity and brush, and quemap crashed. Name the node volume instead.

The world-bounds check below is deliberately left alone: the head volume is `Box3_Expand(tree->bounds, 1.f)`, so it only exceeds `MAX_WORLD_COORD` when the map touches the world edge, which is unchanged from today.

Phase 0 of #963.

## Test plan

- [x] quemap builds with no warnings
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)