### PR TITLE
Strip color escapes from the Discord map title

### DIFF
--- a/src/cgame/common/cg_discord.c
+++ b/src/cgame/common/cg_discord.c
@@ -199,7 +199,10 @@ void Cg_UpdateDiscord(void) {
         presence.largeImageKey = "default";
         presence.state = "Playing";
 
-        q_snprintf(details, sizeof(details), "%s - %s", Cg_GetGameMode(), cgi.ConfigString(CS_MESSAGE));
+        char message[MAX_STRING_CHARS];
+        q_strcolorstrip(cgi.ConfigString(CS_MESSAGE), message);
+
+        q_snprintf(details, sizeof(details), "%s - %s", Cg_GetGameMode(), message);
         presence.details = details;
 
         if (q_strcmp(cgi.server_name, "localhost")) {


### PR DESCRIPTION
## Summary

Worldspawn `message` strings carry `^N` colour escapes — 12 shipped maps do, e.g. `"^1D^7evolver - by ^3TRaK"` — and `Cg_UpdateDiscord` passed `CS_MESSAGE` straight into the rich-presence `details`, so Discord showed the raw codes. Strip them with `q_strcolorstrip` first.

Phase 0 of #963.

## Test plan

- [x] cgame modules build with no warnings
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)