### PR TITLE
Let clients vote on the map, the bots, the limits and each other

### DIFF
--- a/Quetoo.vs15/game-ctf.vcxproj.filters
+++ b/Quetoo.vs15/game-ctf.vcxproj.filters
@@ -54,6 +54,9 @@
     <ClInclude Include="..\src\game\common\bg_pmove.h">
       <Filter>src\common</Filter>
     </ClInclude>
+    <ClInclude Include="..\src\game\common\bg_vote.h">
+      <Filter>src\common</Filter>
+    </ClInclude>
     <ClInclude Include="..\src\game\common\bg_pmove_internal.h">
       <Filter>src\common</Filter>
     </ClInclude>
@@ -118,6 +121,9 @@
       <Filter>src\common</Filter>
     </ClInclude>
     <ClInclude Include="..\src\game\common\g_hook.h">
+      <Filter>src\common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\game\common\g_vote.h">
       <Filter>src\common</Filter>
     </ClInclude>
     <ClInclude Include="..\src\game\common\bg_hook.h">
@@ -207,6 +213,9 @@
       <Filter>src\common</Filter>
     </ClCompile>
     <ClCompile Include="..\src\game\common\g_rules.c">
+      <Filter>src\common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\game\common\g_vote.c">
       <Filter>src\common</Filter>
     </ClCompile>
     <ClCompile Include="..\src\game\common\g_physics.c">

--- a/Quetoo.vs15/game-lithium.vcxproj.filters
+++ b/Quetoo.vs15/game-lithium.vcxproj.filters
@@ -51,6 +51,9 @@
     <ClInclude Include="..\src\game\common\bg_pmove.h">
       <Filter>src\common</Filter>
     </ClInclude>
+    <ClInclude Include="..\src\game\common\bg_vote.h">
+      <Filter>src\common</Filter>
+    </ClInclude>
     <ClInclude Include="..\src\game\common\bg_pmove_internal.h">
       <Filter>src\common</Filter>
     </ClInclude>
@@ -115,6 +118,9 @@
       <Filter>src\common</Filter>
     </ClInclude>
     <ClInclude Include="..\src\game\common\g_hook.h">
+      <Filter>src\common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\game\common\g_vote.h">
       <Filter>src\common</Filter>
     </ClInclude>
     <ClInclude Include="..\src\game\common\bg_hook.h">
@@ -201,6 +207,9 @@
       <Filter>src\common</Filter>
     </ClCompile>
     <ClCompile Include="..\src\game\common\g_rules.c">
+      <Filter>src\common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\game\common\g_vote.c">
       <Filter>src\common</Filter>
     </ClCompile>
     <ClCompile Include="..\src\game\common\g_physics.c">

--- a/Quetoo.vs15/game.vcxproj.filters
+++ b/Quetoo.vs15/game.vcxproj.filters
@@ -51,6 +51,12 @@
     <ClInclude Include="..\src\game\common\bg_pmove.h">
       <Filter>src\common</Filter>
     </ClInclude>
+    <ClInclude Include="..\src\game\common\bg_vote.h">
+      <Filter>src\common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\game\common\g_vote.h">
+      <Filter>src\common</Filter>
+    </ClInclude>
     <ClInclude Include="..\src\game\common\bg_pmove_internal.h">
       <Filter>src\common</Filter>
     </ClInclude>
@@ -189,6 +195,9 @@
       <Filter>src\common</Filter>
     </ClCompile>
     <ClCompile Include="..\src\game\common\g_rules.c">
+      <Filter>src\common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\game\common\g_vote.c">
       <Filter>src\common</Filter>
     </ClCompile>
     <ClCompile Include="..\src\game\common\g_physics.c">

--- a/Quetoo.vs15/game_common.props
+++ b/Quetoo.vs15/game_common.props
@@ -15,6 +15,8 @@
   <ItemGroup>
     <ClCompile Include="..\src\game\common\bg_pmove.c" />
     <ClInclude Include="..\src\game\common\bg_pmove.h" />
+    <ClInclude Include="..\src\game\common\bg_vote.h" />
+    <ClInclude Include="..\src\game\common\g_vote.h" />
     <ClInclude Include="..\src\game\common\bg_pmove_internal.h" />
     <ClCompile Include="..\src\game\common\g_ai_goal.c" />
     <ClInclude Include="..\src\game\common\g_ai_goal.h" />
@@ -51,6 +53,7 @@
     <ClInclude Include="..\src\game\common\g_entity_trigger.h" />
     <ClInclude Include="..\src\game\common\g_module.h" />
     <ClCompile Include="..\src\game\common\g_rules.c" />
+    <ClCompile Include="..\src\game\common\g_vote.c" />
     <ClCompile Include="..\src\game\common\g_main.c" />
     <ClInclude Include="..\src\game\common\g_main.h" />
     <ClCompile Include="..\src\game\common\g_weapon.c" />

--- a/Quetoo.xcodeproj/project.pbxproj
+++ b/Quetoo.xcodeproj/project.pbxproj
@@ -105,6 +105,7 @@
 		CE052A8721483275003446C9 /* check_thread.c in Sources */ = {isa = PBXBuildFile; fileRef = CE12D6D71C5C58C300CD0B13 /* check_thread.c */; };
 		CE052A88214832E1003446C9 /* libcommon.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CE80FDE31C5E3E1100A21A51 /* libcommon.a */; };
 		CE05B2883022486E0012862B /* g_rules.c in Sources */ = {isa = PBXBuildFile; fileRef = CEFEEE00000000000000A101 /* g_rules.c */; };
