### PR TITLE
Compile the game modules with -ffp-contract=off

### DIFF
--- a/Quetoo.vs15/cgame-ctf.vcxproj
+++ b/Quetoo.vs15/cgame-ctf.vcxproj
@@ -73,6 +73,7 @@
            $(ExtraPreprocessorDefinitions), which expands empty by the time
            build_settings.props' item definition is evaluated. -->
       <PreprocessorDefinitions>G_CTF;G_HOOK;G_TECH;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalOptions>%(AdditionalOptions) -ffp-contract=off</AdditionalOptions>
     </ClCompile>
     <Link>
       <AdditionalDependencies>Objectively.lib;ObjectivelyMVC.lib;SDL3.lib;SDL3_image.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/Quetoo.vs15/cgame-lithium.vcxproj
+++ b/Quetoo.vs15/cgame-lithium.vcxproj
@@ -72,6 +72,7 @@
            $(ExtraPreprocessorDefinitions), which expands empty by the time
            build_settings.props' item definition is evaluated. -->
       <PreprocessorDefinitions>G_HOOK;G_TECH;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalOptions>%(AdditionalOptions) -ffp-contract=off</AdditionalOptions>
     </ClCompile>
     <Link>
       <AdditionalDependencies>Objectively.lib;ObjectivelyMVC.lib;SDL3.lib;SDL3_image.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/Quetoo.vs15/cgame.vcxproj
+++ b/Quetoo.vs15/cgame.vcxproj
@@ -59,6 +59,7 @@
            every module has a cg_local.h and a g_types.h: one global list
            would make them ambiguous. -->
       <AdditionalIncludeDirectories>..\src\cgame\default;..\src\cgame\common;..\src\cgame\common\ui;..\src\cgame\common\ui\controls;..\src\cgame\common\ui\credits;..\src\cgame\common\ui\editor;..\src\cgame\common\ui\home;..\src\cgame\common\ui\main;..\src\cgame\common\ui\play;..\src\cgame\common\ui\settings;..\src\cgame\common\ui\teams;..\src\cgame;..\src\game\default;..\src\game\common;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalOptions>%(AdditionalOptions) -ffp-contract=off</AdditionalOptions>
     </ClCompile>
     <Link>
       <AdditionalDependencies>Objectively.lib;ObjectivelyMVC.lib;SDL3.lib;SDL3_image.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/Quetoo.vs15/game-ctf.vcxproj
+++ b/Quetoo.vs15/game-ctf.vcxproj
@@ -73,7 +73,7 @@
       <!-- g_client_s and g_entity_s embed the server's view of themselves as an
            anonymous member, which needs this. clang-cl enables it by default; it
            is spelled out so that a toolset change cannot take it away quietly. -->
-      <AdditionalOptions>%(AdditionalOptions) -fms-extensions -Wno-microsoft-anon-tag</AdditionalOptions>
+      <AdditionalOptions>%(AdditionalOptions) -fms-extensions -Wno-microsoft-anon-tag -ffp-contract=off</AdditionalOptions>
       <!-- These switch the optional features on in the common sources. Set
            here rather than through
            $(ExtraPreprocessorDefinitions), which expands empty by the time

--- a/Quetoo.vs15/game-lithium.vcxproj
+++ b/Quetoo.vs15/game-lithium.vcxproj
@@ -72,7 +72,7 @@
       <!-- g_client_s and g_entity_s embed the server's view of themselves as an
            anonymous member, which needs this. clang-cl enables it by default; it
            is spelled out so that a toolset change cannot take it away quietly. -->
-      <AdditionalOptions>%(AdditionalOptions) -fms-extensions -Wno-microsoft-anon-tag</AdditionalOptions>
+      <AdditionalOptions>%(AdditionalOptions) -fms-extensions -Wno-microsoft-anon-tag -ffp-contract=off</AdditionalOptions>
       <!-- These switch the optional features on in the common sources. Set
            here rather than through
            $(ExtraPreprocessorDefinitions), which expands empty by the time

--- a/Quetoo.vs15/game.vcxproj
+++ b/Quetoo.vs15/game.vcxproj
@@ -63,7 +63,7 @@
       <!-- g_client_s and g_entity_s embed the server's view of themselves as an
            anonymous member, which needs this. clang-cl enables it by default; it
            is spelled out so that a toolset change cannot take it away quietly. -->
