### PR TITLE
Add the client game's prediction and input hooks

### DIFF
--- a/doc/game-module-hooks.md
+++ b/doc/game-module-hooks.md
@@ -353,6 +353,11 @@ and make the block additive instead.
 | `DrawHudElements` | `cg_hud.c` | ctf, techs |
 | `ListGameplayModes` | `cg_main.c` | ctf |
 | `ClipEntity` | `cg_predict.c` | — |
+| `UsePrediction` | `cg_predict.c` | — |
+| `Move` | `cg_input.c` | — |
+| `MoveCommandWillRun` | `cg_predict.c` | — |
+| `MoveCommandDidRun` | `cg_predict.c` | — |
+| `PredictionDidComplete` | `cg_predict.c` | — |
 | `ParseServerCommand` | `cg_main.c` | — |
 | `ParseConfigString` | `cg_main.c` | — |
 | `StateDidClear` | `cg_main.c` | — |

--- a/src/cgame/common/cg_input.c
+++ b/src/cgame/common/cg_input.c
@@ -224,7 +224,7 @@ void Cg_Look(pm_cmd_t *cmd) {
 /**
  * @brief Accumulate movement and button interactions for the specified command.
  */
-void Cg_Move(pm_cmd_t *cmd) {
+static void Cg_Move_Common(pm_cmd_t *cmd) {
 
   if (in_attack.state & (BUTTON_STATE_HELD | BUTTON_STATE_DOWN)) {
     if (!((in_attack.state & BUTTON_STATE_DOWN) && Cg_AttemptSelectWeapon(&cgi.client->frame.ps))) {
@@ -273,6 +273,17 @@ void Cg_Move(pm_cmd_t *cmd) {
       }
     }
   }
+}
+
+Move Cg_Move = Cg_Move_Common;
+
+/**
+ * @brief The `Move` export. The client holds this rather than the chain head, so
+ * that the chain a module installs from `Cg_Module_Init` is the one that gets
+ * called.
+ */
+void Cg_ExportMove(pm_cmd_t *cmd) {
+  Cg_Move(cmd);
 }
 
 /**

--- a/src/cgame/common/cg_input.h
+++ b/src/cgame/common/cg_input.h
@@ -31,7 +31,7 @@ extern button_t cg_buttons[4];
 void Cg_HandleEvent(const SDL_Event *event);
 void Cg_ParseViewKick(void);
 void Cg_Look(pm_cmd_t *cmd);
-void Cg_Move(pm_cmd_t *cmd);
+void Cg_ExportMove(pm_cmd_t *cmd);
 void Cg_ClearInput(void);
 void Cg_InitInput(void);
 #endif

--- a/src/cgame/common/cg_main.c
+++ b/src/cgame/common/cg_main.c
@@ -565,13 +565,13 @@ cg_export_t *Cg_LoadCgame(cg_import_t *import) {
   cge.ClearState = Cg_ClearState;
   cge.HandleEvent = Cg_HandleEvent;
   cge.Look = Cg_Look;
-  cge.Move = Cg_Move;
+  cge.Move = Cg_ExportMove;
   cge.LoadMedia = Cg_LoadMedia;
   cge.FreeMedia = Cg_FreeMedia;
   cge.ParsedMessage = Cg_ParsedMessage;
   cge.ParseMessage = Cg_ParseMessage;
   cge.Interpolate = Cg_Interpolate;
-  cge.UsePrediction = Cg_UsePrediction;
+  cge.UsePrediction = Cg_ExportUsePrediction;
   cge.PredictMovement = Cg_PredictMovement;
   cge.UpdateLoading = Cg_UpdateLoading;
   cge.PrepareScene = Cg_PrepareScene;

--- a/src/cgame/common/cg_module.h
+++ b/src/cgame/common/cg_module.h
@@ -162,6 +162,59 @@ typedef bool (*ClipEntity)(const cl_entity_t *mover, const cl_entity_t *ent, con
 extern ClipEntity Cg_ClipEntity;
 
 /**
+ * @brief Whether the client predicts its own movement this frame. The default
+ * says no for demos, the third person view, a dead or frozen player, a frame
+ * with nothing to delta from, or when `cg_predict` is off.
+ * @details Chainable. A feature that cannot vouch for its prediction - one whose
+ * physics the server has not yet confirmed, say - answers false and otherwise
+ * defers to previous.
+ * @return True to predict.
+ */
+typedef bool (*UsePrediction)(void);
+
+extern UsePrediction Cg_UsePrediction;
+
+/**
+ * @brief Builds the movement command from the client's input: the movement,
+ * the buttons, and the muzzle for an attack. The default reads the bound keys.
+ * @details Chainable. A feature adding an input reads its own key, sets what it
+ * sets on `cmd` and defers to previous.
+ */
+typedef void (*Move)(pm_cmd_t *cmd);
+
+extern Move Cg_Move;
+
+/**
+ * @brief A pending command with time is about to be run through `Pm_Move` for
+ * prediction. The move is set up once from the last server frame and carried
+ * through every pending command, so whatever a feature sets on it here - a
+ * training aid installing `pm->Accelerate`, say - stays set for the commands
+ * that follow.
+ * @details Notification; the tail does nothing.
+ */
+typedef void (*MoveCommandWillRun)(pm_move_t *pm, const cl_cmd_t *cmd);
+
+extern MoveCommandWillRun Cg_MoveCommandWillRun;
+
+/**
+ * @brief A pending command with time has been run through `Pm_Move` for
+ * prediction.
+ * @details Notification; the tail does nothing.
+ */
+typedef void (*MoveCommandDidRun)(const pm_move_t *pm, const cl_cmd_t *cmd);
+
+extern MoveCommandDidRun Cg_MoveCommandDidRun;
+
+/**
+ * @brief Every pending command has been predicted and `pm` holds the result
+ * the view will be rendered from.
+ * @details Notification; the tail does nothing.
+ */
+typedef void (*PredictionDidComplete)(const pm_move_t *pm);
+
+extern PredictionDidComplete Cg_PredictionDidComplete;
+
+/**
  * @}
  * @defgroup cg-hooks-messages Messages
  * @brief What the server sends. Tails in cg_main.c.

--- a/src/cgame/common/cg_predict.c
+++ b/src/cgame/common/cg_predict.c
@@ -25,7 +25,7 @@
 /**
  * @brief Returns true if client side prediction should be used.
  */
-bool Cg_UsePrediction(void) {
+static bool Cg_UsePrediction_Common(void) {
 
   if (!cg_predict->value) {
     return false;
@@ -53,6 +53,32 @@ bool Cg_UsePrediction(void) {
 
   return true;
 }
+
+UsePrediction Cg_UsePrediction = Cg_UsePrediction_Common;
+
+/**
+ * @brief The `UsePrediction` export. The client holds this rather than the chain head, so
+ * that the chain a module installs from `Cg_Module_Init` is the one that gets
+ * called.
+ */
+bool Cg_ExportUsePrediction(void) {
+  return Cg_UsePrediction();
+}
+
+static void Cg_MoveCommandWillRun_Common(pm_move_t *pm, const cl_cmd_t *cmd) {
+}
+
+MoveCommandWillRun Cg_MoveCommandWillRun = Cg_MoveCommandWillRun_Common;
+
+static void Cg_MoveCommandDidRun_Common(const pm_move_t *pm, const cl_cmd_t *cmd) {
+}
+
+MoveCommandDidRun Cg_MoveCommandDidRun = Cg_MoveCommandDidRun_Common;
+
+static void Cg_PredictionDidComplete_Common(const pm_move_t *pm) {
+}
+
+PredictionDidComplete Cg_PredictionDidComplete = Cg_PredictionDidComplete_Common;
 
 /**
  * @brief Trace wrapper for `Pm_Move`.
@@ -119,12 +145,19 @@ void Cg_PredictMovement(const Vector *cmds) {
 
       // simulate the movement
       pm.cmd = cmd->cmd;
+
+      Cg_MoveCommandWillRun(&pm, cmd);
+
       Pm_Move(&pm);
+
+      Cg_MoveCommandDidRun(&pm, cmd);
     }
 
     // save for error detection
     cmd->prediction.origin = pm.s.origin;
   }
+
+  Cg_PredictionDidComplete(&pm);
 
   // save for rendering
   if (Vec3_Distance(pr->view.origin, pm.s.origin) > TRACE_EPSILON) {

--- a/src/cgame/common/cg_predict.h
+++ b/src/cgame/common/cg_predict.h
@@ -24,7 +24,7 @@
 #include "cg_types.h"
 
 #if defined(__CG_LOCAL_H__)
-bool Cg_UsePrediction(void);
+bool Cg_ExportUsePrediction(void);
 void Cg_PredictMovement(const Vector *cmds);
 bool Cg_ExportClipEntity(const cl_entity_t *mover, const cl_entity_t *ent, const vec3_t start, const vec3_t end, const box3_t bounds);
 #endif


### PR DESCRIPTION
## Summary

Second D11 batch on #963: the seams that retire the fork's shadows of `cg_predict.c` and `cg_input.c`.

- **Decisions:** `UsePrediction()` (tail = the former `Cg_UsePrediction`; a feature that cannot vouch for its physics answers false) and `Move(cmd)` (tail = the former `Cg_Move`; a feature adding an input reads its key and defers to previous). Both exported through wrappers, as `ClipEntity` is, because `Cg_LoadCgame` fills `cge` before `Cg_Module_Init` installs any chain.
- **Notifications:** `MoveCommandWillRun(pm, cmd)` / `MoveCommandDidRun(pm, cmd)` around `Pm_Move` for each pending command with time, and `PredictionDidComplete(pm)` after the loop. The move is set up once and carried through every command, so a training aid can install `pm->Accelerate` (#979) in `WillRun`.

Tails are the previous code paths or no-ops; default / ctf / lithium are unchanged.

## Test plan

- [x] all cgame modules build with no warnings
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)