+		D1A5B0000000000000000102 /* g_vote.c in Sources */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000101 /* g_vote.c */; };
 		CE05B2893022486E0012862B /* bg_pmove.c in Sources */ = {isa = PBXBuildFile; fileRef = CE12D6411C5C58C300CD0B13 /* bg_pmove.c */; };
 		CE05B28A3022486E0012862B /* g_ai_goal.c in Sources */ = {isa = PBXBuildFile; fileRef = CE27E9F127BDA2AE003D56AC /* g_ai_goal.c */; };
 		CE05B28B3022486E0012862B /* g_ai_grid.c in Sources */ = {isa = PBXBuildFile; fileRef = CE4E05402FDAE2CE00B92C32 /* g_ai_grid.c */; };
@@ -138,6 +139,7 @@
 		CE05B2AA3022486E0012862B /* Objectively.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CEF601BA2FE60508005C680C /* Objectively.framework */; };
 		CE05B2AB3022486E0012862B /* libshared.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CE80FDD51C5E3D4E00A21A51 /* libshared.a */; };
 		CE05B2AE3022486E0012862B /* bg_pmove.h in Headers */ = {isa = PBXBuildFile; fileRef = CE12D6421C5C58C300CD0B13 /* bg_pmove.h */; };
+		D1A5B0000000000000000106 /* bg_vote.h in Headers */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000105 /* bg_vote.h */; };
 		D1A5B0000000000000000002 /* bg_pmove_internal.h in Headers */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000001 /* bg_pmove_internal.h */; };
 		CE05B2AF3022486E0012862B /* g_ai_goal.h in Headers */ = {isa = PBXBuildFile; fileRef = CE27E9F327BDA2AE003D56AC /* g_ai_goal.h */; };
 		CE05B2B03022486E0012862B /* g_ai_grid.h in Headers */ = {isa = PBXBuildFile; fileRef = CE4E053F2FDAE2CE00B92C32 /* g_ai_grid.h */; };
@@ -161,6 +163,7 @@
 		CE05B2C23022486E0012862B /* g_entity_target.h in Headers */ = {isa = PBXBuildFile; fileRef = CE12D65E1C5C58C300CD0B13 /* g_entity_target.h */; };
 		CE05B2C33022486E0012862B /* g_entity_trigger.h in Headers */ = {isa = PBXBuildFile; fileRef = CE12D6601C5C58C300CD0B13 /* g_entity_trigger.h */; };
 		CE05B2C53022486E0012862B /* g_hook.h in Headers */ = {isa = PBXBuildFile; fileRef = CEC011002026010200000007 /* g_hook.h */; };
+		D1A5B0000000000000000110 /* g_vote.h in Headers */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000108 /* g_vote.h */; };
 		CE05B2C63022486E0012862B /* bg_hook.h in Headers */ = {isa = PBXBuildFile; fileRef = CEC011002026010200000009 /* bg_hook.h */; };
 		CE05B2C73022486E0012862B /* g_item.h in Headers */ = {isa = PBXBuildFile; fileRef = CE12D6621C5C58C300CD0B13 /* g_item.h */; };
 		CE05B2C83022486E0012862B /* g_local.h in Headers */ = {isa = PBXBuildFile; fileRef = CE12D6631C5C58C300CD0B13 /* g_local.h */; };
@@ -787,12 +790,14 @@
 		CEC0FF002026010300000120 /* g_util.h in Headers */ = {isa = PBXBuildFile; fileRef = CE12D66E1C5C58C300CD0B13 /* g_util.h */; };
 		CEC0FF002026010300000121 /* g_weapon.h in Headers */ = {isa = PBXBuildFile; fileRef = CE12D6701C5C58C300CD0B13 /* g_weapon.h */; };
 		CEC0FF002026010300000122 /* bg_pmove.h in Headers */ = {isa = PBXBuildFile; fileRef = CE12D6421C5C58C300CD0B13 /* bg_pmove.h */; };
+		D1A5B0000000000000000107 /* bg_vote.h in Headers */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000105 /* bg_vote.h */; };
 		D1A5B0000000000000000003 /* bg_pmove_internal.h in Headers */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000001 /* bg_pmove_internal.h */; };
 		CEC0FF002026010300000123 /* g_effect.h in Headers */ = {isa = PBXBuildFile; fileRef = CEC011002026010200000003 /* g_effect.h */; };
 		CEC0FF002026010300000124 /* g_entity_func.h in Headers */ = {isa = PBXBuildFile; fileRef = CE12D6581C5C58C300CD0B13 /* g_entity_func.h */; };
 		CEC0FF002026010300000125 /* g_entity_misc.h in Headers */ = {isa = PBXBuildFile; fileRef = CE12D65C1C5C58C300CD0B13 /* g_entity_misc.h */; };
 		CEC0FF002026010300000126 /* g_entity_target.h in Headers */ = {isa = PBXBuildFile; fileRef = CE12D65E1C5C58C300CD0B13 /* g_entity_target.h */; };
 		CEC0FF002026010300000127 /* g_hook.h in Headers */ = {isa = PBXBuildFile; fileRef = CEC011002026010200000007 /* g_hook.h */; };
+		D1A5B0000000000000000111 /* g_vote.h in Headers */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000108 /* g_vote.h */; };
 		CEC0FF002026010300000128 /* bg_hook.h in Headers */ = {isa = PBXBuildFile; fileRef = CEC011002026010200000009 /* bg_hook.h */; };
 		CEC0FF002026010300000129 /* g_physics.h in Headers */ = {isa = PBXBuildFile; fileRef = CE12D66B1C5C58C300CD0B13 /* g_physics.h */; };
 		CEC0FF00202601030000012A /* g_sound.h in Headers */ = {isa = PBXBuildFile; fileRef = CEFF1295277D439B001E1500 /* g_sound.h */; };
@@ -975,7 +980,9 @@
 		CEFEEE0000000000000000D2 /* g_tech.h in Headers */ = {isa = PBXBuildFile; fileRef = CEFEEE0000000000000000C2 /* g_tech.h */; };
 		CEFEEE0000000000000000D3 /* bg_tech.h in Headers */ = {isa = PBXBuildFile; fileRef = CEFEEE0000000000000000C3 /* bg_tech.h */; };
 		CEFEEE00000000000000A102 /* g_rules.c in Sources */ = {isa = PBXBuildFile; fileRef = CEFEEE00000000000000A101 /* g_rules.c */; };
