### PR TITLE
Add the level, frame, stats and hook-allow hooks

### DIFF
--- a/doc/game-module-hooks.md
+++ b/doc/game-module-hooks.md
@@ -289,6 +289,13 @@ have produced a module that did not compile.
 | `ClientDidMove` | `g_client.c` | — |
 | `HandleClientCommand` | `g_cmd.c` | — |
 | `ClientDidChat` | `g_cmd.c` | — |
+| `WriteStats` | `g_client_stats.c` | — |
+| `WriteScore` | `g_client_stats.c` | — |
+| `LevelWillSpawn` | `g_entity.c` | — |
+| `SpawnEntity` | `g_entity.c` | — |
+| `AllowNextMap` | `g_rules.c` | — |
+| `AllowHook` | `g_hook.c` | — |
+| `FrameDidEnd` | `g_client_view.c` | — |
 
 The tail of each chain lives beside the code that calls it, never in a catch-all:
 `g_module.c` was deleted once its last default moved out, because a file that

--- a/src/game/common/g_client_stats.c
+++ b/src/game/common/g_client_stats.c
@@ -94,7 +94,19 @@ static void G_UpdateScore(const g_client_t *cl, g_score_t *s) {
 #if defined(G_CTF)
   s->captures = cl->persistent.captures;
 #endif
+
+  G_WriteScore(cl, s);
 }
+
+static void G_WriteScore_Common(const g_client_t *cl, g_score_t *s) {
+}
+
+WriteScore G_WriteScore = G_WriteScore_Common;
+
+static void G_WriteStats_Common(g_client_t *cl) {
+}
+
+WriteStats G_WriteStats = G_WriteStats_Common;
 
 /**
  * @brief Returns the number of scores written to the buffer.
@@ -274,6 +286,8 @@ void G_ClientStats(g_client_t *cl) {
 
   // copy full inventory to player state for delta-compression over the wire
   memcpy(cl->ps.inventory, cl->inventory, sizeof(cl->inventory));
+
+  G_WriteStats(cl);
 }
 
 /**

--- a/src/game/common/g_client_view.c
+++ b/src/game/common/g_client_view.c
@@ -544,4 +544,11 @@ void G_EndClientFrames(void) {
       G_ClientSpectatorStats(cl);
     }
   });
+
+  G_FrameDidEnd();
 }
+
+static void G_FrameDidEnd_Common(void) {
+}
+
+FrameDidEnd G_FrameDidEnd = G_FrameDidEnd_Common;

--- a/src/game/common/g_entity.c
+++ b/src/game/common/g_entity.c
@@ -150,27 +150,21 @@ static void G_InitEntityFields(g_entity_t *ent) {
 }
 
 /**
- * @brief Populates common entity fields and then dispatches the class initializer.
+ * @brief The tail of the `G_SpawnEntity` chain: the items, the weapons'
+ * projectiles and the built-in classes.
  */
