### PR TITLE
Let the game decide which entities a trace clips

### DIFF
--- a/doc/game-module-hooks.md
+++ b/doc/game-module-hooks.md
@@ -270,6 +270,7 @@ have produced a module that did not compile.
 | `InitMedia` | `g_entity.c` | ctf, techs, hook |
 | `ConfigureLevel` | `g_entity.c` | techs, hook |
 | `PrepareMove` | `g_client.c` | hook |
+| `ClipEntity` | `g_client.c` | — |
 
 The tail of each chain lives beside the code that calls it, never in a catch-all:
 `g_module.c` was deleted once its last default moved out, because a file that

--- a/src/cgame/cgame.h
+++ b/src/cgame/cgame.h
@@ -36,7 +36,7 @@
 #include <Objectively/RESTClient.h>
 #include <Objectively/Vector.h>
 
-#define CGAME_API_VERSION 35
+#define CGAME_API_VERSION 36
 
 /**
  * @brief The client game import struct imports engine functionailty to the client game.
@@ -1104,6 +1104,13 @@ typedef struct cg_export_s {
    */
   void (*UpdateDiscord)(void);
 
+  /**
+   * @brief Called by `Cl_Trace` for each solid entity a trace could clip, after
+   * the client's own skip rules. The reciprocal of the game's `ClipEntity`, so
+   * that prediction clips exactly what the server does.
+   * @param mover The entity the trace is on behalf of, or `NULL`.
+   */
+  bool (*ClipEntity)(const cl_entity_t *mover, const cl_entity_t *ent, const vec3_t start, const vec3_t end, const box3_t bounds);
 } cg_export_t;
 
 #endif

--- a/src/cgame/common/cg_main.c
+++ b/src/cgame/common/cg_main.c
@@ -534,6 +534,7 @@ cg_export_t *Cg_LoadCgame(cg_import_t *import) {
   cge.UpdateScreen = Cg_UpdateScreen;
   cge.UpdateInstaller = Cg_UpdateInstaller;
   cge.UpdateDiscord = Cg_UpdateDiscord;
+  cge.ClipEntity = Cg_ExportClipEntity;
 
   return &cge;
 }

--- a/src/cgame/common/cg_module.h
+++ b/src/cgame/common/cg_module.h
@@ -145,5 +145,23 @@ extern ListGameplayModes Cg_ListGameplayModes;
 
 /**
  * @}
+ * @defgroup cg-hooks-movement Movement
+ * @brief How the client predicts movement. Tails in cg_predict.c.
+ * @{
+ */
+
+/**
+ * @brief Decides whether `ent` clips a trace made on behalf of `mover`, after the
+ * client has applied its own skip rules. The default clips everything.
+ * @details Chainable, and the reciprocal of the game's `ClipEntity`: a feature
+ * installs the same rule on both sides, or prediction disagrees with the server.
+ * An implementation MUST be pure.
+ */
+typedef bool (*ClipEntity)(const cl_entity_t *mover, const cl_entity_t *ent, const vec3_t start, const vec3_t end, const box3_t bounds);
+
+extern ClipEntity Cg_ClipEntity;
+
+/**
+ * @}
  */
 #endif

--- a/src/cgame/common/cg_predict.c
+++ b/src/cgame/common/cg_predict.c
@@ -62,6 +62,24 @@ static cm_trace_t Cg_PredictMovement_Trace(const vec3_t start, const vec3_t end,
 }
 
 /**
+ * @brief The tail of the `Cg_ClipEntity` chain: every entity clips.
+ */
+static bool Cg_ClipEntity_Common(const cl_entity_t *mover, const cl_entity_t *ent, const vec3_t start, const vec3_t end, const box3_t bounds) {
+  return true;
+}
+
+ClipEntity Cg_ClipEntity = Cg_ClipEntity_Common;
+
+/**
+ * @brief The `ClipEntity` export. The client holds this rather than the chain
+ * head, so that the chain a module installs from `Cg_Module_Init` is the one
+ * that gets called.
+ */
+bool Cg_ExportClipEntity(const cl_entity_t *mover, const cl_entity_t *ent, const vec3_t start, const vec3_t end, const box3_t bounds) {
+  return Cg_ClipEntity(mover, ent, start, end, bounds);
+}
+
+/**
  * @brief Run recent movement commands through the player movement code locally, storing the
  * resulting state so that it may be interpolated to and reconciled later.
  */