+		D1A5B0000000000000000103 /* g_vote.c in Sources */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000101 /* g_vote.c */; };
 		CEFEEE00000000000000A103 /* g_rules.c in Sources */ = {isa = PBXBuildFile; fileRef = CEFEEE00000000000000A101 /* g_rules.c */; };
+		D1A5B0000000000000000104 /* g_vote.c in Sources */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000101 /* g_vote.c */; };
 		CEFEEE00000000000000B102 /* g_module.c in Sources */ = {isa = PBXBuildFile; fileRef = CEFEEE00000000000000B101 /* g_module.c */; };
 		CEFEEE00000000000000B104 /* g_module.c in Sources */ = {isa = PBXBuildFile; fileRef = CEFEEE00000000000000B103 /* g_module.c */; };
 		CEFF1297277D439B001E1500 /* g_sound.h in Headers */ = {isa = PBXBuildFile; fileRef = CEFF1295277D439B001E1500 /* g_sound.h */; };
@@ -1692,6 +1699,7 @@
 		CE12D63E1C5C58C300CD0B13 /* filesystem.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = filesystem.h; sourceTree = "<group>"; };
 		CE12D6411C5C58C300CD0B13 /* bg_pmove.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = bg_pmove.c; sourceTree = "<group>"; };
 		CE12D6421C5C58C300CD0B13 /* bg_pmove.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = bg_pmove.h; sourceTree = "<group>"; };
+		D1A5B0000000000000000105 /* bg_vote.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = bg_vote.h; sourceTree = "<group>"; };
 		D1A5B0000000000000000001 /* bg_pmove_internal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = bg_pmove_internal.h; sourceTree = "<group>"; };
 		CE12D6471C5C58C300CD0B13 /* g_ballistics.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = g_ballistics.c; sourceTree = "<group>"; };
 		CE12D6481C5C58C300CD0B13 /* g_ballistics.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = g_ballistics.h; sourceTree = "<group>"; };
@@ -2216,6 +2224,7 @@
 		CEC011002026010200000003 /* g_effect.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = g_effect.h; sourceTree = "<group>"; };
 		CEC011002026010200000005 /* g_hook.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = g_hook.c; sourceTree = "<group>"; };
 		CEC011002026010200000007 /* g_hook.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = g_hook.h; sourceTree = "<group>"; };
+		D1A5B0000000000000000108 /* g_vote.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = g_vote.h; sourceTree = "<group>"; };
 		CEC011002026010200000009 /* bg_hook.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = bg_hook.h; sourceTree = "<group>"; };
 		CE12D55D1C5C58C300CD0C11 /* cg_module.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = cg_module.c; sourceTree = "<group>"; };
 		CEC0FA002026010800000001 /* g_ctf.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = g_ctf.c; sourceTree = "<group>"; };
@@ -2280,6 +2289,7 @@
 		CEFEEE0000000000000000C2 /* g_tech.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = g_tech.h; sourceTree = "<group>"; };
 		CEFEEE0000000000000000C3 /* bg_tech.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = bg_tech.h; sourceTree = "<group>"; };
 		CEFEEE00000000000000A101 /* g_rules.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = g_rules.c; sourceTree = "<group>"; };
+		D1A5B0000000000000000101 /* g_vote.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = g_vote.c; sourceTree = "<group>"; };
 		CEFEEE00000000000000B101 /* g_module.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = g_module.c; sourceTree = "<group>"; };
 		CEFEEE00000000000000B103 /* g_module.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = g_module.c; sourceTree = "<group>"; };
 		CEFF1295277D439B001E1500 /* g_sound.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = g_sound.h; sourceTree = "<group>"; };
@@ -3849,6 +3859,7 @@
 			children = (
 				CEC011002026010200000009 /* bg_hook.h */,
 				CE12D6421C5C58C300CD0B13 /* bg_pmove.h */,
+				D1A5B0000000000000000105 /* bg_vote.h */,
 				D1A5B0000000000000000001 /* bg_pmove_internal.h */,
 				CE12D6411C5C58C300CD0B13 /* bg_pmove.c */,
 				CEFEEE0000000000000000C3 /* bg_tech.h */,
@@ -3896,6 +3907,7 @@
 				CE12D6601C5C58C300CD0B13 /* g_entity_trigger.h */,
 				CE12D65F1C5C58C300CD0B13 /* g_entity_trigger.c */,
 				CEC011002026010200000007 /* g_hook.h */,
+				D1A5B0000000000000000108 /* g_vote.h */,
 				CEC011002026010200000005 /* g_hook.c */,
 				CE12D6621C5C58C300CD0B13 /* g_item.h */,
 				CE12D6611C5C58C300CD0B13 /* g_item.c */,
@@ -3905,6 +3917,7 @@
 				CE12D66B1C5C58C300CD0B13 /* g_physics.h */,
 				CE12D66A1C5C58C300CD0B13 /* g_physics.c */,
 				CEFEEE00000000000000A101 /* g_rules.c */,
+				D1A5B0000000000000000101 /* g_vote.c */,
 				CE12D6631C5C58C300CD0B13 /* g_local.h */,
 				CEFF1295277D439B001E1500 /* g_sound.h */,
 				CEFF1296277D439B001E1500 /* g_sound.c */,
@@ -3994,6 +4007,7 @@
 				CE05B2C63022486E0012862B /* bg_hook.h in Headers */,
 				CE05B2F0302248070012F003 /* bg_item.h in Headers */,
 				CE05B2AE3022486E0012862B /* bg_pmove.h in Headers */,