-static void G_SpawnEntity(cm_entity_t *def) {
-
-  const char *classname = gi.EntityValue(def, "classname")->string;
-  g_entity_t *ent = G_AllocEntity(classname);
-
-  ent->def = def;
-
-  G_InitEntityFields(ent);
+static bool G_SpawnEntity_Common(g_entity_t *ent) {
 
   // check item spawn functions
   const g_item_t *it = G_FindItemByClassName(ent->classname);
   if (it) {
     G_SpawnItem(ent, it);
-    return;
+    return true;
   }
 
   // check the ballistics entities, which are one classname per weapon
   if (G_ballistics(ent)) {
-    return;
+    return true;
   }
 
   // check normal spawn functions
@@ -179,8 +173,34 @@ static void G_SpawnEntity(cm_entity_t *def) {
 
     if (!q_strcmp(clazz->classname, ent->classname)) {
       clazz->Init(ent);
-      return;
+      return true;
     }
+  }
+
+  return false;
+}
+
+SpawnEntity G_SpawnEntity = G_SpawnEntity_Common;
+
+static void G_LevelWillSpawn_Common(const char *name) {
+}
+
+LevelWillSpawn G_LevelWillSpawn = G_LevelWillSpawn_Common;
+
+/**
+ * @brief Populates common entity fields and then dispatches the class initializer.
+ */
+static void G_SpawnEntityDef(cm_entity_t *def) {
+
+  const char *classname = gi.EntityValue(def, "classname")->string;
+  g_entity_t *ent = G_AllocEntity(classname);
+
+  ent->def = def;
+
+  G_InitEntityFields(ent);
+
+  if (G_SpawnEntity(ent)) {
+    return;
   }
 
   G_Warn("%s doesn't have a spawn function\n", etos(ent));
@@ -580,6 +600,8 @@ void G_SpawnEntities(const char *name, const cm_entity_t *props, cm_entity_t *co
 
   q_strlcpy(g_level.name, name, sizeof(g_level.name));
 
+  G_LevelWillSpawn(name);
+
   g_level.frags    = $(alloc(Vector), initWithSize, sizeof(g_frag_t));
 
 #if defined(G_CTF)
@@ -614,7 +636,7 @@ void G_SpawnEntities(const char *name, const cm_entity_t *props, cm_entity_t *co
     if (editor->value) {
       G_SpawnEditorEntity((int32_t) i, entities[i]);
     } else {
-      G_SpawnEntity(entities[i]);
+      G_SpawnEntityDef(entities[i]);
     }
   }
 

--- a/src/game/common/g_hook.c
+++ b/src/game/common/g_hook.c
@@ -549,6 +549,15 @@ static void G_HookCheckFire(g_client_t *cl, const bool refire) {
 }
 
 /**
+ * @brief The tail of the `G_AllowHook` chain: every client may hook.
+ */
+static bool G_AllowHook_Common(const g_client_t *cl) {
+  return true;
+}
+
+AllowHook G_AllowHook = G_AllowHook_Common;
+
+/**
  * @brief Handles management of the hook for a given player.
  */
 void G_HookThink(g_client_t *cl, const bool refire) {
@@ -566,7 +575,7 @@ void G_HookThink(g_client_t *cl, const bool refire) {
     return;
   }
 
-  if (G_Ai_InDeveloperMode()) {
+  if (G_Ai_InDeveloperMode() || !G_AllowHook(cl)) {
     if (cl->hook.entity) {
       G_HookDetach(cl);
     }

--- a/src/game/common/g_main.c
+++ b/src/game/common/g_main.c
@@ -805,7 +805,7 @@ static void G_Frame(void) {
 
   // check for level change after running intermission
   if (g_level.intermission_time) {
-    if (g_level.time > g_level.intermission_time + INTERMISSION) {
+    if (g_level.time > g_level.intermission_time + INTERMISSION && G_AllowNextMap()) {
       g_level.intermission_time = 0;
 
       gi.Cbuf("next_map\n");

--- a/src/game/common/g_module.h
+++ b/src/game/common/g_module.h
@@ -111,6 +111,30 @@ typedef void (*InitMedia)(void);
 extern InitMedia G_InitMedia;
 
 /**
+ * @brief The level is about to be spawned: `g_level` is reset and named, the
+ * previous level's entities are about to be freed, and nothing of the new one,
+ * not even the worldspawn, exists yet. A feature that layers per-level
+ * settings over cvars the worldspawn reads does so here.
+ * @details Notification; the tail does nothing.
+ */
+typedef void (*LevelWillSpawn)(const char *name);
+
+extern LevelWillSpawn G_LevelWillSpawn;
+
+/**
+ * @brief Spawns an entity by its class name. The default knows the items, the
+ * weapons' projectiles and the built-in classes.
+ * @details Chainable. A feature adding entities spawns the class names it owns
+ * and defers to previous for the rest. An entity nobody spawns is warned about
+ * and freed by the caller. The editor spawns its inert placeholders without
+ * consulting the chain.
+ * @return True if the entity was spawned.
+ */
+typedef bool (*SpawnEntity)(g_entity_t *ent);
+
+extern SpawnEntity G_SpawnEntity;
+
+/**
  * @}
  * @defgroup hooks-items Items
  * @brief Placing items in the world, and what becomes of them. Tails in g_item.c.
@@ -268,6 +292,18 @@ typedef bool (*ClipEntity)(const g_entity_t *mover, const g_entity_t *ent, const
 extern ClipEntity G_ClipEntity;
 
 /**
+ * @brief Whether a client may use the grapple hook right now. The default says
+ * yes whenever the hook feature is built and enabled; a client refused here has
+ * their hook detached. Exists only when the module builds `G_HOOK`.
+ * @details Chainable. A mode that allows the hook only some of the time answers
+ * for its cases and defers to previous.
+ * @return True if the client may hook.
+ */
+typedef bool (*AllowHook)(const g_client_t *cl);
+
+extern AllowHook G_AllowHook;
+
+/**
  * @}
  * @defgroup hooks-rules Rules
  * @brief The rules a module enforces, once per frame or once per level. Tails in
@@ -298,6 +334,17 @@ extern CheckCvars G_CheckCvars;
 typedef bool (*CheckWinner)(void);
 
 extern CheckWinner G_CheckWinner;
+
+/**
+ * @brief Whether the level may advance now that the intermission has run its
+ * course. The default says yes.
+ * @details Chainable. A feature that holds the level for a vote answers false
+ * until the vote is in, then defers to previous.
+ * @return True to advance to the next map.
+ */
+typedef bool (*AllowNextMap)(void);
+
+extern AllowNextMap G_AllowNextMap;
 
 /**
  * @brief Coerces a requested gameplay mode to one this module actually
@@ -431,13 +478,51 @@ extern HandleClientCommand G_HandleClientCommand;
 
 /**
  * @brief The client said something, and it was delivered. `text` is the line as
- * the other clients saw it: the name, its color escapes and a trailing newline.
+ * the other clients saw it: the name, its color escapes and a trailing newline,
+ * in a buffer that lives only for this call; a feature that keeps it copies it.
  * A muted, empty or flood-limited message is not delivered and not reported.
  * @details Notification; the tail does nothing.
  */
 typedef void (*ClientDidChat)(g_client_t *cl, const char *text, bool team);
 
 extern ClientDidChat G_ClientDidChat;
+
+/**
+ * @brief Writes a client's stats for this frame, after the built-in ones. A
+ * feature that shows something on the HUD writes its stat here, into the slots
+ * its module's `g_types.h` numbers. A spectator chasing another client inherits
+ * that client's stats wholesale and does not run the chain.
+ * @details Chainable; call previous, then write.
+ */
+typedef void (*WriteStats)(g_client_t *cl);
+
+extern WriteStats G_WriteStats;
+
+/**
+ * @brief Writes a client's scoreboard entry, after the built-in fields. A
+ * feature with its own columns fills the fields its module's `g_score_t`
+ * carries.
+ * @details Chainable; call previous, then write.
+ */
+typedef void (*WriteScore)(const g_client_t *cl, g_score_t *s);
+
+extern WriteScore G_WriteScore;
+
+/**
+ * @}
+ * @defgroup hooks-frame Frame
+ * @brief The server frame. Tail in g_client_view.c.
+ * @{
+ */
+
+/**
+ * @brief The frame is complete: every entity has run, the rules are checked and
+ * every client's player state is built.
+ * @details Notification; the tail does nothing.
+ */
+typedef void (*FrameDidEnd)(void);
+
+extern FrameDidEnd G_FrameDidEnd;
 
 /**
  * @}

--- a/src/game/common/g_rules.c
+++ b/src/game/common/g_rules.c
@@ -66,6 +66,15 @@ static bool G_CheckWinner_Common(void) {
 CheckWinner G_CheckWinner = G_CheckWinner_Common;
 
 /**
+ * @brief The tail of the `G_AllowNextMap` chain: the level may always advance.
+ */
+static bool G_AllowNextMap_Common(void) {
+  return true;
+}
+
+AllowNextMap G_AllowNextMap = G_AllowNextMap_Common;
+
+/**
  * @brief The tail of the `G_ClampGameplay` hook: every mode `g_gameplay_id_t`
  * defines is one this module supports, so there is nothing to coerce.
  */


### PR DESCRIPTION
## Summary

Third D7 batch on #963.

- **Decisions:** `SpawnEntity(ent)` — chainable; the tail is the item / projectile / class-table lookup as it was, and the caller still warns and frees an entity nobody spawns. `AllowNextMap()` gates the `next_map` after the intermission elapses (holds the level for an end-of-map vote). `AllowHook(cl)` lets a mode allow the grapple only some of the time; a refused client is detached like developer mode does today. `WriteStats(cl)` and `WriteScore(cl, s)` run after the built-in fields (a chasing spectator inherits its target's stats and does not run the chain).
- **Notifications:** `LevelWillSpawn(name)` — `g_level` is reset and named, nothing of the new level exists yet, so per-level settings can be layered over cvars the worldspawn reads. `FrameDidEnd()` — every player state is built.
- Also documents that `ClientDidChat`'s `text` lives only for the call (Copilot's note on #981).

All tails are the previous behaviour or no-ops; default / ctf / lithium are unchanged.

## Test plan

- [x] all game modules build with no warnings
- [x] `edge` 80 / 85 / 85 under each module
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)