### PR TITLE
Let a module supply the movement kernel

### DIFF
--- a/Quetoo.vs15/cgame-ctf.vcxproj.filters
+++ b/Quetoo.vs15/cgame-ctf.vcxproj.filters
@@ -282,6 +282,9 @@
     <ClInclude Include="..\src\game\common\bg_pmove.h">
       <Filter>src\game\common</Filter>
     </ClInclude>
+    <ClInclude Include="..\src\game\common\bg_pmove_internal.h">
+      <Filter>src\game\common</Filter>
+    </ClInclude>
     <ClInclude Include="..\src\game\ctf\bg_item.h">
       <Filter>src\game\ctf</Filter>
     </ClInclude>

--- a/Quetoo.vs15/cgame-lithium.vcxproj.filters
+++ b/Quetoo.vs15/cgame-lithium.vcxproj.filters
@@ -279,6 +279,9 @@
     <ClInclude Include="..\src\game\common\bg_pmove.h">
       <Filter>src\game\common</Filter>
     </ClInclude>
+    <ClInclude Include="..\src\game\common\bg_pmove_internal.h">
+      <Filter>src\game\common</Filter>
+    </ClInclude>
     <ClInclude Include="..\src\game\lithium\bg_item.h">
       <Filter>src\game\lithium</Filter>
     </ClInclude>

--- a/Quetoo.vs15/cgame.vcxproj
+++ b/Quetoo.vs15/cgame.vcxproj
@@ -22,6 +22,7 @@
     <ClInclude Include="..\src\cgame\cgame.h" />
     <ClInclude Include="..\src\game\default\bg_item.h" />
     <ClInclude Include="..\src\game\common\bg_pmove.h" />
+    <ClInclude Include="..\src\game\common\bg_pmove_internal.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\src\game\default\bg_item.c" />

--- a/Quetoo.vs15/cgame.vcxproj.filters
+++ b/Quetoo.vs15/cgame.vcxproj.filters
@@ -276,6 +276,9 @@
     <ClInclude Include="..\src\game\common\bg_pmove.h">
       <Filter>src\game\common</Filter>
     </ClInclude>
+    <ClInclude Include="..\src\game\common\bg_pmove_internal.h">
+      <Filter>src\game\common</Filter>
+    </ClInclude>
     <ClInclude Include="..\src\game\default\bg_item.h">
       <Filter>src\game\default</Filter>
     </ClInclude>

--- a/Quetoo.vs15/game-ctf.vcxproj.filters
+++ b/Quetoo.vs15/game-ctf.vcxproj.filters
@@ -54,6 +54,9 @@
     <ClInclude Include="..\src\game\common\bg_pmove.h">
       <Filter>src\common</Filter>
     </ClInclude>
+    <ClInclude Include="..\src\game\common\bg_pmove_internal.h">
+      <Filter>src\common</Filter>
+    </ClInclude>
     <ClInclude Include="..\src\game\common\g_ai_goal.h">
       <Filter>src\common</Filter>
     </ClInclude>

--- a/Quetoo.vs15/game-lithium.vcxproj.filters
+++ b/Quetoo.vs15/game-lithium.vcxproj.filters
@@ -51,6 +51,9 @@
     <ClInclude Include="..\src\game\common\bg_pmove.h">
       <Filter>src\common</Filter>
     </ClInclude>
+    <ClInclude Include="..\src\game\common\bg_pmove_internal.h">
+      <Filter>src\common</Filter>
+    </ClInclude>
     <ClInclude Include="..\src\game\common\g_ai_goal.h">
       <Filter>src\common</Filter>
     </ClInclude>

--- a/Quetoo.vs15/game.vcxproj.filters
+++ b/Quetoo.vs15/game.vcxproj.filters
@@ -51,6 +51,9 @@
     <ClInclude Include="..\src\game\common\bg_pmove.h">
       <Filter>src\common</Filter>
     </ClInclude>