+				D1A5B0000000000000000106 /* bg_vote.h in Headers */,
 				D1A5B0000000000000000002 /* bg_pmove_internal.h in Headers */,
 				CE05B2CD3022486E0012862B /* bg_tech.h in Headers */,
 				CE05B2AF3022486E0012862B /* g_ai_goal.h in Headers */,
@@ -4018,6 +4032,7 @@
 				CE05B2C23022486E0012862B /* g_entity_target.h in Headers */,
 				CE05B2C33022486E0012862B /* g_entity_trigger.h in Headers */,
 				CE05B2C53022486E0012862B /* g_hook.h in Headers */,
+				D1A5B0000000000000000110 /* g_vote.h in Headers */,
 				CE05B2C73022486E0012862B /* g_item.h in Headers */,
 				CE05B2C83022486E0012862B /* g_local.h in Headers */,
 				CE05B2C93022486E0012862B /* g_main.h in Headers */,
@@ -4305,6 +4320,7 @@
 				CEC0FF002026010300000128 /* bg_hook.h in Headers */,
 				CEC0FF00202601030000010A /* bg_item.h in Headers */,
 				CEC0FF002026010300000122 /* bg_pmove.h in Headers */,
+				D1A5B0000000000000000107 /* bg_vote.h in Headers */,
 				D1A5B0000000000000000003 /* bg_pmove_internal.h in Headers */,
 				CEFEEE0000000000000000D3 /* bg_tech.h in Headers */,
 				CEC0FF00202601030000010B /* g_ai_goal.h in Headers */,
@@ -4330,6 +4346,7 @@
 				CEC0FF002026010300000126 /* g_entity_target.h in Headers */,
 				CEC0FF00202601030000011B /* g_entity_trigger.h in Headers */,
 				CEC0FF002026010300000127 /* g_hook.h in Headers */,
+				D1A5B0000000000000000111 /* g_vote.h in Headers */,
 				CEC0FF00202601030000011C /* g_item.h in Headers */,
 				CEC0FF00202601030000011D /* g_local.h in Headers */,
 				CEC0FF00202601030000011E /* g_main.h in Headers */,
@@ -5386,6 +5403,7 @@
 				CE05B2F0302248070012F002 /* g_module.c in Sources */,
 				CE05B29A3022486E0012862B /* g_physics.c in Sources */,
 				CE05B2883022486E0012862B /* g_rules.c in Sources */,
+				D1A5B0000000000000000102 /* g_vote.c in Sources */,
 				CE05B29B3022486E0012862B /* g_sound.c in Sources */,
 				CE05B29C3022486E0012862B /* g_tech.c in Sources */,
 				CE05B29D3022486E0012862B /* g_util.c in Sources */,
@@ -5503,6 +5521,7 @@
 				CEFEEE00000000000000B102 /* g_module.c in Sources */,
 				CE12D7E41C5C5D6A00CD0B13 /* g_physics.c in Sources */,
 				CEFEEE00000000000000A102 /* g_rules.c in Sources */,
+				D1A5B0000000000000000103 /* g_vote.c in Sources */,
 				CEFF1298277D439B001E1500 /* g_sound.c in Sources */,
 				CE12D7E51C5C5D6A00CD0B13 /* g_util.c in Sources */,
 				CE12D7E61C5C5D6A00CD0B13 /* g_weapon.c in Sources */,
@@ -5922,6 +5941,7 @@
 				CEFEEE00000000000000B104 /* g_module.c in Sources */,
 				CEC0FF002026010300000108 /* g_physics.c in Sources */,
 				CEFEEE00000000000000A103 /* g_rules.c in Sources */,
+				D1A5B0000000000000000104 /* g_vote.c in Sources */,
 				CEC0FF002026010300000109 /* g_sound.c in Sources */,
 				CEFEEE0000000000000000D1 /* g_tech.c in Sources */,
 				CEC0FF002026010300000101 /* g_util.c in Sources */,

--- a/doc/game-module-hooks.md
+++ b/doc/game-module-hooks.md
@@ -294,6 +294,8 @@ have produced a module that did not compile.
 | `LevelWillSpawn` | `g_entity.c` | — |
 | `SpawnEntity` | `g_entity.c` | — |
 | `AllowNextMap` | `g_rules.c` | — |
+| `PrepareVote` | `g_vote.c` | — |
+| `ApplyVote` | `g_vote.c` | — |
 | `AllowHook` | `g_hook.c` | — |
 | `FrameDidEnd` | `g_client_view.c` | — |
 

--- a/src/game/common/bg_vote.h
+++ b/src/game/common/bg_vote.h
@@ -1,0 +1,92 @@
+/*
+ * Copyright(c) 1997-2001 id Software, Inc.
+ * Copyright(c) 2002 The Quakeforge Project.
+ * Copyright(c) 2006 Quetoo.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+#pragma once
+
+#include "shared/shared.h"
+
+/**
+ * @file
+ * @brief What a vote is about, shared by the game and the client game so that
+ * the screen that calls a vote and the server that runs it agree.
+ */
+
+/**
+ * @brief The kind of argument a vote type takes.
+ */
+typedef enum {
+  VOTE_ARG_NONE,
+  VOTE_ARG_MAP, // a map name, or "next"
+  VOTE_ARG_CLIENT, // a client's name
+  VOTE_ARG_INTEGER // a number within the type's range
+} vote_arg_t;
+
+/**
+ * @brief A kind of vote a client may call.
+ */
+typedef struct {
+
+  /**
+   * @brief The name, as the `vote` command and the config string spell it.
+   */
+  const char *name;
+
+  /**
+   * @brief The title the client game shows.
+   */
+  const char *title;
+
+  /**
+   * @brief What the argument is.
+   */
+  vote_arg_t arg;
+
+  /**
+   * @brief The range of an integer argument, inclusive.
+   */
+  int32_t min, max;
+} vote_type_t;
+
+/**
+ * @brief The votes every game offers.
+ */
+static const vote_type_t vote_types_common[] = {
+  { "map", "Change map", VOTE_ARG_MAP, 0, 0 },
+  { "bots", "Bots", VOTE_ARG_INTEGER, 0, 8 },
+  { "spectate", "Force spectate", VOTE_ARG_CLIENT, 0, 0 },
+  { "frag_limit", "Frag limit", VOTE_ARG_INTEGER, 0, 100 },
+  { "time_limit", "Time limit", VOTE_ARG_INTEGER, 0, 60 },
+};
+
+/**
+ * @brief The `CS_VOTE` config string: empty when no vote is active, else these
+ * fields separated by `\`, in this order.
+ */
+typedef enum {
+  VOTE_CS_TYPE,
+  VOTE_CS_ARG,
+  VOTE_CS_YES,
+  VOTE_CS_NO,
+  VOTE_CS_ELIGIBLE,
+  VOTE_CS_DEADLINE, // level time in milliseconds
+  VOTE_CS_INITIATOR,
+  VOTE_CS_FIELDS
+} vote_cs_field_t;

