### PR TITLE
Fix stray text in quetoo_all.sln VisualStudioVersion

### DIFF
--- a/Quetoo.vs15/quetoo_all.sln
+++ b/Quetoo.vs15/quetoo_all.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 18
-VisualStudioVersion = 18.0.11205.157 d18.0
+VisualStudioVersion = 18.0.11205.157
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "quetoo", "quetoo.vcxproj", "{A05CAC53-F8F2-4A14-9C81-8A34F4EA9085}"
 	ProjectSection(ProjectDependencies) = postProject


### PR DESCRIPTION
## Summary

`quetoo_all.sln` had `VisualStudioVersion = 18.0.11205.157 d18.0`; the trailing ` d18.0` is stray text. `quetoo.sln` uses the bare form.

Phase 0 of #963.

🤖 Generated with [Claude Code](https://claude.com/claude-code)