-      <AdditionalOptions>%(AdditionalOptions) -fms-extensions -Wno-microsoft-anon-tag</AdditionalOptions>
+      <AdditionalOptions>%(AdditionalOptions) -fms-extensions -Wno-microsoft-anon-tag -ffp-contract=off</AdditionalOptions>
     </ClCompile>
     <Link>
       <AdditionalDependencies>Objectively.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/Quetoo.xcodeproj/project.pbxproj
+++ b/Quetoo.xcodeproj/project.pbxproj
@@ -6353,6 +6353,7 @@
 				MACH_O_TYPE = mh_bundle;
 				OTHER_CFLAGS = (
 					"$(inherited)",
+					"-ffp-contract=off",
 					"-fms-extensions",
 					"-Wno-microsoft-anon-tag",
 				);
@@ -6381,6 +6382,7 @@
 				MACH_O_TYPE = mh_bundle;
 				OTHER_CFLAGS = (
 					"$(inherited)",
+					"-ffp-contract=off",
 					"-fms-extensions",
 					"-Wno-microsoft-anon-tag",
 				);
@@ -6407,6 +6409,10 @@
 				);
 				LIBRARY_SEARCH_PATHS = "$(HOMEBREW_PREFIX)/lib";
 				MACH_O_TYPE = mh_bundle;
+				OTHER_CFLAGS = (
+					"$(inherited)",
+					"-ffp-contract=off",
+				);
 				OTHER_LDFLAGS = "-all_load";
 				PRODUCT_NAME = "cgame-lithium";
 				USER_HEADER_SEARCH_PATHS = (
@@ -6443,6 +6449,10 @@
 				);
 				LIBRARY_SEARCH_PATHS = "$(HOMEBREW_PREFIX)/lib";
 				MACH_O_TYPE = mh_bundle;
