### PR TITLE
Add the client lifecycle hooks

### DIFF
--- a/doc/game-module-hooks.md
+++ b/doc/game-module-hooks.md
@@ -183,6 +183,14 @@ Neither feature mentions the other, and no module hand-writes a dispatcher.
   live in `common` and serve every module, so naming them after one of the three
   would invite the question of why default's code is in common.
 - Avoid a leading underscore: C reserves `_` followed by an uppercase letter.
+- **Verb-first decides; SubjectWill/Did informs.** Every hook above is a decision
+  the chain makes, and VerbSubject fits those. A hook that only tells the module
+  something happened is a *notification*: it is named `SubjectWillVerb` or
+  `SubjectDidVerb` — `ClientDidBegin`, `ClientWillDisconnect` — in the shape
+  ObjectivelyMVC already uses (`viewWillAppear`, `viewDidLoad`). `Will` runs
+  before the thing and `Did` after it, the tail does nothing, and an
+  implementation MUST NOT try to change the outcome from a notification. So a
+  verb-first name means you decide; `Will`/`Did` means you are told.
 
 ### Where things live
 
@@ -190,7 +198,8 @@ Neither feature mentions the other, and no module hand-writes a dispatcher.
   authoritative list of every variation point.
 - **Tails** go in the domain file that owns the behaviour — `g_item.c` for items
   and for parting a client from them, `g_combat.c` for damage, `g_entity.c` for the
-  level, `g_client.c` for movement, `g_rules.c` for the rules. Never a catch-all:
+  level, `g_client.c` for movement and the spawn, `g_rules.c` for the rules. Never a
+  catch-all:
   `g_module.c` existed for exactly two tails and was deleted, because a file that
   accumulates every hookable function in the game is what this design exists to
   prevent.
@@ -271,6 +280,13 @@ have produced a module that did not compile.
 | `ConfigureLevel` | `g_entity.c` | techs, hook |
 | `PrepareMove` | `g_client.c` | hook |
 | `ClipEntity` | `g_client.c` | — |
+| `InitInventory` | `g_client.c` | — |
+| `PrepareSpawn` | `g_client.c` | — |
+| `ClientDidBegin` | `g_client.c` | — |
+| `ClientDidChangeUserInfo` | `g_client.c` | — |
+| `ClientWillDisconnect` | `g_client.c` | — |
+| `ClientWillThink` | `g_client.c` | — |
+| `ClientDidMove` | `g_client.c` | — |
 
 The tail of each chain lives beside the code that calls it, never in a catch-all:
 `g_module.c` was deleted once its last default moved out, because a file that

