### PR TITLE
Add the client game's message, lifecycle, entity and presentation hooks

### DIFF
--- a/doc/game-module-hooks.md
+++ b/doc/game-module-hooks.md
@@ -339,6 +339,26 @@ brace so that the two branches of the preprocessor close different blocks,
 compiles and then breaks the next person to edit around it. Restate the condition
 and make the block additive instead.
 
+### The client game's hooks
+
+| hook | tail lives in | installed by |
+| --- | --- | --- |
+| `DrawHudElements` | `cg_hud.c` | ctf, techs |
+| `ListGameplayModes` | `cg_main.c` | ctf |
+| `ClipEntity` | `cg_predict.c` | — |
+| `ParseServerCommand` | `cg_main.c` | — |
+| `ParseConfigString` | `cg_main.c` | — |
+| `StateDidClear` | `cg_main.c` | — |
+| `MediaDidLoad` | `cg_media.c` | — |
+| `SceneDidPopulate` | `cg_main.c` | — |
+| `ScreenDidUpdate` | `cg_main.c` | — |
+| `FilterEntity` | `cg_entity.c` | — |
+| `DescribeGameMode` | `cg_discord.c` | — |
+| `DrawScores` | `cg_score.c` | — |
+
+`cg_hud_layout_t.draw_time` lets a module that arranges the whole HUD keep the
+clock or place it itself, where it used to have to push `stat_y` off screen.
+
 ### The client side
 
 `cg_hud.c` and `cg_score.c` were the same fork on the client, and moved the same

--- a/src/cgame/common/cg_discord.c
+++ b/src/cgame/common/cg_discord.c
@@ -151,7 +151,11 @@ static void Cg_DiscordReady(const DiscordUser *user) {
   cg_discord_state.initialized = true;
 }
 
