### PR TITLE
Publish a validated hook pull speed to the client

### DIFF
--- a/src/cgame/common/cg_main.c
+++ b/src/cgame/common/cg_main.c
@@ -279,9 +279,15 @@ static void Cg_UpdateConfigString(int32_t i) {
       cg_state.items = (g_items_t) strtol(s, NULL, 10);
       return;
 #if defined(G_HOOK)
-    case CS_HOOK_PULL_SPEED:
-      cg_state.hook_pull_speed = strtof(s, NULL);
+    case CS_HOOK_PULL_SPEED: {
+      char *end;
+      cg_state.hook_pull_speed = strtof(s, &end);
+      if (end == s || *end || !isfinite(cg_state.hook_pull_speed) || cg_state.hook_pull_speed <= 0.f) {
+        Cg_Warn("Invalid hook pull speed \"%s\"\n", s);
+        cg_state.hook_pull_speed = PM_SPEED_HOOK_PULL;
+      }
       return;
+    }
 #endif
     case CS_MAX_CLIENTS:
       cg_state.max_clients = (int32_t) strtol(s, NULL, 10);

--- a/src/game/common/bg_pmove.h
+++ b/src/game/common/bg_pmove.h
@@ -82,6 +82,7 @@
 #define PM_SPEED_WATER_JUMP  420.f
 #define PM_SPEED_WATER_SINK -16.f
 #define PM_SPEED_STEP        150.f
+#define PM_SPEED_HOOK_PULL   800.f
 
 /**
  * @brief The walk modifier slows all user-controlled speeds.

--- a/src/game/common/g_hook.c
+++ b/src/game/common/g_hook.c
@@ -116,6 +116,22 @@ static void G_InitMedia_Hook(void) {
 }
 
 /**
+ * @brief Publishes the pull speed the client predicts with. The cvar's value,
+ * not its string, is what the game moves players by, so that is what goes on
+ * the wire; a string that does not parse as a positive speed is reset first.
+ */
+static void G_Hook_PublishPullSpeed(void) {
+
+  if (!isfinite(g_hook_pull_speed->value) || g_hook_pull_speed->value <= 0.f) {
+    G_Warn("Invalid g_hook_pull_speed \"%s\", resetting to %g\n", g_hook_pull_speed->string, PM_SPEED_HOOK_PULL);
+    gi.SetCvarValue("g_hook_pull_speed", PM_SPEED_HOOK_PULL);
+    g_hook_pull_speed->modified = false;
+  }
+
+  gi.SetConfigString(CS_HOOK_PULL_SPEED, va("%.9g", g_hook_pull_speed->value));
+}
+
+/**
  * @brief Resolves whether the hook is available this level, and publishes the
  * pull speed the client predicts with.
  */
@@ -123,7 +139,7 @@ static void G_ConfigureLevel_Hook(void) {
 
   G_Hook_CheckState();
 
-  gi.SetConfigString(CS_HOOK_PULL_SPEED, g_hook_pull_speed->string);
+  G_Hook_PublishPullSpeed();
 
   previous.ConfigureLevel();
 }
@@ -153,9 +169,9 @@ static bool G_CheckCvars_Hook(void) {
   if (g_hook_pull_speed->modified) {
     g_hook_pull_speed->modified = false;
 
-    gi.BroadcastPrint(PRINT_HIGH, "Hook pull speed has been changed to %g\n", g_hook_pull_speed->value);
+    G_Hook_PublishPullSpeed();
 
-    gi.SetConfigString(CS_HOOK_PULL_SPEED, g_hook_pull_speed->string);
+    gi.BroadcastPrint(PRINT_HIGH, "Hook pull speed has been changed to %g\n", g_hook_pull_speed->value);
   }
 
   if (g_hook_style->modified) {
@@ -211,7 +227,7 @@ void G_Hook_Init(void) {
   g_hook_style = gi.AddCvar("g_hook_style", "default", 0, "Whether to allow only \"pull\", \"swing_manual\", \"swing_auto\" or any (\"default\") hook swing style.");
   g_hook_auto_refire = gi.AddCvar("g_hook_auto_refire", "0", 0, "If the hook automatically refires when it hits a non-solid surface, like players or weapon clips. (Currently non-functional)");
   g_hook_distance = gi.AddCvar("g_hook_distance", va("%.1f", PM_HOOK_DEF_DIST), 0, "The maximum distance the hook will travel.");
-  g_hook_pull_speed = gi.AddCvar("g_hook_pull_speed", "800", 0, "The speed that you get pulled towards the hook.");
+  g_hook_pull_speed = gi.AddCvar("g_hook_pull_speed", va("%g", PM_SPEED_HOOK_PULL), 0, "The speed that you get pulled towards the hook.");
   g_hook_refire = gi.AddCvar("g_hook_refire", "0.25", 0, "The refire delay on the grapple hook in seconds.");
   g_hook_sky = gi.AddCvar("g_hook_sky", "0", CVAR_SERVER_INFO, "If enabled, the grapple hook attaches to sky surfaces rather than detaching.");
   g_hook_speed = gi.AddCvar("g_hook_speed", "1200", 0, "The speed that the hook will fly at.");


### PR DESCRIPTION
## Summary

The game moves hooked players by `g_hook_pull_speed->value`, but published the cvar's raw *string* on `CS_HOOK_PULL_SPEED`, and the client parsed it with an unchecked `strtof(s, NULL)` into the speed prediction uses (`cg_predict.c:81`). `set g_hook_pull_speed abc` left the server pulling at 0 while the client predicted something else, with no warning on either side.

- `G_Hook_PublishPullSpeed` resets a non-positive (or NaN) value to the default, clears `modified` so the reset is not announced as an admin change, and publishes `%.9g` of the value the game actually uses, from both `ConfigureLevel` and `CheckCvars`.
- The client parses with an end pointer and falls back to the same default with a `Cg_Warn` on garbage.
- The default is `PM_SPEED_HOOK_PULL` in `bg_pmove.h`, beside the other movement cvar defaults, so both sides share it.

Phase 0 of #963.

## Test plan

- [x] `default`, `ctf`, `lithium` game and cgame modules build with no warnings
- [x] `quetoo-dedicated +game lithium +set g_hook_pull_speed abc +map edge`: exactly one `Invalid g_hook_pull_speed "abc", resetting to 800`, no spurious "changed" broadcast, 85 entities
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)