--- a/src/cgame/common/cg_predict.h
+++ b/src/cgame/common/cg_predict.h
@@ -26,4 +26,5 @@
 #if defined(__CG_LOCAL_H__)
 bool Cg_UsePrediction(void);
 void Cg_PredictMovement(const Vector *cmds);
+bool Cg_ExportClipEntity(const cl_entity_t *mover, const cl_entity_t *ent, const vec3_t start, const vec3_t end, const box3_t bounds);
 #endif

--- a/src/client/cl_predict.c
+++ b/src/client/cl_predict.c
@@ -165,6 +165,10 @@ static void Cl_ClipTraceToEntities(cl_trace_t *trace) {
       continue;
     }
 
+    if (cls.cgame && !cls.cgame->ClipEntity(trace->skip, ent, trace->start, trace->end, trace->bounds)) {
+      continue;
+    }
+
     const int32_t head_node = Cl_HullForEntity(s);
 
     cm_trace_t tr;

--- a/src/game/common/g_client.c
+++ b/src/game/common/g_client.c
@@ -1828,6 +1828,24 @@ static void G_PrepareMove_Common(g_client_t *cl, pm_move_t *pm) {
 PrepareMove G_PrepareMove = G_PrepareMove_Common;
 
 /**
+ * @brief The tail of the `G_ClipEntity` chain: every entity clips.
+ */
+static bool G_ClipEntity_Common(const g_entity_t *mover, const g_entity_t *ent, const vec3_t start, const vec3_t end, const box3_t bounds) {
+  return true;
+}
+
+ClipEntity G_ClipEntity = G_ClipEntity_Common;
+
+/**
+ * @brief The `ClipEntity` export. The server holds this rather than the chain
+ * head, so that the chain a module installs from `G_Module_Init` is the one
+ * that gets called.
+ */
+bool G_ExportClipEntity(const g_entity_t *mover, const g_entity_t *ent, const vec3_t start, const vec3_t end, const box3_t bounds) {
+  return G_ClipEntity(mover, ent, start, end, bounds);
+}
+
+/**
  * @brief Process the movement command, call `Pm_Move` and act on the result.
  */
 static void G_ClientMove(g_client_t *cl, pm_cmd_t *cmd) {

--- a/src/game/common/g_client.h
+++ b/src/game/common/g_client.h
@@ -31,5 +31,6 @@ void G_ClientDisconnect(g_client_t *cl);
 void G_ClientRespawn(g_client_t *cl, bool voluntary);
 void G_ClientThink(g_client_t *cl, pm_cmd_t *cmd);
 void G_ClientUserInfoChanged(g_client_t *cl, const char *user_info);
+bool G_ExportClipEntity(const g_entity_t *mover, const g_entity_t *ent, const vec3_t start, const vec3_t end, const box3_t bounds);
 void G_Giblets(const g_giblets_t *giblets);
 #endif

--- a/src/game/common/g_main.c
+++ b/src/game/common/g_main.c
@@ -1192,6 +1192,7 @@ g_export_t *G_LoadGame(g_import_t *import) {
   ge.Frame = G_Frame;
 
   ge.GameName = G_GameName;
+  ge.ClipEntity = G_ExportClipEntity;
 
   return &ge;
 }

--- a/src/game/common/g_module.h
+++ b/src/game/common/g_module.h
@@ -231,6 +231,20 @@ typedef void (*PrepareMove)(g_client_t *cl, pm_move_t *pm);
 extern PrepareMove G_PrepareMove;
 
 /**
+ * @brief Decides whether `ent` clips a trace made on behalf of `mover`, after the
+ * server has applied its own skip rules. The default clips everything.
+ * @details Chainable. A feature that makes an entity solid to some movers and not
+ * others, such as a one-way wall, returns false for the movers it lets through
+ * and defers to previous otherwise. `mover` is `NULL` for a trace with no
+ * entity behind it. An implementation MUST be pure: the server and the client
+ * both call it, from `Sv_Trace` and `Cl_Trace`, and speculative traces such as
+ * the bots' lookahead run it many times for a move that never happens.
+ */
+typedef bool (*ClipEntity)(const g_entity_t *mover, const g_entity_t *ent, const vec3_t start, const vec3_t end, const box3_t bounds);
+
+extern ClipEntity G_ClipEntity;
+
+/**
  * @}
  * @defgroup hooks-rules Rules
  * @brief The rules a module enforces, once per frame or once per level. Tails in

--- a/src/game/game.h
+++ b/src/game/game.h
@@ -25,7 +25,7 @@
 #include "collision/cm_types.h"
 #include <Objectively/Vector.h>
 
-#define GAME_API_VERSION 33
+#define GAME_API_VERSION 34
 
 /**
  * @brief Server flags for `g_entity_t`.
@@ -780,4 +780,13 @@ typedef struct g_export_s {
    * @brief Returns the game name advertised to server browsers.
    */
   const char *(*GameName)(void);
+
+  /**
+   * @brief Called by `Sv_Trace` for each solid entity a trace could clip, after
+   * the server's own skip rules, and by `Sv_Clip` for the entity it tests.
+   * Returning false leaves `ent` out of the trace, which is how a module makes
+   * an entity solid to some movers and not others.
+   * @param mover The entity the trace is on behalf of, or `NULL`.
+   */
+  bool (*ClipEntity)(const g_entity_t *mover, const g_entity_t *ent, const vec3_t start, const vec3_t end, const box3_t bounds);
 } g_export_t;

--- a/src/server/sv_world.c
+++ b/src/server/sv_world.c
@@ -471,6 +471,10 @@ static void Sv_ClipTraceToEntity(sv_trace_t *trace, const g_entity_t *ent) {
     }
   }
 
