### PR TITLE
Add the client command hooks

### DIFF
--- a/doc/game-module-hooks.md
+++ b/doc/game-module-hooks.md
@@ -287,6 +287,8 @@ have produced a module that did not compile.
 | `ClientWillDisconnect` | `g_client.c` | — |
 | `ClientWillThink` | `g_client.c` | — |
 | `ClientDidMove` | `g_client.c` | — |
+| `HandleClientCommand` | `g_cmd.c` | — |
+| `ClientDidChat` | `g_cmd.c` | — |
 
 The tail of each chain lives beside the code that calls it, never in a catch-all:
 `g_module.c` was deleted once its last default moved out, because a file that

--- a/src/game/common/g_cmd.c
+++ b/src/game/common/g_cmd.c
@@ -502,6 +502,8 @@ static void G_Say_f(g_client_t *cl) {
   if (dedicated->value) { // print to the console
     gi.Print("%s", text);
   }
+
+  G_ClientDidChat(cl, text, team);
 }
 
 /**
@@ -708,11 +710,29 @@ void G_PlayPmove(void);
 #endif
 
 /**
+ * @brief The tail of the `G_HandleClientCommand` chain, which handles nothing.
+ */
+static bool G_HandleClientCommand_Common(g_client_t *cl, const char *cmd, bool intermission) {
+  return false;
+}
+
+HandleClientCommand G_HandleClientCommand = G_HandleClientCommand_Common;
+
+static void G_ClientDidChat_Common(g_client_t *cl, const char *text, bool team) {
+}
+
+ClientDidChat G_ClientDidChat = G_ClientDidChat_Common;
+
+/**
  * @brief Dispatches an incoming client command string to the appropriate handler.
  */
 void G_ClientCommand(g_client_t *cl) {
 
   const char *cmd = gi.Argv(0);
+
+  if (G_HandleClientCommand(cl, cmd, g_level.intermission_time != 0)) {
+    return;
+  }
 
   if (q_strcmp(cmd, "say") == 0) {
     G_Say_f(cl);

--- a/src/game/common/g_module.h
+++ b/src/game/common/g_module.h
@@ -162,7 +162,8 @@ extern ResetItem G_ResetItem;
 /**
  * @}
  * @defgroup hooks-inventory Inventory
- * @brief Parting a client from what they are carrying. Tails in g_item.c.
+ * @brief What a client carries: given at the spawn, parted from on death or
+ * disconnect. Tails in g_item.c, and in g_client.c for the spawn.
  * @{
  */
 
@@ -411,6 +412,32 @@ extern ClientWillThink G_ClientWillThink;
 typedef void (*ClientDidMove)(g_client_t *cl, const pm_cmd_t *cmd);
 
 extern ClientDidMove G_ClientDidMove;
+
+/**
+ * @brief Handles a command the client sent, ahead of the built-in commands.
+ * @details Chainable. A feature that adds commands answers true for the ones it
+ * owns and defers to previous for the rest; one that overrides a built-in
+ * command answers true for that name and the built-in never sees it. The tail
+ * handles nothing, so an unclaimed command falls through to the built-in table
+ * and, failing that, to chat. `intermission` is true while the level is ending,
+ * when the built-in table ignores everything but chat. `cmd` is `gi.Argv(0)`;
+ * an implementation MUST NOT call `gi.TokenizeString`, which would replace it
+ * under the built-in table that runs next.
+ * @return True if the command was handled.
+ */
+typedef bool (*HandleClientCommand)(g_client_t *cl, const char *cmd, bool intermission);
+
+extern HandleClientCommand G_HandleClientCommand;
+
+/**
+ * @brief The client said something, and it was delivered. `text` is the line as
+ * the other clients saw it: the name, its color escapes and a trailing newline.
+ * A muted, empty or flood-limited message is not delivered and not reported.
+ * @details Notification; the tail does nothing.
+ */
+typedef void (*ClientDidChat)(g_client_t *cl, const char *text, bool team);
+
+extern ClientDidChat G_ClientDidChat;
 
 /**
  * @}


### PR DESCRIPTION
## Summary

Second D7 batch on #963.

- `HandleClientCommand(cl, cmd, intermission)` — chainable decision run at the very top of `G_ClientCommand`, ahead of chat, the intermission early-return and the built-in table. A feature answers true for the commands it owns; anything unclaimed falls through exactly as today. This is what retires the fork's hard-coded list of its own command names in the shared table.
- `ClientDidChat(cl, text, team)` — notification at the end of `G_Say_f`, after delivery; muted, empty or flood-limited messages are not reported. `text` is the formatted line the other clients saw.
- Also fixes the Inventory group's docblock, which #980 left saying its tails are only in `g_item.c`.

Tails handle nothing / do nothing, so default / ctf / lithium are unchanged.

## Test plan

- [x] all game modules build with no warnings
- [x] `edge` 80 / 85 / 85 under each module
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)