-static const char *Cg_GetGameMode(void) {
+/**
+ * @brief The tail of the `Cg_DescribeGameMode` chain: the gameplay and the
+ * team count, or the flag mode.
+ */
+static const char *Cg_DescribeGameMode_Common(void) {
 
 #if defined(G_CTF)
   return va("%i-Team CTF", cg_state.num_teams);
@@ -178,6 +182,8 @@ static const char *Cg_GetGameMode(void) {
 #endif
 }
 
+DescribeGameMode Cg_DescribeGameMode = Cg_DescribeGameMode_Common;
+
 void Cg_UpdateDiscord(void) {
 
   if (cg_discord_state.failed) {
@@ -202,7 +208,7 @@ void Cg_UpdateDiscord(void) {
         char message[MAX_STRING_CHARS];
         q_strcolorstrip(cgi.ConfigString(CS_MESSAGE), message);
 
-        q_snprintf(details, sizeof(details), "%s - %s", Cg_GetGameMode(), message);
+        q_snprintf(details, sizeof(details), "%s - %s", Cg_DescribeGameMode(), message);
         presence.details = details;
 
         if (q_strcmp(cgi.server_name, "localhost")) {

--- a/src/cgame/common/cg_entity.c
+++ b/src/cgame/common/cg_entity.c
@@ -225,6 +225,12 @@ static void Cg_EntitySound(cl_entity_t *ent) {
   s->sound = 0;
 }
 
+static bool Cg_FilterEntity_Common(const cl_entity_t *ent) {
+  return true;
+}
+
+FilterEntity Cg_FilterEntity = Cg_FilterEntity_Common;
+
 /**
  * @brief Interpolate the current frame, processing any new events and advancing the simulation.
  */
@@ -239,13 +245,14 @@ void Cg_Interpolate(const cl_frame_t *frame) {
 
     cl_entity_t *ent = &cgi.client->entities[s->number];
 
-    Cg_EntitySound(ent);
+    if (Cg_FilterEntity(ent)) {
+      Cg_EntitySound(ent);
+      Cg_EntityEvent(ent);
+    }
 
-    Cg_EntityEvent(ent);
-
-    // Also clear the event in the circular buffer to prevent it from being restored
-    // by the spawn_id validation in Cg_AddEntities()
-    s->event = 0;
+    // the event is consumed whether or not it was shown, so that parsing the
+    // same frame again does not fire it twice
+    ent->current.event = s->event = 0;
   }
 }
 
@@ -333,6 +340,10 @@ void Cg_AddEntities(const cl_frame_t *frame) {
     const uint32_t snum = (frame->entity_state + i) & ENTITY_STATE_MASK;
     const entity_state_t *s = &cgi.client->entity_states[snum];
     cl_entity_t *ent = &cgi.client->entities[s->number];
+
+    if (!Cg_FilterEntity(ent)) {
+      continue;
+    }
 
     Cg_EntityTrail(ent);
 

--- a/src/cgame/common/cg_hud.c
+++ b/src/cgame/common/cg_hud.c
@@ -360,11 +360,14 @@ void Cg_DrawHud(const player_state_t *ps) {
   cg_hud_layout_t layout = {
     .powerup_y = cgi.context->h / 2,
     .stat_y = HUD_PIC_HEIGHT + ch, // the pickup holds the first row
+    .draw_time = true,
   };
 
   Cg_DrawHudElements(ps, &layout);
 
-  Cg_DrawTime(ps, layout.stat_y);
+  if (layout.draw_time) {
+    Cg_DrawTime(ps, layout.stat_y);
+  }
 
   Cg_DrawCenterPrint(ps);
 

--- a/src/cgame/common/cg_hud.h
+++ b/src/cgame/common/cg_hud.h
@@ -61,6 +61,13 @@ typedef struct {
    * @brief The y of the next stat row.
    */
   int32_t stat_y;
+
+  /**
+   * @brief Whether the match time is drawn beneath the stat column once the
+   * elements have been arranged. A module that places the clock itself, or has
+   * no use for it, clears this.
+   */
+  bool draw_time;
 } cg_hud_layout_t;
 
 #if defined(__CG_LOCAL_H__)

--- a/src/cgame/common/cg_main.c
+++ b/src/cgame/common/cg_main.c
@@ -257,11 +257,21 @@ static void Cg_ParseTeamInfo(const char *s) {
   release(info);
 }
 
+static bool Cg_ParseConfigString_Common(int32_t index) {
+  return false;
+}
+
+ParseConfigString Cg_ParseConfigString = Cg_ParseConfigString_Common;
+
 /**
  * @brief An updated configuration string has just been received from the server.
  * Refresh related variables and media that aren't managed by the engine.
  */
 static void Cg_UpdateConfigString(int32_t i) {
+
+  if (Cg_ParseConfigString(i)) {
+    return;
+  }
 
   const char *s = cgi.ConfigString(i);
 
@@ -329,10 +339,20 @@ static void Cg_ParsedMessage(int32_t cmd, void *data) {
   }
 }
 
+static bool Cg_ParseServerCommand_Common(int32_t cmd) {
+  return false;
+}
+
+ParseServerCommand Cg_ParseServerCommand = Cg_ParseServerCommand_Common;
+
 /**
  * @brief Parse a single server command, returning true on success.
  */
 static bool Cg_ParseMessage(int32_t cmd) {
+
+  if (Cg_ParseServerCommand(cmd)) {
+    return true;
+  }
 
   switch (cmd) {
     case SV_CMD_SOUND:
@@ -414,7 +434,14 @@ static void Cg_ClearState(void) {
   Cg_ClearScores();
 
   Cg_ClearUi();
+
+  Cg_StateDidClear();
 }
+
+static void Cg_StateDidClear_Common(void) {
+}
+
+StateDidClear Cg_StateDidClear = Cg_StateDidClear_Common;
 
 /**
  * @brief Prepares the scene so that early rendering operations may begin.
@@ -440,7 +467,14 @@ static void Cg_PopulateScene(const cl_frame_t *frame) {
   Cg_AddSprites();
 
   Cg_AddLights();
+
+  Cg_SceneDidPopulate(frame);
 }
+
+static void Cg_SceneDidPopulate_Common(const cl_frame_t *frame) {
+}
+
+SceneDidPopulate Cg_SceneDidPopulate = Cg_SceneDidPopulate_Common;
 
 /**
  * @brief Returns the colored key name bound to the given command, or red "`UNBOUND`" if not set.
@@ -505,7 +539,14 @@ static void Cg_UpdateScreen(const cl_frame_t *frame) {
   }
 
   Cg_CheckEditor();
+
+  Cg_ScreenDidUpdate(frame);
 }
+
+static void Cg_ScreenDidUpdate_Common(const cl_frame_t *frame) {
+}
+
+ScreenDidUpdate Cg_ScreenDidUpdate = Cg_ScreenDidUpdate_Common;
 
 /**
  * @brief Entry point that populates and returns the cgame export table with all function pointers.

--- a/src/cgame/common/cg_media.c
+++ b/src/cgame/common/cg_media.c
@@ -377,8 +377,15 @@ void Cg_LoadMedia(void) {
   
   Cg_CreateFramebuffer();
 
+  Cg_MediaDidLoad();
+
   Cg_Debug("Complete\n");
 }
+
+static void Cg_MediaDidLoad_Common(void) {
+}
+
+MediaDidLoad Cg_MediaDidLoad = Cg_MediaDidLoad_Common;
 
 /**
  * @brief Frees all client game media and resets per-level subsystem state.

--- a/src/cgame/common/cg_module.h
+++ b/src/cgame/common/cg_module.h
@@ -91,7 +91,7 @@ void Cg_Module_Shutdown(void);
 
 /**
  * @}
- * @defgroup hooks-hud Heads up display
+ * @defgroup cg-hooks-hud Heads up display
  * @brief What the HUD is made of, and how it is arranged. Tail in cg_hud.c.
  * @{
  */
@@ -124,7 +124,7 @@ extern DrawHudElements Cg_DrawHudElements;
 
 /**
  * @}
- * @defgroup hooks-gameplay Gameplay
+ * @defgroup cg-hooks-gameplay Gameplay
  * @brief What modes this module offers in the create-server menu. Tail in cg_main.c.
  * @{
  */
@@ -160,6 +160,133 @@ extern ListGameplayModes Cg_ListGameplayModes;
 typedef bool (*ClipEntity)(const cl_entity_t *mover, const cl_entity_t *ent, const vec3_t start, const vec3_t end, const box3_t bounds);
 
 extern ClipEntity Cg_ClipEntity;
+
+/**
+ * @}
+ * @defgroup cg-hooks-messages Messages
+ * @brief What the server sends. Tails in cg_main.c.
+ * @{
+ */
+
+/**
+ * @brief Parses a server command, ahead of the built-in ones. A module numbers
+ * its commands from `SV_CMD_CGAME` in its `g_types.h`.
+ * @details Chainable. A feature reads the payload of the commands it owns and
+ * answers true; it defers to previous for the rest. The tail parses nothing, so
+ * an unclaimed command falls through to the built-in ones. A feature that
+ * answers true for a built-in command replaces its parsing entirely. A feature
+ * MUST read exactly the payload its game half wrote, or every message after it
+ * is misparsed.
+ * @return True if the command was parsed.
+ */
+typedef bool (*ParseServerCommand)(int32_t cmd);
+
+extern ParseServerCommand Cg_ParseServerCommand;
+
+/**
+ * @brief Applies a config string that changed, ahead of the built-in handling.
+ * A module's config strings start at `CS_GAME` in its `g_types.h`.
+ * @details Chainable. A feature applies the indices it owns and answers true;
+ * it defers to previous for the rest. The tail applies nothing.
+ * @return True if the config string was applied.
+ */
+typedef bool (*ParseConfigString)(int32_t index);
+
+extern ParseConfigString Cg_ParseConfigString;
+
+/**
+ * @}
+ * @defgroup cg-hooks-lifecycle Lifecycle
+ * @brief The client game's life across connections and frames. Tails in
+ * cg_main.c and cg_media.c.
+ *
+ * These are notifications: the module is told what happened and MUST NOT try
+ * to change it.
+ * @{
+ */
+
+/**
+ * @brief The client game state was cleared, on connecting to a server or
+ * leaving one. A feature drops what it knew about the last server here.
+ * @details Notification; the tail does nothing.
+ */
+typedef void (*StateDidClear)(void);
+
+extern StateDidClear Cg_StateDidClear;
+
+/**
+ * @brief The level's media are loaded. A feature loads its own here.
+ * @details Notification; the tail does nothing.
+ */
+typedef void (*MediaDidLoad)(void);
+
+extern MediaDidLoad Cg_MediaDidLoad;
+
+/**
+ * @brief The scene holds every entity, effect, flare, sprite and light the
+ * client game adds for this frame. A feature adds its own here.
+ * @details Notification; the tail does nothing.
+ */
+typedef void (*SceneDidPopulate)(const cl_frame_t *frame);
+
+extern SceneDidPopulate Cg_SceneDidPopulate;
+
+/**
+ * @brief The HUD, the scoreboard and the editor are drawn for this frame. A
+ * feature that draws an overlay of its own does so here, over the top.
+ * @details Notification; the tail does nothing.
+ */
+typedef void (*ScreenDidUpdate)(const cl_frame_t *frame);
+
+extern ScreenDidUpdate Cg_ScreenDidUpdate;
+
+/**
+ * @}
+ * @defgroup cg-hooks-entities Entities
+ * @brief The entities the server sends. Tails in cg_entity.c.
+ * @{
+ */
+
+/**
+ * @brief Whether an entity the server sent is shown at all: interpolated, given
+ * its sounds and events, trailed and added to the scene. The default shows
+ * everything.
+ * @details Chainable. A feature that hides other players, say, answers false
+ * for them and defers to previous for the rest.
+ * @return True to show the entity.
+ */
+typedef bool (*FilterEntity)(const cl_entity_t *ent);
+
+extern FilterEntity Cg_FilterEntity;
+
+/**
+ * @}
+ * @defgroup cg-hooks-presentation Presentation
+ * @brief What the client game says about the game. Tails in cg_discord.c and
+ * cg_score.c.
+ * @{
+ */
+
+/**
+ * @brief Describes the game being played, for Discord and the like: "Arena",
+ * "2-Team CTF".
+ * @details Chainable so that a feature can qualify what it was handed, but a
+ * feature that names its mode outright does not defer to previous.
+ * @return A static or `va` string.
+ */
+typedef const char *(*DescribeGameMode)(void);
+
+extern DescribeGameMode Cg_DescribeGameMode;
+
+/**
+ * @brief Draws the scoreboard when the player state asks for it.
+ * @details Not chained: exactly one arrangement is possible. A module with its
+ * own board installs over the top and does not call previous; the parsed scores
+ * are still assembled by common, so it only replaces the drawing.
+ */
+typedef void (*DrawScores)(const player_state_t *ps);
+
+extern DrawScores Cg_DrawScores;
 
 /**
  * @}

--- a/src/cgame/common/cg_score.c
+++ b/src/cgame/common/cg_score.c
@@ -304,9 +304,9 @@ static void Cg_DrawDmScores(const int32_t start_y) {
 }
 
 /**
- * @brief Draws the full scores overlay when the scores stat is active.
+ * @brief The tail of the `Cg_DrawScores` hook: the frags, deaths and teams.
  */
-void Cg_DrawScores(const player_state_t *ps) {
+static void Cg_DrawScores_Common(const player_state_t *ps) {
 
   if (!ps->stats[STAT_SCORES]) {
     return;
@@ -324,3 +324,5 @@ void Cg_DrawScores(const player_state_t *ps) {
     Cg_DrawDmScores(start_y);
   }
 }
+
+DrawScores Cg_DrawScores = Cg_DrawScores_Common;

--- a/src/cgame/common/cg_score.h
+++ b/src/cgame/common/cg_score.h
@@ -26,5 +26,4 @@
 #if defined(__CG_LOCAL_H__)
 void Cg_ParseScores(void);
 void Cg_ClearScores(void);
-void Cg_DrawScores(const player_state_t *ps);
 #endif


### PR DESCRIPTION
## Summary

Decision D11 on #963: the client-game seams that retire the Race fork's shadows of `cg_main.c`, `cg_media.c`, `cg_entity.c`, `cg_discord.c` and `cg_score.c` — its `cg_module_compat.h` lists exactly these.

- **Decisions:** `ParseServerCommand(cmd)` and `ParseConfigString(index)`, run ahead of the built-in handling (`SV_CMD_CGAME` was reserved for modules but never dispatched); `FilterEntity(ent)` consulted in `Cg_Interpolate` and `Cg_AddEntities` (filtered entities still consume their events); `DescribeGameMode()` (tail = the former `Cg_GetGameMode`); `DrawScores(ps)`, not chained (tail = the former `Cg_DrawScores`; parsing stays in common).
- **Notifications:** `StateDidClear`, `MediaDidLoad`, `SceneDidPopulate(frame)`, `ScreenDidUpdate(frame)`.
- `cg_hud_layout_t.draw_time` replaces the fork's `stat_y = h` trick for suppressing the common clock.
- Doc gains the client hooks table; group names unified under `cg-hooks-`.

All tails are the previous behaviour or no-ops, so default / ctf / lithium are unchanged.

## Test plan

- [x] all cgame modules build with no warnings
- [ ] CI
- [ ] HUD/scoreboard screenshots need a GUI session (no behaviour changed by inspection: every tail is the old code path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)