+    <ClInclude Include="..\src\game\common\bg_pmove_internal.h">
+      <Filter>src\common</Filter>
+    </ClInclude>
     <ClInclude Include="..\src\game\common\g_ai_goal.h">
       <Filter>src\common</Filter>
     </ClInclude>

--- a/Quetoo.vs15/game_common.props
+++ b/Quetoo.vs15/game_common.props
@@ -15,6 +15,7 @@
   <ItemGroup>
     <ClCompile Include="..\src\game\common\bg_pmove.c" />
     <ClInclude Include="..\src\game\common\bg_pmove.h" />
+    <ClInclude Include="..\src\game\common\bg_pmove_internal.h" />
     <ClCompile Include="..\src\game\common\g_ai_goal.c" />
     <ClInclude Include="..\src\game\common\g_ai_goal.h" />
     <ClCompile Include="..\src\game\common\g_ai_grid.c" />

--- a/Quetoo.xcodeproj/project.pbxproj
+++ b/Quetoo.xcodeproj/project.pbxproj
@@ -138,6 +138,7 @@
 		CE05B2AA3022486E0012862B /* Objectively.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CEF601BA2FE60508005C680C /* Objectively.framework */; };
 		CE05B2AB3022486E0012862B /* libshared.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CE80FDD51C5E3D4E00A21A51 /* libshared.a */; };
 		CE05B2AE3022486E0012862B /* bg_pmove.h in Headers */ = {isa = PBXBuildFile; fileRef = CE12D6421C5C58C300CD0B13 /* bg_pmove.h */; };
+		D1A5B0000000000000000002 /* bg_pmove_internal.h in Headers */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000001 /* bg_pmove_internal.h */; };
 		CE05B2AF3022486E0012862B /* g_ai_goal.h in Headers */ = {isa = PBXBuildFile; fileRef = CE27E9F327BDA2AE003D56AC /* g_ai_goal.h */; };
 		CE05B2B03022486E0012862B /* g_ai_grid.h in Headers */ = {isa = PBXBuildFile; fileRef = CE4E053F2FDAE2CE00B92C32 /* g_ai_grid.h */; };
 		CE05B2B13022486E0012862B /* g_ai_info.h in Headers */ = {isa = PBXBuildFile; fileRef = CE27E9FB27BDA2AE003D56AC /* g_ai_info.h */; };
@@ -786,6 +787,7 @@
 		CEC0FF002026010300000120 /* g_util.h in Headers */ = {isa = PBXBuildFile; fileRef = CE12D66E1C5C58C300CD0B13 /* g_util.h */; };
 		CEC0FF002026010300000121 /* g_weapon.h in Headers */ = {isa = PBXBuildFile; fileRef = CE12D6701C5C58C300CD0B13 /* g_weapon.h */; };
 		CEC0FF002026010300000122 /* bg_pmove.h in Headers */ = {isa = PBXBuildFile; fileRef = CE12D6421C5C58C300CD0B13 /* bg_pmove.h */; };
+		D1A5B0000000000000000003 /* bg_pmove_internal.h in Headers */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000001 /* bg_pmove_internal.h */; };
 		CEC0FF002026010300000123 /* g_effect.h in Headers */ = {isa = PBXBuildFile; fileRef = CEC011002026010200000003 /* g_effect.h */; };
 		CEC0FF002026010300000124 /* g_entity_func.h in Headers */ = {isa = PBXBuildFile; fileRef = CE12D6581C5C58C300CD0B13 /* g_entity_func.h */; };
 		CEC0FF002026010300000125 /* g_entity_misc.h in Headers */ = {isa = PBXBuildFile; fileRef = CE12D65C1C5C58C300CD0B13 /* g_entity_misc.h */; };
