### PR TITLE
Let ModifyDamage see the whole attack and veto it

### DIFF
--- a/src/game/common/g_combat.c
+++ b/src/game/common/g_combat.c
@@ -299,16 +299,18 @@ static int32_t G_CheckArmor(g_entity_t *ent, const vec3_t pos, const vec3_t norm
 
 /**
  * @brief The tail of the `G_ModifyDamage` chain, applying the quad damage
- * powerup. Features holding their own modifiers install over the top.
+ * powerup. Never vetoes. Features holding their own modifiers install over the top.
  */
-static void G_ModifyDamage_Common(g_entity_t *target, g_entity_t *attacker, int32_t *damage, int32_t *knockback) {
+static bool G_ModifyDamage_Common(const g_damage_t *dmg, int32_t *damage, int32_t *knockback) {
 
-  if (attacker->client) {
-    if (attacker->client->inventory[POWERUP_QUAD]) {
+  if (dmg->attacker->client) {
+    if (dmg->attacker->client->inventory[POWERUP_QUAD]) {
       *damage *= QUAD_DAMAGE_FACTOR;
       *knockback *= QUAD_KNOCKBACK_FACTOR;
     }
   }
+
+  return true;
 }
 
 ModifyDamage G_ModifyDamage = G_ModifyDamage_Common;
@@ -367,6 +369,14 @@ void G_Damage(const g_damage_t *dmg) {
     }
   }
 
+  g_damage_t resolved = *dmg;
+  resolved.inflictor = inflictor;
+  resolved.attacker = attacker;
+
+  if (!G_ModifyDamage(&resolved, &damage, &knockback)) {
+    return;
+  }
+
   if (target->client && !(dflags & DMG_NO_GOD)) { // invulnerability
     if (target->client->inventory[POWERUP_INVULNERABILITY]) {
       G_MulticastSound(&(const g_play_sound_t) {
@@ -377,8 +387,6 @@ void G_Damage(const g_damage_t *dmg) {
       // knockback is intentionally preserved so rocket jumping still works
     }
   }
-
-  G_ModifyDamage(target, attacker, &damage, &knockback);
 
   // friendly fire avoidance
   if (target != attacker && g_level.teams) {

--- a/src/game/common/g_module.h
+++ b/src/game/common/g_module.h
@@ -201,14 +201,25 @@ extern TossInventory G_TossInventory;
  */
 
 /**
- * @brief Scales the damage and the knockback an attack is about to impart,
- * before friendly fire and self damage are resolved.
+ * @brief Scales the damage and the knockback an attack is about to impart, or
+ * vetoes the attack outright. Runs once the target is known to take damage and
+ * is not under respawn protection, before invulnerability, friendly fire and
+ * self damage are resolved, so that a veto precedes every side effect of being
+ * hit. Respawn protection runs first because it has no side effects of its own,
+ * and a hook that ran ahead of it would fire its own for a hit that never lands.
  * @details The quad damage powerup is the default. A feature carrying its own
  * modifiers, such as the resist and strength techs, installs over the top;
  * because the modifiers multiply, where it calls previous decides only how the
- * integer truncation falls.
+ * integer truncation falls, and whether its own side effects precede a veto
+ * further down the chain. A feature that forbids an attack entirely, one in
+ * which players never hurt each other, say, returns false without calling
+ * previous, and `G_Damage` does nothing at all: no pain, no blood, no knockback.
+ * A link that calls previous MUST return false when previous does.
+ * `dmg->inflictor` and `dmg->attacker` are resolved to the world entity when the
+ * attack had none.
+ * @return False to abort the attack.
  */
-typedef void (*ModifyDamage)(g_entity_t *target, g_entity_t *attacker, int32_t *damage, int32_t *knockback);
+typedef bool (*ModifyDamage)(const g_damage_t *dmg, int32_t *damage, int32_t *knockback);
 
 extern ModifyDamage G_ModifyDamage;
 

--- a/src/game/common/g_tech.c
+++ b/src/game/common/g_tech.c
@@ -99,7 +99,10 @@ static const g_item_t *G_ResolveInventoryItem_Tech(g_client_t *cl, const char *n
  * previous so that the three keep the order they had before resist and strength
  * were a hook.
  */
-static void G_ModifyDamage_Tech(g_entity_t *target, g_entity_t *attacker, int32_t *damage, int32_t *knockback) {
+static bool G_ModifyDamage_Tech(const g_damage_t *dmg, int32_t *damage, int32_t *knockback) {
+
+  g_entity_t *const target = dmg->target;
+  g_entity_t *const attacker = dmg->attacker;
 
   if (target->client && G_HasTech(target->client, TECH_RESIST)) {
     *damage *= TECH_RESIST_DAMAGE_FACTOR;
@@ -108,7 +111,9 @@ static void G_ModifyDamage_Tech(g_entity_t *target, g_entity_t *attacker, int32_
     G_PlayTechSound(target->client);
   }
 
-  previous.ModifyDamage(target, attacker, damage, knockback);
+  if (!previous.ModifyDamage(dmg, damage, knockback)) {
+    return false;
+  }
 
   if (attacker->client && G_HasTech(attacker->client, TECH_STRENGTH)) {
     *damage *= TECH_STRENGTH_DAMAGE_FACTOR;
@@ -116,6 +121,8 @@ static void G_ModifyDamage_Tech(g_entity_t *target, g_entity_t *attacker, int32_
 
     G_PlayTechSound(attacker->client);
   }
+
+  return true;
 }
 
 /**


### PR DESCRIPTION
## Summary

Decision D4 on #963. `ModifyDamage` could scale an attack but not stop it, and saw only target and attacker; the Race fork bolted a second `FilterDamage` hook in front of it and smuggled the inflictor through a file static.

- `bool (*ModifyDamage)(const g_damage_t *dmg, int32_t *damage, int32_t *knockback)`; `false` aborts `G_Damage` before pain, blood, knockback, armor.
- `dmg->inflictor` / `dmg->attacker` are pre-resolved to the world entity, as `G_Damage` already does internally.
- Call site moves to after respawn protection (no side effects to pre-empt; keeps tech sounds silent on protected players exactly as today) and before invulnerability (which plays a sound the veto must precede). One refinement from D4's "before protection" wording, recorded on the issue.
- `G_ModifyDamage_Common` (quad) and `G_ModifyDamage_Tech` adapt; the tech link propagates a veto from previous. Docblock states the chain rule.

Quad and tech scaling are multiplicative, so default / ctf / lithium behave identically.

## Test plan

- [x] all game modules build with no warnings
- [x] `edge` 80 / 85 / 85 with bots fighting under each module
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)