+				OTHER_CFLAGS = (
+					"$(inherited)",
+					"-ffp-contract=off",
+				);
 				OTHER_LDFLAGS = "-all_load";
 				PRODUCT_NAME = "cgame-lithium";
 				USER_HEADER_SEARCH_PATHS = (
@@ -6607,6 +6617,7 @@
 				MACH_O_TYPE = mh_bundle;
 				OTHER_CFLAGS = (
 					"$(inherited)",
+					"-ffp-contract=off",
 					"-fms-extensions",
 					"-Wno-microsoft-anon-tag",
 				);
@@ -6630,6 +6641,7 @@
 				MACH_O_TYPE = mh_bundle;
 				OTHER_CFLAGS = (
 					"$(inherited)",
+					"-ffp-contract=off",
 					"-fms-extensions",
 					"-Wno-microsoft-anon-tag",
 				);
@@ -6651,6 +6663,10 @@
 				EXECUTABLE_EXTENSION = so;
 				LIBRARY_SEARCH_PATHS = "$(HOMEBREW_PREFIX)/lib";
 				MACH_O_TYPE = mh_bundle;
+				OTHER_CFLAGS = (
+					"$(inherited)",
+					"-ffp-contract=off",
+				);
 				OTHER_LDFLAGS = "-all_load";
 				PRODUCT_NAME = "cgame-default";
 				USER_HEADER_SEARCH_PATHS = (
@@ -6682,6 +6698,10 @@
 				EXECUTABLE_EXTENSION = so;
 				LIBRARY_SEARCH_PATHS = "$(HOMEBREW_PREFIX)/lib";
 				MACH_O_TYPE = mh_bundle;
+				OTHER_CFLAGS = (
+					"$(inherited)",
+					"-ffp-contract=off",
+				);
 				OTHER_LDFLAGS = "-all_load";
 				PRODUCT_NAME = "cgame-default";
 				USER_HEADER_SEARCH_PATHS = (
@@ -7351,6 +7371,7 @@
 				MACH_O_TYPE = mh_bundle;
 				OTHER_CFLAGS = (
 					"$(inherited)",
+					"-ffp-contract=off",
 					"-fms-extensions",
 					"-Wno-microsoft-anon-tag",
 				);
@@ -7380,6 +7401,7 @@
 				MACH_O_TYPE = mh_bundle;
 				OTHER_CFLAGS = (
 					"$(inherited)",
+					"-ffp-contract=off",
 					"-fms-extensions",
 					"-Wno-microsoft-anon-tag",
 				);
@@ -7407,6 +7429,10 @@
 				);
 				LIBRARY_SEARCH_PATHS = "$(HOMEBREW_PREFIX)/lib";
 				MACH_O_TYPE = mh_bundle;
+				OTHER_CFLAGS = (
+					"$(inherited)",
+					"-ffp-contract=off",
+				);
 				OTHER_LDFLAGS = "-all_load";
 				PRODUCT_NAME = "cgame-ctf";
 				USER_HEADER_SEARCH_PATHS = (
@@ -7444,6 +7470,10 @@
 				);
 				LIBRARY_SEARCH_PATHS = "$(HOMEBREW_PREFIX)/lib";
 				MACH_O_TYPE = mh_bundle;
+				OTHER_CFLAGS = (
+					"$(inherited)",
+					"-ffp-contract=off",
+				);
 				OTHER_LDFLAGS = "-all_load";
 				PRODUCT_NAME = "cgame-ctf";
 				USER_HEADER_SEARCH_PATHS = (

--- a/src/cgame/ctf/Makefile.am
+++ b/src/cgame/ctf/Makefile.am
@@ -25,6 +25,7 @@ AM_CPPFLAGS = \
 	-I$(GAME_COMMON_DIR)
 
 AM_CFLAGS = \
+	-ffp-contract=off \
 	@SO_CFLAGS@ \
 	@BASE_CFLAGS@ \
 	@OBJECTIVELY_CFLAGS@ \

--- a/src/cgame/default/Makefile.am
+++ b/src/cgame/default/Makefile.am
@@ -22,6 +22,7 @@ AM_CPPFLAGS = \
 	-I$(GAME_COMMON_DIR)
 
 AM_CFLAGS = \
+	-ffp-contract=off \
 	@SO_CFLAGS@ \
 	@BASE_CFLAGS@ \
 	@OBJECTIVELY_CFLAGS@ \

--- a/src/cgame/lithium/Makefile.am
+++ b/src/cgame/lithium/Makefile.am
@@ -24,6 +24,7 @@ AM_CPPFLAGS = \
 	-I$(GAME_COMMON_DIR)
 
 AM_CFLAGS = \
+	-ffp-contract=off \
 	@SO_CFLAGS@ \
 	@BASE_CFLAGS@ \
 	@OBJECTIVELY_CFLAGS@ \

--- a/src/game/ctf/Makefile.am
+++ b/src/game/ctf/Makefile.am
@@ -10,6 +10,7 @@ AM_CPPFLAGS = \
 	-I$(GAME_COMMON_DIR)
 
 AM_CFLAGS = \
+	-ffp-contract=off \
 	-fms-extensions \
 	-Wno-microsoft-anon-tag \
 	@SO_CFLAGS@ \

--- a/src/game/default/Makefile.am
+++ b/src/game/default/Makefile.am
@@ -7,6 +7,7 @@ AM_CPPFLAGS = \
 	-I$(GAME_COMMON_DIR)
 
 AM_CFLAGS = \
+	-ffp-contract=off \
 	-fms-extensions \
 	-Wno-microsoft-anon-tag \
 	@SO_CFLAGS@ \

--- a/src/game/lithium/Makefile.am
+++ b/src/game/lithium/Makefile.am
@@ -9,6 +9,7 @@ AM_CPPFLAGS = \
 	-I$(GAME_COMMON_DIR)
 
 AM_CFLAGS = \
+	-ffp-contract=off \
 	-fms-extensions \
 	-Wno-microsoft-anon-tag \
 	@SO_CFLAGS@ \


### PR DESCRIPTION
## Summary

`bg_pmove.c` is compiled into each mod's game module and again into its cgame module, and prediction replays the server's movement and compares. FMA contraction is decided per translation unit and per target, so the two copies can round differently for no reason in the code. Turn it off on every game and cgame module target in autotools, MSVS (ClangCL accepts the bare flag via `AdditionalOptions`, as it already does `-fms-extensions`) and Xcode (`$(inherited)` kept). The engine is untouched.

Phase 0 of #963.

## Test plan

- [x] autotools: flag present on `bg_pmove.c` compile lines for game and cgame; all six modules build with no warnings
- [x] `verify_projects.py`: 6 module(s) agree
- [x] Xcode: scripted check that all six module targets carry the flag in Debug and Release and `check_mem` does not
- [ ] CI (Windows job exercises the MSVS change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)