@@ -1690,6 +1692,7 @@
 		CE12D63E1C5C58C300CD0B13 /* filesystem.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = filesystem.h; sourceTree = "<group>"; };
 		CE12D6411C5C58C300CD0B13 /* bg_pmove.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = bg_pmove.c; sourceTree = "<group>"; };
 		CE12D6421C5C58C300CD0B13 /* bg_pmove.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = bg_pmove.h; sourceTree = "<group>"; };
+		D1A5B0000000000000000001 /* bg_pmove_internal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = bg_pmove_internal.h; sourceTree = "<group>"; };
 		CE12D6471C5C58C300CD0B13 /* g_ballistics.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = g_ballistics.c; sourceTree = "<group>"; };
 		CE12D6481C5C58C300CD0B13 /* g_ballistics.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = g_ballistics.h; sourceTree = "<group>"; };
 		CE12D6491C5C58C300CD0B13 /* g_client.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = g_client.c; sourceTree = "<group>"; };
@@ -3846,6 +3849,7 @@
 			children = (
 				CEC011002026010200000009 /* bg_hook.h */,
 				CE12D6421C5C58C300CD0B13 /* bg_pmove.h */,
+				D1A5B0000000000000000001 /* bg_pmove_internal.h */,
 				CE12D6411C5C58C300CD0B13 /* bg_pmove.c */,
 				CEFEEE0000000000000000C3 /* bg_tech.h */,
 				CE27E9F327BDA2AE003D56AC /* g_ai_goal.h */,
@@ -3990,6 +3994,7 @@
 				CE05B2C63022486E0012862B /* bg_hook.h in Headers */,
 				CE05B2F0302248070012F003 /* bg_item.h in Headers */,
 				CE05B2AE3022486E0012862B /* bg_pmove.h in Headers */,
+				D1A5B0000000000000000002 /* bg_pmove_internal.h in Headers */,
 				CE05B2CD3022486E0012862B /* bg_tech.h in Headers */,
 				CE05B2AF3022486E0012862B /* g_ai_goal.h in Headers */,
 				CE05B2B03022486E0012862B /* g_ai_grid.h in Headers */,
@@ -4300,6 +4305,7 @@
 				CEC0FF002026010300000128 /* bg_hook.h in Headers */,
 				CEC0FF00202601030000010A /* bg_item.h in Headers */,
 				CEC0FF002026010300000122 /* bg_pmove.h in Headers */,
+				D1A5B0000000000000000003 /* bg_pmove_internal.h in Headers */,
 				CEFEEE0000000000000000D3 /* bg_tech.h in Headers */,
 				CEC0FF00202601030000010B /* g_ai_goal.h in Headers */,
 				CEC0FF00202601030000010C /* g_ai_grid.h in Headers */,

--- a/src/game/common/bg_pmove.c
+++ b/src/game/common/bg_pmove.c
@@ -20,6 +20,7 @@
  */
 
 #include "bg_pmove.h"
+#include "bg_pmove_internal.h"
 
 /**
  * @brief The default bounding boxes. `Pm_Bounds` applies the height the movement
@@ -58,77 +59,15 @@ box3_t Pm_Bounds(const pm_params_t *params, bool ducked) {
   return Box3_Scale(bounds, PM_SCALE);
 }
 
-static pm_move_t *pm;
+pm_move_t *pm;
 
-#define MAX_CLIP_PLANES  6
-
-/**
- * @brief A structure containing full floating point precision copies of all
- * movement variables. This is initialized with the player's last movement
- * at each call to `Pm_Move` (this is obviously not thread-safe).
- */
-static struct {
-
-  /**
-   * @brief Previous (incoming) origin, in case movement fails and must be reverted.
-   */
-  vec3_t previous_origin;
-
-  /**
-   * @brief Previous (incoming) velocity, used for detecting landings.
-   */
-  vec3_t previous_velocity;
-
-  /**
-   * @brief Directional vectors based on command angles, with Z component.
-   */
-  vec3_t forward, right, up;
-
-  /**
-   * @brief Directional vectors without Z component, for air and ground movement.
-   */
-  vec3_t forward_xy, right_xy;
-
-  /**
-   * @brief The current movement command duration, in seconds.
-   */
-  float time;
-
-  /**
-   * @brief The player's ground interaction.
-   */
-  cm_trace_t ground;
-
-  /**
-   * @brief The clipping planes per slide-move.
-   */
-  cm_bsp_plane_t clip_planes[MAX_CLIP_PLANES];
-
-  /**
-   * @brief The number of clipping planes per slide-move.
-   */
-  int32_t num_clip_planes;
-
-} pm_locals;
-
-/**
- * @brief Unlike the game and the client game, this keeps its own mask test: it is
- * called per move, from the movement loop, where the arguments it would otherwise
- * format are worth skipping. `do while` rather than a statement expression, so it
- * is standard C.
- */
-#define Pm_Debug(...) \
-  do { \
-    if (pm->DebugMask() & pm->debug_mask) { \
-      pm->Debug(pm->debug_mask, __func__, __VA_ARGS__); \
-    } \
-  } while (0)
+pm_locals_t pm_locals;
 
 /**
  * @brief Mark the specified entity as touched. This enables the game module to
  * detect player -> entity interactions.
  */