--- a/src/game/common/g_local.h
+++ b/src/game/common/g_local.h
@@ -63,4 +63,5 @@
 #endif
 #include "g_types.h"
 #include "g_util.h"
+#include "g_vote.h"
 #include "g_weapon.h"

--- a/src/game/common/g_main.c
+++ b/src/game/common/g_main.c
@@ -899,6 +899,8 @@ void G_Init(void) {
   G_Ctf_Init();
 #endif
 
+  G_Vote_Init();
+
   G_Module_Init();
 
   for (int32_t i = 0; i < sv_max_clients->integer; i++) {

--- a/src/game/common/g_module.h
+++ b/src/game/common/g_module.h
@@ -347,6 +347,29 @@ typedef bool (*AllowNextMap)(void);
 extern AllowNextMap G_AllowNextMap;
 
 /**
+ * @brief Validates a vote a client is calling, writing the argument in the
+ * form the vote will be applied and announced with. The default knows the
+ * votes in `bg_vote.h`.
+ * @details Chainable. A feature with votes of its own validates the types it
+ * owns and defers to previous for the rest.
+ * @return True if the vote may be called.
+ */
+typedef bool (*PrepareVote)(const g_client_t *cl, const char *type, const char *arg, char *canonical, size_t size);
+
+extern PrepareVote G_PrepareVote;
+
+/**
+ * @brief Applies a vote that passed. The default applies the votes in
+ * `bg_vote.h`.
+ * @details Chainable. A feature applies the types it owns and defers to
+ * previous for the rest.
+ * @return True if the vote was applied.
+ */
+typedef bool (*ApplyVote)(const char *type, const char *arg);
+
+extern ApplyVote G_ApplyVote;
+
+/**
  * @brief Coerces a requested gameplay mode to one this module actually
  * supports, before it is written back to `g_gameplay` or applied to the level.
  * @param gameplay The mode `g_gameplay` parsed to, `GAMEPLAY_TEAMS` included.

--- a/src/game/common/g_vote.c
+++ b/src/game/common/g_vote.c
@@ -1,0 +1,449 @@
+/*
+ * Copyright(c) 1997-2001 id Software, Inc.
+ * Copyright(c) 2002 The Quakeforge Project.
+ * Copyright(c) 2006 Quetoo.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+#include <ctype.h>
+
+#include "g_local.h"
+#include "bg_vote.h"
+
+cvar_t *g_vote;
+cvar_t *g_vote_time;
+cvar_t *g_vote_threshold;
+cvar_t *g_vote_cooldown;
+
+typedef enum {
+  BALLOT_NONE,
+  BALLOT_YES,
+  BALLOT_NO
+} g_ballot_t;
+
+static struct {
+  bool active;
+  char type[MAX_QPATH];
+  char arg[MAX_QPATH];
+  char initiator[MAX_NET_NAME];
+  uint32_t deadline;
+  g_ballot_t ballots[MAX_CLIENTS];
+  uint32_t cooldown[MAX_CLIENTS];
+  int32_t published[3]; // yes, no and eligible as last published
+} g_vote_state;
+
+static struct {
+  HandleClientCommand HandleClientCommand;
+  FrameDidEnd FrameDidEnd;
+  ClientWillDisconnect ClientWillDisconnect;
+  ConfigureLevel ConfigureLevel;
+} previous;
+
+static bool installed;
+
+/**
+ * @brief Connected human players and spectators may vote; bots may not.
+ */
+static bool G_Vote_Eligible(const g_client_t *cl) {
+  return cl->in_use && !cl->ai;
+}
+
+/**
+ * @brief A map name is a bare file name: letters, digits, underscores and dashes.
+ */
+static bool G_Vote_ValidMapName(const char *name) {
+
+  if (!*name || q_strlen(name) >= MAX_QPATH) {
+    return false;
+  }
+
+  for (const char *c = name; *c; c++) {
+    if (!isalnum((unsigned char) *c) && *c != '_' && *c != '-') {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+/**
+ * @brief The eligible client with exactly this name, or `NULL`. A vote that
+ * could land on the nearest name would be a vote on somebody else.
+ */
+static g_client_t *G_Vote_ClientByName(const char *name) {
+
+  G_ForEachClient(cl, {
+    if (G_Vote_Eligible(cl) && !q_strcasecmp(cl->persistent.net_name, name)) {
+      return cl;
+    }
+  });
+
+  return NULL;
+}
+
+static const vote_type_t *G_Vote_Type(const char *name) {
+
+  for (size_t i = 0; i < lengthof(vote_types_common); i++) {
+    if (!q_strcmp(vote_types_common[i].name, name)) {
+      return &vote_types_common[i];
+    }
+  }
+
+  return NULL;
+}
+
+/**
+ * @brief The tail of the `G_PrepareVote` chain: the common votes.
+ */
+static bool G_PrepareVote_Common(const g_client_t *cl, const char *type, const char *arg, char *canonical, size_t size) {
+
+  const vote_type_t *vote = G_Vote_Type(type);
+  if (!vote) {
+    return false;
+  }
+
+  switch (vote->arg) {
+    case VOTE_ARG_NONE:
+      canonical[0] = '\0';
+      return true;
+
+    case VOTE_ARG_MAP:
+      if (!q_strcmp(arg, "next")) {
+        q_strlcpy(canonical, arg, size);
+        return true;
+      }
+      if (!G_Vote_ValidMapName(arg) || !gi.FileExists(va("maps/%s.bsp", arg))) {
+        return false;
+      }
+      q_strlcpy(canonical, arg, size);
+      return true;
+
+    case VOTE_ARG_CLIENT: {
+      const g_client_t *target = G_Vote_ClientByName(arg);
+      if (!target) {
+        return false;
+      }
+      q_strlcpy(canonical, target->persistent.net_name, size);
+      return true;
+    }
+
+    case VOTE_ARG_INTEGER: {
+      if (!q_strcmp(type, "bots") && g_level.min_clients_map > -1) {
+        return false;
+      }
+
+      char *end;
+      const long value = strtol(arg, &end, 10);
+      if (end == arg || *end || value < vote->min || value > vote->max) {
+        return false;
+      }
+      q_snprintf(canonical, size, "%ld", value);
+      return true;
+    }
+  }
+
+  return false;
+}
+
+PrepareVote G_PrepareVote = G_PrepareVote_Common;
+
+/**
+ * @brief The tail of the `G_ApplyVote` chain: the common votes.
+ */
+static bool G_ApplyVote_Common(const char *type, const char *arg) {
+
+  const vote_type_t *vote = G_Vote_Type(type);
+  if (!vote) {
+    return false;
+  }
+
+  if (!q_strcmp(type, "map")) {
+    if (!q_strcmp(arg, "next")) {
+      gi.Cbuf("next_map\n");
+    } else {
+      gi.Cbuf(va("map %s\n", arg));
+    }
+    return true;
+  }
+
+  if (!q_strcmp(type, "bots")) {
+    gi.SetCvarInteger("sv_min_clients", (int32_t) strtol(arg, NULL, 10));
+    return true;
+  }
+
+  if (!q_strcmp(type, "spectate")) {
+    g_client_t *target = G_Vote_ClientByName(arg);
+    if (target && !target->persistent.spectator) {
+      G_TossInventory(target);
+      target->persistent.spectator = true;
+      G_ClientRespawn(target, false);
+    }
+    return true;
+  }
+
+  if (!q_strcmp(type, "frag_limit") || !q_strcmp(type, "time_limit")) {
+    gi.SetCvarInteger(va("g_%s", type), (int32_t) strtol(arg, NULL, 10));
+    return true;
+  }
+
+  return false;
+}
+
+ApplyVote G_ApplyVote = G_ApplyVote_Common;
+
+/**
+ * @brief Counts the ballots and the clients entitled to cast one.
+ */
+static void G_Vote_Count(int32_t *yes, int32_t *no, int32_t *eligible) {
+
+  *yes = *no = *eligible = 0;
+
+  G_ForEachClient(cl, {
+    if (G_Vote_Eligible(cl)) {
+      (*eligible)++;
+
+      switch (g_vote_state.ballots[cl->ps.client]) {
+        case BALLOT_YES:
+          (*yes)++;
+          break;
+        case BALLOT_NO:
+          (*no)++;
+          break;
+        default:
+          break;
+      }
+    }
+  });
+}
+
+/**
+ * @brief Publishes the vote to the clients, or its absence.
+ */
+static void G_Vote_Publish(void) {
+
+  if (!g_vote_state.active) {
+    gi.SetConfigString(CS_VOTE, "");
+    return;
+  }
+
+  int32_t yes, no, eligible;
+  G_Vote_Count(&yes, &no, &eligible);
+
+  g_vote_state.published[0] = yes;
+  g_vote_state.published[1] = no;
+  g_vote_state.published[2] = eligible;
+
+  gi.SetConfigString(CS_VOTE, va("%s\\%s\\%d\\%d\\%d\\%u\\%s",
+                                 g_vote_state.type, g_vote_state.arg, yes, no, eligible,
+                                 g_vote_state.deadline, g_vote_state.initiator));
+}
+
+static void G_Vote_End(bool passed) {
+
+  gi.BroadcastPrint(PRINT_HIGH, "Vote %s%s%s %s\n", g_vote_state.type,
+                    *g_vote_state.arg ? " " : "", g_vote_state.arg, passed ? "passed" : "failed");
+
+  g_vote_state.active = false;
+  G_Vote_Publish();
+
+  if (passed) {
+    if (!G_ApplyVote(g_vote_state.type, g_vote_state.arg)) {
+      G_Warn("Nobody applied vote %s %s\n", g_vote_state.type, g_vote_state.arg);
+    }
+  }
+}
+
+/**
+ * @brief Decides the vote once it can be, and at its deadline.
+ */
+static void G_Vote_Check(void) {
+
+  if (!g_vote_state.active) {
+    return;
+  }
+
+  if (g_level.intermission_time) { // the level is ending; a vote does not decide it
+    gi.BroadcastPrint(PRINT_HIGH, "Vote %s%s%s cancelled\n", g_vote_state.type,
+                      *g_vote_state.arg ? " " : "", g_vote_state.arg);
+    g_vote_state.active = false;
+    G_Vote_Publish();
+    return;
+  }
+
+  int32_t yes, no, eligible;
+  G_Vote_Count(&yes, &no, &eligible);
+
+  const int32_t needed = (int32_t) floorf(eligible * Clampf(g_vote_threshold->value, 0.f, 1.f)) + 1;
+
+  if (yes >= needed) {
+    G_Vote_End(true);
+  } else if (eligible - no < needed || g_level.time >= g_vote_state.deadline) {
+    G_Vote_End(false);
+  } else if (yes != g_vote_state.published[0] || no != g_vote_state.published[1] || eligible != g_vote_state.published[2]) {
+    G_Vote_Publish();
+  }
+}
+
+static void G_Vote_Cast(g_client_t *cl, g_ballot_t ballot) {
+
+  if (!g_vote_state.active) {
+    gi.ClientPrint(cl, PRINT_HIGH, "No vote is in progress\n");
+    return;
+  }
+
+  if (!G_Vote_Eligible(cl)) {
+    return;
+  }
+
+  g_vote_state.ballots[cl->ps.client] = ballot;
+
+  G_Vote_Publish();
+  G_Vote_Check();
+}
+
+static void G_Vote_Call(g_client_t *cl, const char *type, const char *arg) {
+
+  if (!g_vote->integer) {
+    gi.ClientPrint(cl, PRINT_HIGH, "Voting is disabled\n");
+    return;
+  }
+
+  if (g_vote_state.active) {
+    gi.ClientPrint(cl, PRINT_HIGH, "A vote is already in progress\n");
+    return;
+  }
+
+  if (!G_Vote_Eligible(cl)) {
+    return;
+  }
+
+  const uint32_t cooldown = g_vote_state.cooldown[cl->ps.client];
+  if (cooldown && g_level.time < cooldown) {
+    gi.ClientPrint(cl, PRINT_HIGH, "You may call another vote in %u seconds\n", (cooldown - g_level.time) / 1000);
+    return;
+  }
+
+  char canonical[MAX_QPATH];
+  if (!G_PrepareVote(cl, type, arg, canonical, sizeof(canonical))) {
+    gi.ClientPrint(cl, PRINT_HIGH, "Invalid vote: %s %s\n", type, arg);
+    return;
+  }
+
+  memset(g_vote_state.ballots, 0, sizeof(g_vote_state.ballots));
+
+  g_vote_state.active = true;
+  q_strlcpy(g_vote_state.type, type, sizeof(g_vote_state.type));
+  q_strlcpy(g_vote_state.arg, canonical, sizeof(g_vote_state.arg));
+  q_strlcpy(g_vote_state.initiator, cl->persistent.net_name, sizeof(g_vote_state.initiator));
+  g_vote_state.deadline = g_level.time + Maxf(1.f, g_vote_time->value) * 1000;
+  g_vote_state.ballots[cl->ps.client] = BALLOT_YES;
+  g_vote_state.cooldown[cl->ps.client] = g_level.time + Maxf(0.f, g_vote_cooldown->value) * 1000;
+
+  gi.BroadcastPrint(PRINT_HIGH, "%s called a vote: %s%s%s\n", cl->persistent.net_name, type,
+                    *canonical ? " " : "", canonical);
+
+  G_Vote_Publish();
+  G_Vote_Check();
+}
+
+/**
+ * @brief `vote yes`, `vote no`, or `vote <type> [argument]`.
+ */
+static bool G_HandleClientCommand_Vote(g_client_t *cl, const char *cmd, bool intermission) {
+
+  if (q_strcmp(cmd, "vote")) {
+    return previous.HandleClientCommand(cl, cmd, intermission);
+  }
+
+  if (gi.Argc() < 2) {
+    gi.ClientPrint(cl, PRINT_HIGH, "Usage: vote yes | no | <type> [argument]\n");
+    return true;
+  }
+
+  const char *what = gi.Argv(1);
+
+  if (!q_strcasecmp(what, "yes")) {
+    G_Vote_Cast(cl, BALLOT_YES);
+  } else if (!q_strcasecmp(what, "no")) {
+    G_Vote_Cast(cl, BALLOT_NO);
+  } else if (intermission) {
+    gi.ClientPrint(cl, PRINT_HIGH, "The level is ending\n");
+  } else {
+    G_Vote_Call(cl, what, gi.Argc() > 2 ? gi.Argv(2) : "");
+  }
+
+  return true;
+}
+
+static void G_FrameDidEnd_Vote(void) {
+
+  G_Vote_Check();
+
+  previous.FrameDidEnd();
+}
+
+/**
+ * @brief A leaving client's ballot no longer counts, and their cooldown ends
+ * with them so that a reconnecting client is not held to it.
+ */
+static void G_ClientWillDisconnect_Vote(g_client_t *cl) {
+
+  g_vote_state.ballots[cl->ps.client] = BALLOT_NONE;
+  g_vote_state.cooldown[cl->ps.client] = 0;
+
+  previous.ClientWillDisconnect(cl);
+}
+
+/**
+ * @brief A vote does not outlive its level.
+ */
+static void G_ConfigureLevel_Vote(void) {
+
+  g_vote_state.active = false;
+  memset(g_vote_state.cooldown, 0, sizeof(g_vote_state.cooldown));
+
+  G_Vote_Publish();
+
+  previous.ConfigureLevel();
+}
+
+/**
+ * @brief Installs voting over the hooks it needs, once per module image.
+ */
+void G_Vote_Init(void) {
+
+  g_vote = gi.AddCvar("g_vote", "1", CVAR_SERVER_INFO, "Whether clients may call votes.");
+  g_vote_time = gi.AddCvar("g_vote_time", "30", 0, "How long a vote runs, in seconds.");
+  g_vote_threshold = gi.AddCvar("g_vote_threshold", "0.5", 0, "The fraction of eligible clients whose yes a vote must exceed to pass; 1 lets nothing pass.");
+  g_vote_cooldown = gi.AddCvar("g_vote_cooldown", "60", 0, "How long a client waits between calling votes, in seconds.");
+
+  if (!installed) {
+    installed = true;
+
+    previous.HandleClientCommand = G_HandleClientCommand;
+    G_HandleClientCommand = G_HandleClientCommand_Vote;
+
+    previous.FrameDidEnd = G_FrameDidEnd;
+    G_FrameDidEnd = G_FrameDidEnd_Vote;
+
+    previous.ClientWillDisconnect = G_ClientWillDisconnect;
+    G_ClientWillDisconnect = G_ClientWillDisconnect_Vote;
+
+    previous.ConfigureLevel = G_ConfigureLevel;
+    G_ConfigureLevel = G_ConfigureLevel_Vote;
+  }
+}

--- a/src/game/common/g_vote.h
+++ b/src/game/common/g_vote.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright(c) 1997-2001 id Software, Inc.
+ * Copyright(c) 2002 The Quakeforge Project.
+ * Copyright(c) 2006 Quetoo.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+#pragma once
+
+#include "g_types.h"
+
+#if defined(__G_LOCAL_H__)
+extern cvar_t *g_vote;
+extern cvar_t *g_vote_time;
+extern cvar_t *g_vote_threshold;
+extern cvar_t *g_vote_cooldown;
+
+void G_Vote_Init(void);
+#endif

--- a/src/game/ctf/Makefile.am
+++ b/src/game/ctf/Makefile.am
@@ -56,6 +56,7 @@ game_la_SOURCES = \
 	g_sound.c \
 	g_tech.c \
 	g_util.c \
+	g_vote.c \
 	g_weapon.c
 
 game_la_LDFLAGS = \

--- a/src/game/ctf/g_types.h
+++ b/src/game/ctf/g_types.h
@@ -82,6 +82,7 @@ typedef enum {
 #define CS_NAV_EDIT        (CS_GAME + 6)  // nav edit mode
 #define CS_ITEM_SET        (CS_GAME + 7)  // active item set (g_items_t)
 #define CS_HOOK_PULL_SPEED (CS_GAME + 8)  // hook speed
+#define CS_VOTE            (CS_GAME + 9)  // the vote in progress (bg_vote.h)
 
 
 /**

--- a/src/game/default/Makefile.am
+++ b/src/game/default/Makefile.am
@@ -50,6 +50,7 @@ game_la_SOURCES = \
 	g_rules.c \
 	g_sound.c \
 	g_util.c \
+	g_vote.c \
 	g_weapon.c
 
 game_la_LDFLAGS = \

--- a/src/game/default/g_types.h
+++ b/src/game/default/g_types.h
@@ -79,6 +79,7 @@ typedef enum {
 #define CS_NUM_TEAMS       (CS_GAME + 5)  // number of teams (0 - MAX_TEAMS)
 #define CS_NAV_EDIT        (CS_GAME + 6)  // nav edit mode
 #define CS_ITEM_SET        (CS_GAME + 7)  // active item set (g_items_t)
+#define CS_VOTE            (CS_GAME + 8)  // the vote in progress (bg_vote.h)
 
 /**
  * @brief Player state statistics (inventory, score, etc).

--- a/src/game/lithium/Makefile.am
+++ b/src/game/lithium/Makefile.am
@@ -54,6 +54,7 @@ game_la_SOURCES = \
 	g_sound.c \
 	g_tech.c \
 	g_util.c \
+	g_vote.c \
 	g_weapon.c
 
 game_la_LDFLAGS = \

--- a/src/game/lithium/g_types.h
+++ b/src/game/lithium/g_types.h
@@ -82,6 +82,7 @@ typedef enum {
 #define CS_NAV_EDIT        (CS_GAME + 6)  // nav edit mode
 #define CS_ITEM_SET        (CS_GAME + 7)  // active item set (g_items_t)
 #define CS_HOOK_PULL_SPEED (CS_GAME + 8)  // hook speed
+#define CS_VOTE            (CS_GAME + 9)  // the vote in progress (bg_vote.h)
 
 /**
  * @brief Player state statistics (inventory, score, etc).


### PR DESCRIPTION
## Summary

Decisions D10 / D16 on #963, and the game half of #865. Voting becomes a common feature of every module, installed over the new hooks (`HandleClientCommand`, `FrameDidEnd`, `ClientWillDisconnect`, `ConfigureLevel`) the way `g_ctf.c` and `g_tech.c` are.

- `vote <type> [argument]` calls a vote; `vote yes` / `vote no` casts. Common types (`bg_vote.h`, shared with the client game): `map <name>|next`, `bots <n>`, `spectate <player>`, `frag_limit <n>`, `time_limit <n>`.
- Published on `CS_VOTE` as `type\arg\yes\no\eligible\deadline\initiator`, empty when inactive; republished when the counts change. New manifest index in all three `g_types.h`.
- Rules: `g_vote` (1), `g_vote_time` (30 s), `g_vote_threshold` (0.5; 1 lets nothing pass), `g_vote_cooldown` (60 s per caller). Eligible = connected humans, spectators included. Passes when yes exceeds the threshold share of eligible voters, fails when it no longer can or at the deadline, and is cancelled when the intermission begins so it never queues a `map` beside `next_map`. With one eligible voter the caller's own yes passes at once — intended for a lone player on a bot server; the cooldown is the brake.
- Two new chainable hooks for modules with votes of their own: `PrepareVote` (validate and canonicalize) and `ApplyVote`.
- Players are matched by exact name: `G_ClientByName` picks the lexicographically nearest name, which for a punitive vote would be the wrong player. Force-spectate tosses inventory and respawns non-voluntarily (score kept, no "likes to watch"). `bots` is refused on maps that fix their own client count.

## Test plan

- [x] default / ctf / lithium build with no warnings; `verify_projects.py` 6/6 (new `g_vote.c`, `g_vote.h`, `bg_vote.h` registered in all three build systems)
- [x] `edge` 80 / 85 / 85 with bots under each module
- [ ] CI
- [ ] Casting a vote needs a connected client; the client half (screen + HUD) follows in the next PR and is where this gets exercised end to end

🤖 Generated with [Claude Code](https://claude.com/claude-code)