--- a/src/game/common/g_client.c
+++ b/src/game/common/g_client.c
@@ -961,7 +961,7 @@ static void G_Give(g_client_t *cl, char *it, int16_t quantity) {
 /**
  * @brief Initializes a client's starting inventory based on the current game mode.
  */
-static void G_InitClientInventory(g_client_t *cl) {
+static void G_InitInventory_Common(g_client_t *cl) {
   const g_item_t *item;
 
   // instagib gets railgun and slugs, both in normal mode and warmup
@@ -998,6 +998,8 @@ static void G_InitClientInventory(g_client_t *cl) {
 
   G_UseWeapon(cl, item);
 }
+
+InitInventory G_InitInventory = G_InitInventory_Common;
 
 /**
  * @brief Returns the distance to the nearest enemy from the given spot.
@@ -1245,7 +1247,40 @@ static g_entity_t *G_SelectSpawnPoint(g_client_t *cl) {
 }
 
 /**
- * @brief The grunt work of putting the client into the server on [re]spawn.
+ * @brief The tail of the `G_PrepareSpawn` chain: the spawn point as selected.
+ */
+static void G_PrepareSpawn_Common(g_client_t *cl, g_client_spawn_t *spawn) {
+}
+
+PrepareSpawn G_PrepareSpawn = G_PrepareSpawn_Common;
+
+static void G_ClientDidBegin_Common(g_client_t *cl) {
+}
+
+ClientDidBegin G_ClientDidBegin = G_ClientDidBegin_Common;
+
+static void G_ClientDidChangeUserInfo_Common(g_client_t *cl) {
+}
+
+ClientDidChangeUserInfo G_ClientDidChangeUserInfo = G_ClientDidChangeUserInfo_Common;
+
+static void G_ClientWillDisconnect_Common(g_client_t *cl) {
+}
+
+ClientWillDisconnect G_ClientWillDisconnect = G_ClientWillDisconnect_Common;
+
+static void G_ClientWillThink_Common(g_client_t *cl, const pm_cmd_t *cmd) {
+}
+
+ClientWillThink G_ClientWillThink = G_ClientWillThink_Common;
+
+static void G_ClientDidMove_Common(g_client_t *cl, const pm_cmd_t *cmd) {
+}
+
+ClientDidMove G_ClientDidMove = G_ClientDidMove_Common;
+
+/**
+ * @brief Spawns the client's entity, as a player or a spectator.
  */
 static void G_ClientRespawn_(g_client_t *cl) {
 
@@ -1280,25 +1315,34 @@ static void G_ClientRespawn_(g_client_t *cl) {
   const g_entity_t *spawn = G_SelectSpawnPoint(cl);
   assert(spawn);
 
+  g_client_spawn_t place = {
+    .origin = spawn->s.origin,
+    .angles = spawn->s.angles,
+    .clip_mask = cl->ai ? CONTENTS_MASK_CLIP_MONSTER : CONTENTS_MASK_CLIP_PLAYER,
+    .kill_box = true,
+  };
+
+  G_PrepareSpawn(cl, &place);
+
   // move to the spawn origin
-  ent->s.origin = spawn->s.origin;
+  ent->s.origin = place.origin;
   ent->s.origin.z += PM_STEP_HEIGHT;
 
   // snap view angles directly to the spawn point; the client will snap
   // cl.angles to match, so no delta_angles compensation is needed
   ent->s.angles = Vec3_Zero();
-  cl->angles = spawn->s.angles;
+  cl->angles = place.angles;
 
   // pack the new origin and view angles into the player state
   cl->ps.pm_state.origin = ent->s.origin;
-  cl->ps.pm_state.view_angles = spawn->s.angles;
+  cl->ps.pm_state.view_angles = place.angles;
   cl->ps.pm_state.delta_angles = Vec3_Zero();
   cl->ps.entity = ent->s.number;
 
   // signal the client to snap to view_angles; only for player spawns, not spectators
   if (!cl->persistent.spectator && !editor->value) {
     gi.WriteByte(SV_CMD_SNAP_ANGLES);
-    gi.WriteAngles(spawn->s.angles);
+    gi.WriteAngles(place.angles);
     gi.Unicast(cl, true);
   }
 
@@ -1349,11 +1393,7 @@ static void G_ClientRespawn_(g_client_t *cl) {
     G_SetAnimation(cl, ANIM_TORSO_STAND1, true);
     G_SetAnimation(cl, ANIM_LEGS_JUMP1, true);
 
-    ent->clip_mask = CONTENTS_MASK_CLIP_PLAYER;
-
-    if (cl->ai) {
-      ent->clip_mask = CONTENTS_MASK_CLIP_MONSTER;
-    }
+    ent->clip_mask = place.clip_mask;
 
     ent->dead = false;
     ent->Die = G_ClientDie;
@@ -1377,13 +1417,15 @@ static void G_ClientRespawn_(g_client_t *cl) {
 
     // setup inventory/weapon
     if (!G_Ai_InDeveloperMode()) {
-      G_InitClientInventory(cl);
+      G_InitInventory(cl);
     }
 
     // briefly disable firing, since we likely just clicked to respawn
     cl->weapon_fire_time = g_level.time + 250;
 
-    G_KillBox(ent); // kill anyone in our spot
+    if (place.kill_box) {
+      G_KillBox(ent); // kill anyone in our spot
+    }
   }
 
   gi.LinkEntity(ent);
@@ -1489,6 +1531,8 @@ void G_ClientBegin(g_client_t *cl) {
 
   // make sure all view stuff is valid
   G_ClientEndFrame(cl);
+
+  G_ClientDidBegin(cl);
 }
 
 /**
@@ -1672,6 +1716,8 @@ void G_ClientUserInfoChanged(g_client_t *cl, const char *user_info) {
 
   // stats guid
   q_strlcpy(cl->persistent.guid, InfoString_Get(user_info, "guid"), sizeof(cl->persistent.guid));
+
+  G_ClientDidChangeUserInfo(cl);
 }
 
 /**
@@ -1716,6 +1762,8 @@ bool G_ClientConnect(g_client_t *cl, char *user_info) {
  * @brief Called when a player drops from the server. Not be called between levels.
  */
 void G_ClientDisconnect(g_client_t *cl) {
+
+  G_ClientWillDisconnect(cl);
 
   if (cl->entity) {
     G_TossInventory(cl);
@@ -2169,6 +2217,8 @@ void G_ClientThink(g_client_t *cl, pm_cmd_t *cmd) {
   cl->buttons = cmd->buttons;
   cl->latched_buttons |= cl->buttons & ~cl->old_buttons;
 
+  G_ClientWillThink(cl, cmd);
+
   if (!cl->chase_target) { // move through the world
 
 #if defined(G_HOOK)
@@ -2178,6 +2228,8 @@ void G_ClientThink(g_client_t *cl, pm_cmd_t *cmd) {
 #endif
 
     G_ClientMove(cl, cmd);
+
+    G_ClientDidMove(cl, cmd);
   }
 
   cl->cmd = *cmd;

--- a/src/game/common/g_module.h
+++ b/src/game/common/g_module.h
@@ -167,6 +167,17 @@ extern ResetItem G_ResetItem;
  */
 
 /**
+ * @brief Gives a client their starting inventory when they spawn.
+ * @details The default is the machinegun with its ammo, or the item set's
+ * equivalent. Chainable: a feature that adds to the loadout calls previous and
+ * then gives; a mode with no weapons at all does not defer to previous. The
+ * tail lives in g_client.c, beside the spawn.
+ */
+typedef void (*InitInventory)(g_client_t *cl);
+
+extern InitInventory G_InitInventory;
+
+/**
  * @brief Resolves the item a client named to one they are carrying, or `NULL`
  * when the name means nothing here.
  * @details Deathmatch resolves the name against the item list. Features that
@@ -309,6 +320,97 @@ extern ClampGameplay G_ClampGameplay;
 typedef void (*FormatGameName)(char *name, size_t size);
 
 extern FormatGameName G_FormatGameName;
+
+/**
+ * @}
+ * @defgroup hooks-clients Clients
+ * @brief A client's life on the server, from connection to disconnection. Tails
+ * in g_client.c.
+ *
+ * Most of these are notifications: the module is told what happened and MUST
+ * NOT try to change it. Their names say so - `ClientDidBegin` - where a hook
+ * the module decides is named for the decision - `PrepareSpawn`.
+ * @{
+ */
+
+/**
+ * @brief Where and how a client is about to spawn.
+ */
+typedef struct {
+
+  /**
+   * @brief The spawn origin and view angles, from the selected spawn point. The
+   * origin is the floor, as a spawn point's is; `PM_STEP_HEIGHT` is added once
+   * the chain has run.
+   */
+  vec3_t origin, angles;
+
+  /**
+   * @brief The clip mask the client's entity moves with.
+   */
+  int32_t clip_mask;
+
+  /**
+   * @brief Whether whatever occupies the spawn is telefragged.
+   */
+  bool kill_box;
+} g_client_spawn_t;
+
+/**
+ * @brief Adjusts where and how a client spawns, after the spawn point has been
+ * selected and before the entity is placed. The default changes nothing.
+ * @details Chainable. A feature that spawns players somewhere of its own, or
+ * lets them pass through each other, edits `spawn` and calls previous.
+ */
+typedef void (*PrepareSpawn)(g_client_t *cl, g_client_spawn_t *spawn);
+
+extern PrepareSpawn G_PrepareSpawn;
+
+/**
+ * @brief The client has entered the game: their entity exists and is placed.
+ * @details Notification; the tail does nothing.
+ */
+typedef void (*ClientDidBegin)(g_client_t *cl);
+
+extern ClientDidBegin G_ClientDidBegin;
+
+/**
+ * @brief The client's user info was applied: name, skin, colors and the rest
+ * are current on `cl->persistent`.
+ * @details Notification; the tail does nothing.
+ */
+typedef void (*ClientDidChangeUserInfo)(g_client_t *cl);
+
+extern ClientDidChangeUserInfo G_ClientDidChangeUserInfo;
+
+/**
+ * @brief The client is about to leave: their inventory is still intact, and so
+ * is their entity if they ever began, so a feature may still read them.
+ * `cl->entity` is `NULL` for a client that connected and left without spawning.
+ * @details Notification; the tail does nothing.
+ */
+typedef void (*ClientWillDisconnect)(g_client_t *cl);
+
+extern ClientWillDisconnect G_ClientWillDisconnect;
+
+/**
+ * @brief A movement command has arrived and the buttons are latched, before
+ * the client moves or fires. Not called during the intermission, when commands
+ * are ignored.
+ * @details Notification; the tail does nothing.
+ */
+typedef void (*ClientWillThink)(g_client_t *cl, const pm_cmd_t *cmd);
+
+extern ClientWillThink G_ClientWillThink;
+
+/**
+ * @brief The client's entity has moved for this command and is linked, before
+ * weapons are handled. Not called for a client chasing another.
+ * @details Notification; the tail does nothing.
+ */
+typedef void (*ClientDidMove)(g_client_t *cl, const pm_cmd_t *cmd);
+
+extern ClientDidMove G_ClientDidMove;
 
 /**
  * @}


### PR DESCRIPTION
## Summary

First D7 batch on #963: the seams that let a mod stop shadowing `g_client.c`.

- **Decisions** (verb-first, chainable): `PrepareSpawn(cl, g_client_spawn_t *)` — floor origin, angles, clip mask, kill-box — consulted after `G_SelectSpawnPoint`; `InitInventory(cl)` whose `_Common` tail is the former static `G_InitClientInventory`.
- **Notifications** (SubjectWill/Did, no-op tails): `ClientDidBegin`, `ClientDidChangeUserInfo`, `ClientWillDisconnect`, `ClientWillThink`, `ClientDidMove`.
- `game-module-hooks.md` gains the D7 naming rule — a verb-first name means you decide, `Will`/`Did` means you are told — and the table rows.

Behaviour of default / ctf / lithium is unchanged: `place` is built from exactly the values the code used, and the tails do nothing.

## Test plan

- [x] all game modules build with no warnings
- [x] `edge` 80 / 85 / 85 with bots joining under each module
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)