-static void Pm_TouchEntity(const cm_trace_t *trace) {
+void Pm_TouchEntity(const cm_trace_t *trace) {
 
   if (trace->ent == NULL) {
     return;
@@ -153,7 +92,7 @@ static void Pm_TouchEntity(const cm_trace_t *trace) {
  * it is adjusted so that the trace begins outside of the solid it impacts.
  * @return The actual trace.
  */
-static cm_trace_t Pm_Trace(const vec3_t start, const vec3_t end, const box3_t bounds) {
+cm_trace_t Pm_Trace(const vec3_t start, const vec3_t end, const box3_t bounds) {
 
   const float offsets[] = { 0.f, 1.f, -1.f };
 
@@ -183,7 +122,7 @@ static cm_trace_t Pm_Trace(const vec3_t start, const vec3_t end, const box3_t bo
 /**
  * @brief Slide off of the impacted plane.
  */
-static vec3_t Pm_ClipVelocity(const vec3_t in, const vec3_t normal, float bounce) {
+vec3_t Pm_ClipVelocity(const vec3_t in, const vec3_t normal, float bounce) {
 
   float backoff = Vec3_Dot(in, normal);
 
@@ -199,7 +138,7 @@ static vec3_t Pm_ClipVelocity(const vec3_t in, const vec3_t normal, float bounce
 /**
  * @brief Collide with the results of the trace, clipping our velocity along the normal.
  */
-static void Pm_ClipMove(const cm_trace_t *trace) {
+void Pm_ClipMove(const cm_trace_t *trace) {
 
   if (trace->ent == NULL) {
     return;
@@ -232,7 +171,7 @@ static void Pm_ClipMove(const cm_trace_t *trace) {
 /**
  * @brief Slide through the world, clipping to impacted planes.
  */
-static float Pm_SlideMove(void) {
+float Pm_SlideMove(void) {
 
   const vec3_t org0 = pm->s.origin;
 
@@ -283,7 +222,7 @@ static float Pm_SlideMove(void) {
 /**
  * @return True if the downward trace yielded a step, false otherwise.
  */
-static bool Pm_CheckStep(const cm_trace_t *trace) {
+bool Pm_CheckStep(const cm_trace_t *trace) {
 
   if (!trace->all_solid) {
     if (trace->ent && trace->plane.normal.z >= PM_STEP_NORMAL) {
@@ -297,7 +236,7 @@ static bool Pm_CheckStep(const cm_trace_t *trace) {
 /**
  * @brief Moves the player origin to the end of a step-down trace and records the step height.
  */
-static void Pm_StepDown(const cm_trace_t *trace) {
+void Pm_StepDown(const cm_trace_t *trace) {
 
   pm->s.origin = trace->end;
   
@@ -311,7 +250,7 @@ static void Pm_StepDown(const cm_trace_t *trace) {
 /**
  * @brief Performs a slide move with stair stepping, attempting to step up over obstacles.
  */
-static void Pm_StepSlideMove(void) {
+void Pm_StepSlideMove(void) {
 
   // store pre-move parameters
   const vec3_t org0 = pm->s.origin;
@@ -373,7 +312,7 @@ static void Pm_StepSlideMove(void) {
  * @brief Handles friction against user intentions, and based on contents.
  * @param flying Whether we should clear Z velocity as well if we are going to stop
  */
-static void Pm_Friction(const bool flying) {
+void Pm_Friction(const bool flying) {
   vec3_t vel = pm->s.velocity;
 
   if (pm->s.flags & PMF_ON_GROUND) {
@@ -423,27 +362,29 @@ static void Pm_Friction(const bool flying) {
 /**
  * @brief Handles user intended acceleration.
  */
-static void Pm_Accelerate(const vec3_t dir, float speed, float accel) {
+void Pm_Accelerate(const vec3_t dir, float speed, float accel) {
   const float current_speed = Vec3_Dot(pm->s.velocity, dir);
   const float add_speed = speed - current_speed;
 
-  if (add_speed <= 0.f) {
-    return;
+  if (add_speed > 0.f) {
+    float accel_speed = accel * pm_locals.time * speed;
+
+    if (accel_speed > add_speed) {
+      accel_speed = add_speed;
+    }
+
+    pm->s.velocity = Vec3_Fmaf(pm->s.velocity, accel_speed, dir);
   }
 
-  float accel_speed = accel * pm_locals.time * speed;
-
-  if (accel_speed > add_speed) {
-    accel_speed = add_speed;
+  if (pm->Accelerate) {
+    pm->Accelerate(pm, dir, speed, accel);
   }
-
-  pm->s.velocity = Vec3_Fmaf(pm->s.velocity, accel_speed, dir);
 }
 
 /**
  * @brief Applies gravity to the current movement.
  */
-static void Pm_Gravity(void) {
+void Pm_Gravity(void) {
 
   if (pm->s.type == PM_HOOK_PULL) {
     return;
@@ -461,7 +402,7 @@ static void Pm_Gravity(void) {
 /**
  * @brief Applies water and conveyor belt current velocities to the player.
  */
-static void Pm_Currents(void) {
+void Pm_Currents(void) {
   vec3_t current = Vec3_Zero();
 
   // add water currents
@@ -519,7 +460,7 @@ static void Pm_Currents(void) {
  * @return True if the player will be eligible for trick jumping should they
  * impact the ground on this frame, false otherwise.
  */
-static bool Pm_CheckTrickJump(void) {
+bool Pm_CheckTrickJump(void) {
 
   if (pm->ground.ent) {
     return false;
@@ -547,7 +488,7 @@ static bool Pm_CheckTrickJump(void) {
 /**
  * @return True if the player is attempting to leave the ground via grappling hook.
  */
-static bool Pm_CheckHookJump(void) {
+bool Pm_CheckHookJump(void) {
 
   if ((pm->s.type >= PM_HOOK_PULL && pm->s.type <= PM_HOOK_SWING_AUTO) && (pm->s.velocity.z > 1.f)) {
 
@@ -563,7 +504,7 @@ static bool Pm_CheckHookJump(void) {
 /**
  * @brief Validates and processes grappling hook state, updating movement type as needed.
  */
-static void Pm_CheckHook(void) {
+void Pm_CheckHook(void) {
 
   // hookers only
   if (pm->s.type < PM_HOOK_PULL || pm->s.type > PM_HOOK_SWING_AUTO) {
@@ -663,7 +604,7 @@ static void Pm_CheckHook(void) {
 /**
  * @brief Checks for ground interaction, enabling trick jumping and dealing with landings.
  */
-static void Pm_CheckGround(void) {
+void Pm_CheckGround(void) {
 
   if (Pm_CheckHookJump()) {
     return;
@@ -741,7 +682,7 @@ static void Pm_CheckGround(void) {
 /**
  * @brief Checks for water interaction, accounting for player ducking, etc.
  */
-static void Pm_CheckWater(void) {
+void Pm_CheckWater(void) {
 
   pm->water_level = WATER_NONE;
   pm->water_type = 0;
@@ -782,7 +723,7 @@ static void Pm_CheckWater(void) {
  * @brief Handles ducking, adjusting both the player's bounding box and view
  * offset accordingly. Players must be on the ground in order to duck.
  */
-static void Pm_CheckDuck(void) {
+void Pm_CheckDuck(void) {
 
   if (pm->s.type == PM_DEAD) {
     if (pm->s.flags & PMF_GIBLET) {
@@ -842,7 +783,7 @@ static void Pm_CheckDuck(void) {
  *
  * @return True if a jump occurs, false otherwise.
  */
-static bool Pm_CheckJump(void) {
+bool Pm_CheckJump(void) {
 
   if (Pm_CheckHookJump()) {
     return true;
@@ -904,11 +845,9 @@ static bool Pm_CheckJump(void) {
 }
 
 /**
- * @brief Check for ladder interaction.
- *
- * @return True if the player is on a ladder, false otherwise.
+ * @brief Check for ladder interaction, setting `PMF_ON_LADDER` when the player is on one.
  */
-static void Pm_CheckLadder(void) {
+void Pm_CheckLadder(void) {
 
   if (pm->s.flags & PMF_TIME_MASK) {
     return;
@@ -935,7 +874,7 @@ static void Pm_CheckLadder(void) {
  *
  * @return True if a water jump has occurred, false otherwise.
  */
-static bool Pm_CheckWaterJump(void) {
+bool Pm_CheckWaterJump(void) {
 
   if (pm->s.type >= PM_HOOK_PULL && pm->s.type <= PM_HOOK_SWING_AUTO) {
     return false;
@@ -991,7 +930,7 @@ static bool Pm_CheckWaterJump(void) {
 /**
  * @brief Handles player movement while climbing a ladder.
  */
-static void Pm_LadderMove(void) {
+void Pm_LadderMove(void) {
 
   Pm_Debug("%s\n", vtos(pm->s.origin));
 
@@ -1050,7 +989,7 @@ static void Pm_LadderMove(void) {
 /**
  * @brief Handles player movement during a water jump, propelling the player out of the water.
  */
-static void Pm_WaterJumpMove(void) {
+void Pm_WaterJumpMove(void) {
 
   Pm_Debug("%s\n", vtos(pm->s.origin));
 
@@ -1078,7 +1017,7 @@ static void Pm_WaterJumpMove(void) {
 /**
  * @brief Handles player movement while submerged or wading in water.
  */
-static void Pm_WaterMove(void) {
+void Pm_WaterMove(void) {
 
   if (Pm_CheckWaterJump()) {
     Pm_WaterJumpMove();
@@ -1145,7 +1084,7 @@ static void Pm_WaterMove(void) {
 /**
  * @brief Handles player movement while airborne, applying friction, gravity, and air acceleration.
  */
-static void Pm_AirMove(void) {
+void Pm_AirMove(void) {
 
   Pm_Debug("%s\n", vtos(pm->s.origin));
 
@@ -1187,7 +1126,7 @@ static void Pm_AirMove(void) {
 /**
  * @brief Called for movements where player is on ground, regardless of water level.
  */
-static void Pm_WalkMove(void) {
+void Pm_WalkMove(void) {
 
   // check for beginning of a jump
   if (Pm_CheckJump()) {
@@ -1270,7 +1209,7 @@ static void Pm_WalkMove(void) {
 /**
  * @brief Handles spectator movement, allowing free-fly navigation through the world.
  */
-static void Pm_SpectatorMove(void) {
+void Pm_SpectatorMove(void) {
 
   Pm_Friction(true);
 
@@ -1300,7 +1239,7 @@ static void Pm_SpectatorMove(void) {
 /**
  * @brief Handles movement for a frozen or dead player, suppressing all movement.
  */
-static void Pm_FreezeMove(void) {
+void Pm_FreezeMove(void) {
 
   Pm_Debug("%s\n", vtos(pm->s.origin));
 }
@@ -1392,7 +1331,7 @@ static void Pm_InitLocal(void) {
 /**
  * @brief Updates the view step offset to smoothly interpolate the camera over stair steps.
  */
-static void Pm_CheckViewStep(void) {
+void Pm_CheckViewStep(void) {
 
   // add the step offset we've made on this frame
   if (pm->step) {
@@ -1437,6 +1376,11 @@ void Pm_Move(pm_move_t *pm_move) {
 
   if (pm->s.type == PM_DEAD) { // no control
     pm->cmd.forward = pm->cmd.right = pm->cmd.up = 0;
+  }
+
+  if (pm->Move) {
+    pm->Move(pm);
+    return;
   }
 
   // check for ladders

--- a/src/game/common/bg_pmove.h
+++ b/src/game/common/bg_pmove.h
@@ -183,7 +183,7 @@ box3_t Pm_Bounds(const pm_params_t *params, bool ducked);
  * @brief The player movement structure provides context management between the
  * game modules and the player movement code.
  */
-typedef struct {
+typedef struct pm_move_s {
   pm_cmd_t cmd; // movement command (in)
 
   pm_state_t s; // movement state (in / out)
@@ -214,6 +214,24 @@ typedef struct {
   debug_t (*DebugMask)(void);
   void (*Debug)(const debug_t debug, const char *func, const char *fmt, ...);
   debug_t debug_mask;
+
+  /**
+   * @brief The movement kernel, or `NULL` for Quetoo's. Runs once the move is
+   * initialized and the frozen, spectator and dead cases are handled, and owns
+   * everything after that: the ground, water, ladder and duck checks, the move
+   * itself, and `Pm_CheckViewStep` if it wants step smoothing. Spectator flight
+   * stays Quetoo's. A module supplying its own kernel builds it from
+   * `bg_pmove_internal.h`, which is how both sides run the same one, and it
+   * MUST NOT call `Pm_Move`.
+   */
+  void (*Move)(struct pm_move_s *pm);
+
+  /**
+   * @brief Called on each user-intended acceleration, or `NULL`, whether or not
+   * the move was already at the wished speed. For training aids that sample the
+   * move as it happens; it MUST NOT change it.
+   */
+  void (*Accelerate)(const struct pm_move_s *pm, const vec3_t dir, float speed, float accel);
 } pm_move_t;
 
 /**

--- a/src/game/common/bg_pmove_internal.h
+++ b/src/game/common/bg_pmove_internal.h
@@ -1,0 +1,131 @@
+/*
+ * Copyright(c) 1997-2001 id Software, Inc.
+ * Copyright(c) 2002 The Quakeforge Project.
+ * Copyright(c) 2006 Quetoo.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+#pragma once
+
+#include "bg_pmove.h"
+
+/**
+ * @file
+ * @brief The movement kernel's working state and the steps it is built from,
+ * for a module that supplies its own kernel through `pm_move_t::Move`.
+ *
+ * `Pm_Move` sets `pm` and `pm_locals` before it dispatches, and every step here
+ * reads them rather than taking the move as a parameter, so a kernel is written
+ * exactly as Quetoo's is. Nothing in this header is for callers of `Pm_Move`.
+ */
+
+#define MAX_CLIP_PLANES  6
+
+/**
+ * @brief A structure containing full floating point precision copies of all
+ * movement variables. This is initialized with the player's last movement
+ * at each call to `Pm_Move` (this is obviously not thread-safe).
+ */
+typedef struct {
+
+  /**
+   * @brief Previous (incoming) origin, in case movement fails and must be reverted.
+   */
+  vec3_t previous_origin;
+
+  /**
+   * @brief Previous (incoming) velocity, used for detecting landings.
+   */
+  vec3_t previous_velocity;
+
+  /**
+   * @brief Directional vectors based on command angles, with Z component.
+   */
+  vec3_t forward, right, up;
+
+  /**
+   * @brief Directional vectors without Z component, for air and ground movement.
+   */
+  vec3_t forward_xy, right_xy;
+
+  /**
+   * @brief The current movement command duration, in seconds.
+   */
+  float time;
+
+  /**
+   * @brief The player's ground interaction.
+   */
+  cm_trace_t ground;
+
+  /**
+   * @brief The clipping planes per slide-move.
+   */
+  cm_bsp_plane_t clip_planes[MAX_CLIP_PLANES];
+
+  /**
+   * @brief The number of clipping planes per slide-move.
+   */
+  int32_t num_clip_planes;
+
+} pm_locals_t;
+
+extern pm_move_t *pm;
+extern pm_locals_t pm_locals;
+
+/**
+ * @brief Unlike the game and the client game, this keeps its own mask test: it is
+ * called per move, from the movement loop, where the arguments it would otherwise
+ * format are worth skipping. `do while` rather than a statement expression, so it
+ * is standard C.
+ */
+#define Pm_Debug(...) \
+  do { \
+    if (pm->DebugMask() & pm->debug_mask) { \
+      pm->Debug(pm->debug_mask, __func__, __VA_ARGS__); \
+    } \
+  } while (0)
+
+void Pm_TouchEntity(const cm_trace_t *trace);
+cm_trace_t Pm_Trace(const vec3_t start, const vec3_t end, const box3_t bounds);
+vec3_t Pm_ClipVelocity(const vec3_t in, const vec3_t normal, float bounce);
+void Pm_ClipMove(const cm_trace_t *trace);
+float Pm_SlideMove(void);
+bool Pm_CheckStep(const cm_trace_t *trace);
+void Pm_StepDown(const cm_trace_t *trace);
+void Pm_StepSlideMove(void);
+void Pm_Friction(const bool flying);
+void Pm_Accelerate(const vec3_t dir, float speed, float accel);
+void Pm_Gravity(void);
+void Pm_Currents(void);
+bool Pm_CheckTrickJump(void);
+bool Pm_CheckHookJump(void);
+void Pm_CheckHook(void);
+void Pm_CheckGround(void);
+void Pm_CheckWater(void);
+void Pm_CheckDuck(void);
+bool Pm_CheckJump(void);
+void Pm_CheckLadder(void);
+bool Pm_CheckWaterJump(void);
+void Pm_LadderMove(void);
+void Pm_WaterJumpMove(void);
+void Pm_WaterMove(void);
+void Pm_AirMove(void);
+void Pm_WalkMove(void);
+void Pm_SpectatorMove(void);
+void Pm_FreezeMove(void);
+void Pm_CheckViewStep(void);

--- a/src/game/common/g_client.c
+++ b/src/game/common/g_client.c
@@ -1881,6 +1881,10 @@ static void G_ClientMove(g_client_t *cl, pm_cmd_t *cmd) {
     } else {
       gi.Print("PMove frame %8" PRIu64 " / %8" PRIu64, pmove_frame, pmove_frames);
       pmove_frame++;
+
+      // the recording holds the pointers of whatever module made it
+      pm.Move = NULL;
+      pm.Accelerate = NULL;
     }
   }
 


### PR DESCRIPTION
## Summary

Decision D2 on #963. The Race fork's `bg_pmove.c` is ours plus a self-contained Quake II kernel spliced in with 23 `if (Pm_Q2FamilyPhysics())` branches. This gives it a seam instead of a shadow.

- `pm_move_t` gains `Move`, a kernel strategy `Pm_Move` dispatches to after `Pm_Init`/`Pm_ClampAngles`/`Pm_InitLocal` and the frozen / spectator / dead handling; and `Accelerate`, an observer called on every user-intended acceleration (including over-speed frames, which a strafe trainer needs). Both `NULL` by default, so default / ctf / lithium are unchanged.
- `bg_pmove_internal.h` exports the kernel's working state (`pm`, `pm_locals`, `Pm_Debug`) and its 29 steps, previously `static`, so a module's kernel is written exactly as ours is and compiled into both its modules. Modules are `RTLD_LOCAL` and the Windows `.def` exports only the entry point, so nothing new leaks across images.
- `pm_move_t` gets a struct tag so the callbacks can name it.
- The `_DEBUG` pmove playback path NULLs the two new pointers after reading a recorded move.

## Test plan

- [x] all game and cgame modules build with no warnings; `verify_projects.py` 6/6 (header registered in MSVS props/filters and Xcode)
- [x] `edge` 80 / 85 / 85 for default / ctf / lithium
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)