### PR TITLE
Assemble scoreboard chunks off the live board and fix their count

### DIFF
--- a/src/cgame/common/cg_main.c
+++ b/src/cgame/common/cg_main.c
@@ -405,6 +405,8 @@ static void Cg_ClearState(void) {
 
   Cg_ClearHud();
 
+  Cg_ClearScores();
+
   Cg_ClearUi();
 }
 

--- a/src/cgame/common/cg_score.c
+++ b/src/cgame/common/cg_score.c
@@ -28,6 +28,9 @@
 typedef struct {
   g_score_t scores[MAX_CLIENTS + MAX_TEAMS];
   size_t num_scores;
+
+  g_score_t pending[MAX_CLIENTS + MAX_TEAMS];
+  size_t num_pending;
 } cg_score_state_t;
 
 static cg_score_state_t cg_score_state;
@@ -61,22 +64,39 @@ void Cg_ParseScores(void) {
   }
 
   if (index == 0) {
-    memset(&cg_score_state, 0, sizeof(cg_score_state));
+    cg_score_state.num_pending = 0;
+  } else if ((size_t) index != cg_score_state.num_pending) {
+    Cg_Warn("Score packet %d arrived with %zu pending\n", index, cg_score_state.num_pending);
+    cg_score_state.num_pending = 0;
+    return;
   }
 
-  cgi.ReadData(cg_score_state.scores + index, count * sizeof(g_score_t));
+  cgi.ReadData(cg_score_state.pending + index, count * sizeof(g_score_t));
+  cg_score_state.num_pending = index + count;
 
   if (cgi.ReadByte()) { // last packet in sequence
 
-    cg_score_state.num_scores = index + count;
+    cg_score_state.num_scores = cg_score_state.num_pending;
+    cg_score_state.num_pending = 0;
 
     // the aggregate scores are the last set in the array
     if (cg_state.num_teams) {
       cg_score_state.num_scores -= MAX_TEAMS;
     }
-  }
 
-  qsort(cg_score_state.scores, cg_score_state.num_scores, sizeof(g_score_t), Cg_ParseScores_Compare);
+    memcpy(cg_score_state.scores, cg_score_state.pending, sizeof(cg_score_state.scores));
+
+    qsort(cg_score_state.scores, cg_score_state.num_scores, sizeof(g_score_t), Cg_ParseScores_Compare);
+  }
+}
+
+/**
+ * @brief Discards the scores, so that a board from the previous server is not
+ * drawn on the next.
+ */
+void Cg_ClearScores(void) {
+
+  memset(&cg_score_state, 0, sizeof(cg_score_state));
 }
 
 /**

--- a/src/cgame/common/cg_score.h
+++ b/src/cgame/common/cg_score.h
@@ -25,5 +25,6 @@
 
 #if defined(__CG_LOCAL_H__)
 void Cg_ParseScores(void);
+void Cg_ClearScores(void);
 void Cg_DrawScores(const player_state_t *ps);
 #endif

--- a/src/game/common/g_client_stats.c
+++ b/src/game/common/g_client_stats.c
@@ -155,7 +155,7 @@ void G_ClientScores(g_client_t *cl) {
     if (len > 512) {
       gi.WriteByte(SV_CMD_SCORES);
       gi.WriteShort((int32_t) j);
-      gi.WriteShort((int32_t) i);
+      gi.WriteShort((int32_t) (i - j));
       gi.WriteData((const void *) (scores + j), len);
       gi.WriteByte(0); // sequence is incomplete
       gi.Unicast(cl, true);
@@ -169,7 +169,7 @@ void G_ClientScores(g_client_t *cl) {
 
   gi.WriteByte(SV_CMD_SCORES);
   gi.WriteShort((int32_t) j);
-  gi.WriteShort((int32_t) i);
+  gi.WriteShort((int32_t) (i - j));
   gi.WriteData((const void *) (scores + j), len);
   gi.WriteByte(1); // sequence is complete
   gi.Unicast(cl, true);


### PR DESCRIPTION
## Summary

Two problems in scoreboard transfer, one of them a wire mismatch:

- `G_ClientScores` wrote `WriteShort(j); WriteShort(i)` — the chunk's **start and end index** — while `Cg_ParseScores` read the second short as a **count**. They coincide only for the first chunk (`j == 0`), so any board large enough to need a second chunk (~32+ rows at ~16 bytes each) read past the chunk's data and mis-assembled. The server now sends `i - j`.
- The client `memset` the live board on the first chunk, copied each chunk straight into it, and `qsort`ed after every chunk with the *previous* sequence's `num_scores`; nothing cleared the board between servers. Chunks now assemble into a `pending` buffer; the board is published and sorted once when the sequence completes; a chunk that breaks contiguity drops the sequence (index 0 always starts a fresh one); `Cg_ClearScores` runs from `Cg_ClearState`.

`num_scores -= MAX_TEAMS` for team aggregates is unchanged.

Phase 0 of #963.

## Test plan

- [x] all game and cgame modules build with no warnings
- [x] reviewed chunk arithmetic: `len == count * sizeof(g_score_t)` on every chunk including the final one
- [ ] CI
- [ ] A >32-player board needs a real client to observe; the arithmetic is verified by inspection

🤖 Generated with [Claude Code](https://claude.com/claude-code)