+  if (!svs.game->ClipEntity(trace->skip, ent, trace->start, trace->end, trace->bounds)) {
+    return;
+  }
+
   const int32_t head_node = Sv_HullForEntity(ent);
   if (head_node == -1) {
     return;


### PR DESCRIPTION
## Summary

Decision D3 on #963. One-way walls and checkpoint gates are solid depending on who is moving and on that mover's run state. `Sv_ClipTraceToEntity` and `Cl_ClipTraceToEntities` had no per-entity predicate, so the Race fork re-implemented entity tracing inside both modules.

- `g_export_t.ClipEntity(mover, ent, start, end, bounds)` consulted by `Sv_Trace`/`Sv_Clip` after the server's skip rules; `cg_export_t.ClipEntity` over `cl_entity_t` consulted by `Cl_Trace`. `GAME_API_VERSION` 34, `CGAME_API_VERSION` 36.
- Each export is backed by a chainable hook per `game-module-hooks.md`: `G_ClipEntity` (tail in `g_client.c`, Movement group) and `Cg_ClipEntity` (tail in `cg_predict.c`), both returning true. The export is a wrapper that reads the chain head at call time, because `G_LoadGame` fills `ge` before `G_Module_Init` installs anything.
- The hook docblocks require purity: both sides call it, and bot lookahead traces moves that never happen. This is what lets Seam B (`TraceMovement`) be withdrawn and one-way latching move to `ClientDidMove`.

## Test plan

- [x] full tree builds; game and cgame modules with no warnings
- [x] `quetoo-dedicated` with the new binary and each branch `game.so`: `edge` spawns 80 / 85 / 85 for default / ctf / lithium, bots join
- [ ] CI (Windows job covers MSVS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)