### PR TITLE
Show the vote and let the player call one

### DIFF
--- a/Quetoo.vs15/cgame-ctf.vcxproj
+++ b/Quetoo.vs15/cgame-ctf.vcxproj
@@ -67,7 +67,7 @@
            These are per project rather than in QuetooFullIncludePath because
            every module has a cg_local.h and a g_types.h: one global list
            would make them ambiguous. -->
-      <AdditionalIncludeDirectories>..\src\cgame\ctf;..\src\cgame\common;..\src\cgame\common\ui;..\src\cgame\common\ui\controls;..\src\cgame\common\ui\credits;..\src\cgame\common\ui\editor;..\src\cgame\common\ui\home;..\src\cgame\common\ui\main;..\src\cgame\common\ui\play;..\src\cgame\common\ui\settings;..\src\cgame\common\ui\teams;..\src\cgame;..\src\game\ctf;..\src\game\common;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\src\cgame\ctf;..\src\cgame\common;..\src\cgame\common\ui;..\src\cgame\common\ui\controls;..\src\cgame\common\ui\credits;..\src\cgame\common\ui\editor;..\src\cgame\common\ui\home;..\src\cgame\common\ui\main;..\src\cgame\common\ui\play;..\src\cgame\common\ui\settings;..\src\cgame\common\ui\teams;..\src\cgame\common\ui\vote;..\src\cgame;..\src\game\ctf;..\src\game\common;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <!-- These switch the optional features on in the common sources. Set
            here rather than through
            $(ExtraPreprocessorDefinitions), which expands empty by the time

--- a/Quetoo.vs15/cgame-ctf.vcxproj.filters
+++ b/Quetoo.vs15/cgame-ctf.vcxproj.filters
@@ -126,6 +126,9 @@
     <ClInclude Include="..\src\cgame\common\cg_ctf.h">
       <Filter>src\common</Filter>
     </ClInclude>
+    <ClInclude Include="..\src\cgame\common\cg_vote.h">
+      <Filter>src\common</Filter>
+    </ClInclude>
     <ClInclude Include="..\src\cgame\common\cg_tech.h">
       <Filter>src\common</Filter>
     </ClInclude>
@@ -374,6 +377,9 @@
     <ClCompile Include="..\src\cgame\common\cg_view.c">
       <Filter>src\common</Filter>
     </ClCompile>
+    <ClCompile Include="..\src\cgame\common\cg_vote.c">
+      <Filter>src\common</Filter>
+    </ClCompile>
     <ClCompile Include="..\src\cgame\common\cg_weapon.c">
       <Filter>src\common</Filter>
     </ClCompile>
@@ -478,6 +484,9 @@
     </ClCompile>
     <ClCompile Include="..\src\cgame\common\ui\teams\TeamsViewController.c">
       <Filter>src\common\ui\teams</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\cgame\common\ui\vote\VoteViewController.c">
+      <Filter>src\common\ui\vote</Filter>
     </ClCompile>
     <ClCompile Include="..\deps\discord-rpc\src\connection_win.cpp">
       <Filter>deps\discord-rpc\src</Filter>

--- a/Quetoo.vs15/cgame-lithium.vcxproj
+++ b/Quetoo.vs15/cgame-lithium.vcxproj
@@ -66,7 +66,7 @@
            These are per project rather than in QuetooFullIncludePath because
            every module has a cg_local.h and a g_types.h: one global list
            would make them ambiguous. -->
-      <AdditionalIncludeDirectories>..\src\cgame\lithium;..\src\cgame\common;..\src\cgame\common\ui;..\src\cgame\common\ui\controls;..\src\cgame\common\ui\credits;..\src\cgame\common\ui\editor;..\src\cgame\common\ui\home;..\src\cgame\common\ui\main;..\src\cgame\common\ui\play;..\src\cgame\common\ui\settings;..\src\cgame\common\ui\teams;..\src\cgame;..\src\game\lithium;..\src\game\common;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\src\cgame\lithium;..\src\cgame\common;..\src\cgame\common\ui;..\src\cgame\common\ui\controls;..\src\cgame\common\ui\credits;..\src\cgame\common\ui\editor;..\src\cgame\common\ui\home;..\src\cgame\common\ui\main;..\src\cgame\common\ui\play;..\src\cgame\common\ui\settings;..\src\cgame\common\ui\teams;..\src\cgame\common\ui\vote;..\src\cgame;..\src\game\lithium;..\src\game\common;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <!-- These switch the optional features on in the common sources. Set
            here rather than through
            $(ExtraPreprocessorDefinitions), which expands empty by the time

--- a/Quetoo.vs15/cgame-lithium.vcxproj.filters
+++ b/Quetoo.vs15/cgame-lithium.vcxproj.filters
@@ -368,6 +368,9 @@
     <ClCompile Include="..\src\cgame\common\cg_view.c">
       <Filter>src\common</Filter>
     </ClCompile>
+    <ClCompile Include="..\src\cgame\common\cg_vote.c">
+      <Filter>src\common</Filter>
+    </ClCompile>
     <ClCompile Include="..\src\cgame\common\cg_weapon.c">
       <Filter>src\common</Filter>
     </ClCompile>
@@ -472,6 +475,9 @@
     </ClCompile>
     <ClCompile Include="..\src\cgame\common\ui\teams\TeamsViewController.c">
       <Filter>src\common\ui\teams</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\cgame\common\ui\vote\VoteViewController.c">
+      <Filter>src\common\ui\vote</Filter>
     </ClCompile>
     <ClCompile Include="..\deps\discord-rpc\src\connection_win.cpp">
       <Filter>deps\discord-rpc\src</Filter>

--- a/Quetoo.vs15/cgame.vcxproj
+++ b/Quetoo.vs15/cgame.vcxproj
@@ -59,7 +59,7 @@
            These are per project rather than in QuetooFullIncludePath because
            every module has a cg_local.h and a g_types.h: one global list
            would make them ambiguous. -->
-      <AdditionalIncludeDirectories>..\src\cgame\default;..\src\cgame\common;..\src\cgame\common\ui;..\src\cgame\common\ui\controls;..\src\cgame\common\ui\credits;..\src\cgame\common\ui\editor;..\src\cgame\common\ui\home;..\src\cgame\common\ui\main;..\src\cgame\common\ui\play;..\src\cgame\common\ui\settings;..\src\cgame\common\ui\teams;..\src\cgame;..\src\game\default;..\src\game\common;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\src\cgame\default;..\src\cgame\common;..\src\cgame\common\ui;..\src\cgame\common\ui\controls;..\src\cgame\common\ui\credits;..\src\cgame\common\ui\editor;..\src\cgame\common\ui\home;..\src\cgame\common\ui\main;..\src\cgame\common\ui\play;..\src\cgame\common\ui\settings;..\src\cgame\common\ui\teams;..\src\cgame\common\ui\vote;..\src\cgame;..\src\game\default;..\src\game\common;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalOptions>%(AdditionalOptions) -ffp-contract=off</AdditionalOptions>
     </ClCompile>
     <Link>

--- a/Quetoo.vs15/cgame.vcxproj.filters
+++ b/Quetoo.vs15/cgame.vcxproj.filters
@@ -362,6 +362,9 @@
     <ClCompile Include="..\src\cgame\common\cg_view.c">
       <Filter>src\common</Filter>
     </ClCompile>
+    <ClCompile Include="..\src\cgame\common\cg_vote.c">
+      <Filter>src\common</Filter>
+    </ClCompile>
     <ClCompile Include="..\src\cgame\common\cg_weapon.c">
       <Filter>src\common</Filter>
     </ClCompile>
@@ -466,6 +469,9 @@
     </ClCompile>
     <ClCompile Include="..\src\cgame\common\ui\teams\TeamsViewController.c">
       <Filter>src\common\ui\teams</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\cgame\common\ui\vote\VoteViewController.c">
+      <Filter>src\common\ui\vote</Filter>
     </ClCompile>
     <ClCompile Include="..\deps\discord-rpc\src\connection_win.cpp">
       <Filter>deps\discord-rpc\src</Filter>

--- a/Quetoo.vs15/cgame_common.props
+++ b/Quetoo.vs15/cgame_common.props
@@ -67,6 +67,7 @@
     <ClInclude Include="..\src\cgame\common\cg_ui.h" />
     <ClCompile Include="..\src\cgame\common\cg_view.c" />
     <ClInclude Include="..\src\cgame\common\cg_view.h" />
+    <ClCompile Include="..\src\cgame\common\cg_vote.c" />
     <ClCompile Include="..\src\cgame\common\cg_weapon.c" />
     <ClInclude Include="..\src\cgame\common\cg_weapon.h" />
   </ItemGroup>
@@ -139,6 +140,8 @@
     <ClInclude Include="..\src\cgame\common\ui\teams\TeamView.h" />
     <ClCompile Include="..\src\cgame\common\ui\teams\TeamsViewController.c" />
     <ClInclude Include="..\src\cgame\common\ui\teams\TeamsViewController.h" />
+    <ClCompile Include="..\src\cgame\common\ui\vote\VoteViewController.c" />
+    <ClInclude Include="..\src\cgame\common\ui\vote\VoteViewController.h" />
   </ItemGroup>
   <!-- Capture the flag, for modules that opt in by setting QuetooCgameCtf and
        defining G_CTF; the counterpart of listing cg_ctf.c in a module's
@@ -146,6 +149,7 @@
   <ItemGroup Condition="'$(QuetooCgameCtf)'=='true'">
     <ClCompile Include="..\src\cgame\common\cg_ctf.c" />
     <ClInclude Include="..\src\cgame\common\cg_ctf.h" />
+    <ClInclude Include="..\src\cgame\common\cg_vote.h" />
   </ItemGroup>
   <!-- The tech powerups, on the same terms: QuetooCgameTech and G_TECH. -->
   <ItemGroup Condition="'$(QuetooCgameTech)'=='true'">

--- a/Quetoo.xcodeproj/project.pbxproj
+++ b/Quetoo.xcodeproj/project.pbxproj
@@ -202,6 +202,7 @@
 		CE05B3F030224900C0DE0015 /* cg_muzzle_flash.c in Sources */ = {isa = PBXBuildFile; fileRef = CE12D5731C5C58C300CD0B13 /* cg_muzzle_flash.c */; };
 		CE05B3F030224900C0DE0016 /* cg_predict.c in Sources */ = {isa = PBXBuildFile; fileRef = CE12D5771C5C58C300CD0B13 /* cg_predict.c */; };
 		CE05B3F030224900C0DE0017 /* cg_score.c in Sources */ = {isa = PBXBuildFile; fileRef = CE12D5791C5C58C300CD0B13 /* cg_score.c */; };
+		D1A5B0000000000000000202 /* cg_vote.c in Sources */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000201 /* cg_vote.c */; };
 		CE05B3F030224900C0DE0018 /* cg_sound.c in Sources */ = {isa = PBXBuildFile; fileRef = CEBDD1B525A0C2710055860E /* cg_sound.c */; };
 		CE05B3F030224900C0DE0019 /* cg_sprite.c in Sources */ = {isa = PBXBuildFile; fileRef = CEAC32B7242124BB007E1253 /* cg_sprite.c */; };
 		CE05B3FC30224E3E0012870B /* cg_module.c in Sources */ = {isa = PBXBuildFile; fileRef = CE05B3FC30224E3E0012870A /* cg_module.c */; };
@@ -240,6 +241,7 @@
 		CE05B3F030224900C0DE003B /* StatsViewController.c in Sources */ = {isa = PBXBuildFile; fileRef = CEA9B3B36C6E4B3A9F010001 /* StatsViewController.c */; };
 		CE05B3F030224900C0DE003C /* TeamPlayerView.c in Sources */ = {isa = PBXBuildFile; fileRef = CEFF1376277FB721001E1500 /* TeamPlayerView.c */; };
 		CE05B3F030224900C0DE003D /* TeamsViewController.c in Sources */ = {isa = PBXBuildFile; fileRef = CEAA78182775337300EAC853 /* TeamsViewController.c */; };
+		D1A5B0000000000000000206 /* VoteViewController.c in Sources */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000205 /* VoteViewController.c */; };
 		CE05B3F030224900C0DE003E /* TeamView.c in Sources */ = {isa = PBXBuildFile; fileRef = CEAA78EB2775388700EAC853 /* TeamView.c */; };
 		CE05B3F030224900C0DE003F /* UpdateViewController.c in Sources */ = {isa = PBXBuildFile; fileRef = CEAD8FB82F93A4990087A850 /* UpdateViewController.c */; };
 		CE05B3F030224900C0DE0040 /* cg_client.h in Headers */ = {isa = PBXBuildFile; fileRef = CE12D55F1C5C58C300CD0B13 /* cg_client.h */; };
@@ -312,6 +314,7 @@
 		CE12D7F91C5C5E0200CD0B13 /* cg_muzzle_flash.c in Sources */ = {isa = PBXBuildFile; fileRef = CE12D5731C5C58C300CD0B13 /* cg_muzzle_flash.c */; };
 		CE12D7FB1C5C5E0200CD0B13 /* cg_predict.c in Sources */ = {isa = PBXBuildFile; fileRef = CE12D5771C5C58C300CD0B13 /* cg_predict.c */; };
 		CE12D7FC1C5C5E0200CD0B13 /* cg_score.c in Sources */ = {isa = PBXBuildFile; fileRef = CE12D5791C5C58C300CD0B13 /* cg_score.c */; };
+		D1A5B0000000000000000203 /* cg_vote.c in Sources */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000201 /* cg_vote.c */; };
 		CE12D7FD1C5C5E0200CD0B13 /* cg_temp_entity.c in Sources */ = {isa = PBXBuildFile; fileRef = CE12D57B1C5C58C300CD0B13 /* cg_temp_entity.c */; };
 		CE12D7FE1C5C5E0200CD0B13 /* cg_view.c in Sources */ = {isa = PBXBuildFile; fileRef = CE12D57E1C5C58C300CD0B13 /* cg_view.c */; };
 		CE12D8C41C5CF86600CD0B13 /* main.c in Sources */ = {isa = PBXBuildFile; fileRef = CE12D67A1C5C58C300CD0B13 /* main.c */; };
@@ -682,10 +685,13 @@
 		CEA9B3A76C6E4B3A9F010001 /* LeaderboardViewController.json in CopyFiles */ = {isa = PBXBuildFile; fileRef = CEA9B3B76C6E4B3A9F010001 /* LeaderboardViewController.json */; };
 		CEA9B3A86C6E4B3A9F010001 /* StatsViewController.json in CopyFiles */ = {isa = PBXBuildFile; fileRef = CEA9B3B86C6E4B3A9F010001 /* StatsViewController.json */; };
 		CEAA781A2775337300EAC853 /* TeamsViewController.c in Sources */ = {isa = PBXBuildFile; fileRef = CEAA78182775337300EAC853 /* TeamsViewController.c */; };
+		D1A5B0000000000000000207 /* VoteViewController.c in Sources */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000205 /* VoteViewController.c */; };
 		CEAA78ED2775388700EAC853 /* TeamView.c in Sources */ = {isa = PBXBuildFile; fileRef = CEAA78EB2775388700EAC853 /* TeamView.c */; };
 		CEAA797827753A5500EAC853 /* TeamView.json in CopyFiles */ = {isa = PBXBuildFile; fileRef = CEAA79542775396800EAC853 /* TeamView.json */; };
 		CEAA7A0C27753C7300EAC853 /* TeamsViewController.css in CopyFiles */ = {isa = PBXBuildFile; fileRef = CEAA7A0B27753AEF00EAC853 /* TeamsViewController.css */; };
+		D1A5B0000000000000000212 /* VoteViewController.css in CopyFiles */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000211 /* VoteViewController.css */; };
 		CEAA7A2F27753C7500EAC853 /* TeamsViewController.json in CopyFiles */ = {isa = PBXBuildFile; fileRef = CEAA7A0A27753AD400EAC853 /* TeamsViewController.json */; };
+		D1A5B0000000000000000210 /* VoteViewController.json in CopyFiles */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000209 /* VoteViewController.json */; };
 		CEAB00032EC1A00000000003 /* sv_http.c in Sources */ = {isa = PBXBuildFile; fileRef = CEAB00012EC1A00000000001 /* sv_http.c */; };
 		CEAB00042EC1A00000000004 /* sv_http.h in Headers */ = {isa = PBXBuildFile; fileRef = CEAB00022EC1A00000000002 /* sv_http.h */; };
 		CEAB00052EC1A00000000005 /* sv_map_list.c in Sources */ = {isa = PBXBuildFile; fileRef = CEAB00072EC1A00000000007 /* sv_map_list.c */; };
@@ -732,6 +738,7 @@
 		CEC0FD002026010500000002 /* cg_hud.c in Sources */ = {isa = PBXBuildFile; fileRef = CE12D56C1C5C58C300CD0B13 /* cg_hud.c */; };
 		CEC0FD002026010500000004 /* cg_hud.h in Headers */ = {isa = PBXBuildFile; fileRef = CE12D56D1C5C58C300CD0B13 /* cg_hud.h */; };
 		CEC0FD002026010500000006 /* cg_score.c in Sources */ = {isa = PBXBuildFile; fileRef = CE12D5791C5C58C300CD0B13 /* cg_score.c */; };
+		D1A5B0000000000000000204 /* cg_vote.c in Sources */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000201 /* cg_vote.c */; };
 		CEC0FD002026010500000008 /* cg_score.h in Headers */ = {isa = PBXBuildFile; fileRef = CE12D57A1C5C58C300CD0B13 /* cg_score.h */; };
 		CEC0FD00202601050000000A /* cg_hud_draw.c in Sources */ = {isa = PBXBuildFile; fileRef = CEC0FD002026010500000009 /* cg_hud_draw.c */; };
 		CEC0FD00202601050000000C /* cg_hud_draw.c in Sources */ = {isa = PBXBuildFile; fileRef = CEC0FD002026010500000009 /* cg_hud_draw.c */; };
@@ -834,6 +841,7 @@
 		CEC0FF00202601030000019C /* TeamPlayerView.c in Sources */ = {isa = PBXBuildFile; fileRef = CEFF1376277FB721001E1500 /* TeamPlayerView.c */; };
 		CEC0FF00202601030000019D /* TeamView.c in Sources */ = {isa = PBXBuildFile; fileRef = CEAA78EB2775388700EAC853 /* TeamView.c */; };
 		CEC0FF00202601030000019E /* TeamsViewController.c in Sources */ = {isa = PBXBuildFile; fileRef = CEAA78182775337300EAC853 /* TeamsViewController.c */; };
+		D1A5B0000000000000000208 /* VoteViewController.c in Sources */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000205 /* VoteViewController.c */; };
 		CEC0FF00202601030000019F /* UpdateViewController.c in Sources */ = {isa = PBXBuildFile; fileRef = CEAD8FB82F93A4990087A850 /* UpdateViewController.c */; };
 		CEC0FF0020260103000001D5 /* SDL3.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = CE1643492FF5A12100863996 /* SDL3.xcframework */; };
 		CEC0FF0020260103000001D6 /* Objectively.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CEF601BA2FE60508005C680C /* Objectively.framework */; };
@@ -1493,7 +1501,9 @@
 			files = (
 				CEFF1426277FB7C8001E1500 /* TeamPlayerView.json in CopyFiles */,
 				CEAA7A0C27753C7300EAC853 /* TeamsViewController.css in CopyFiles */,
+				D1A5B0000000000000000212 /* VoteViewController.css in CopyFiles */,
 				CEAA7A2F27753C7500EAC853 /* TeamsViewController.json in CopyFiles */,
+				D1A5B0000000000000000210 /* VoteViewController.json in CopyFiles */,
 				CEAA797827753A5500EAC853 /* TeamView.json in CopyFiles */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1583,6 +1593,7 @@
 		CE12D5721C5C58C300CD0B13 /* cg_media.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = cg_media.h; sourceTree = "<group>"; };
 		CE12D5721C5C58C300CD0D01 /* cg_ctf.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = cg_ctf.c; sourceTree = "<group>"; };
 		CE12D5721C5C58C300CD0D02 /* cg_ctf.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = cg_ctf.h; sourceTree = "<group>"; };
+		D1A5B0000000000000000213 /* cg_vote.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = cg_vote.h; sourceTree = "<group>"; };
 		CE12D5721C5C58C300CD0D03 /* cg_tech.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = cg_tech.c; sourceTree = "<group>"; };
 		CE12D5721C5C58C300CD0D04 /* cg_tech.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = cg_tech.h; sourceTree = "<group>"; };
 		CE12D5721C5C58C300CD0C21 /* cg_module.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = cg_module.h; sourceTree = "<group>"; };
@@ -1591,6 +1602,7 @@
 		CE12D5771C5C58C300CD0B13 /* cg_predict.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; lineEnding = 0; path = cg_predict.c; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.c; };
 		CE12D5781C5C58C300CD0B13 /* cg_predict.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = cg_predict.h; sourceTree = "<group>"; };
 		CE12D5791C5C58C300CD0B13 /* cg_score.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = cg_score.c; sourceTree = "<group>"; };
+		D1A5B0000000000000000201 /* cg_vote.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = cg_vote.c; sourceTree = "<group>"; };
 		CE12D57A1C5C58C300CD0B13 /* cg_score.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = cg_score.h; sourceTree = "<group>"; };
 		CE12D57B1C5C58C300CD0B13 /* cg_temp_entity.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = cg_temp_entity.c; sourceTree = "<group>"; };
 		CE12D57C1C5C58C300CD0B13 /* cg_temp_entity.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = cg_temp_entity.h; sourceTree = "<group>"; };
@@ -2171,11 +2183,14 @@
 		CEA9B3B86C6E4B3A9F010001 /* StatsViewController.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = StatsViewController.json; sourceTree = "<group>"; };
 		CEAA77F02775333300EAC853 /* TeamsViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TeamsViewController.h; sourceTree = "<group>"; };
 		CEAA78182775337300EAC853 /* TeamsViewController.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = TeamsViewController.c; sourceTree = "<group>"; };
+		D1A5B0000000000000000205 /* VoteViewController.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = VoteViewController.c; sourceTree = "<group>"; };
 		CEAA78EA2775388700EAC853 /* TeamView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TeamView.h; sourceTree = "<group>"; };
 		CEAA78EB2775388700EAC853 /* TeamView.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = TeamView.c; sourceTree = "<group>"; };
 		CEAA79542775396800EAC853 /* TeamView.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = TeamView.json; sourceTree = "<group>"; };
 		CEAA7A0A27753AD400EAC853 /* TeamsViewController.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = TeamsViewController.json; sourceTree = "<group>"; };
+		D1A5B0000000000000000209 /* VoteViewController.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = VoteViewController.json; sourceTree = "<group>"; };
 		CEAA7A0B27753AEF00EAC853 /* TeamsViewController.css */ = {isa = PBXFileReference; lastKnownFileType = text.css; path = TeamsViewController.css; sourceTree = "<group>"; };
+		D1A5B0000000000000000211 /* VoteViewController.css */ = {isa = PBXFileReference; lastKnownFileType = text.css; path = VoteViewController.css; sourceTree = "<group>"; };
 		CEAAA50C25C6E75000EE81B3 /* Quetoo.app */ = {isa = PBXFileReference; lastKnownFileType = wrapper.application; path = Quetoo.app; sourceTree = "<group>"; };
 		CEAB00012EC1A00000000001 /* sv_http.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = sv_http.c; sourceTree = "<group>"; };
 		CEAB00022EC1A00000000002 /* sv_http.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = sv_http.h; sourceTree = "<group>"; };
@@ -3777,9 +3792,12 @@
 				CEFF1378277FB721001E1500 /* TeamPlayerView.h */,
 				CEFF1377277FB721001E1500 /* TeamPlayerView.json */,
 				CEAA78182775337300EAC853 /* TeamsViewController.c */,
+				D1A5B0000000000000000205 /* VoteViewController.c */,
 				CEAA7A0B27753AEF00EAC853 /* TeamsViewController.css */,
+				D1A5B0000000000000000211 /* VoteViewController.css */,
 				CEAA77F02775333300EAC853 /* TeamsViewController.h */,
 				CEAA7A0A27753AD400EAC853 /* TeamsViewController.json */,
+				D1A5B0000000000000000209 /* VoteViewController.json */,
 				CEAA78EB2775388700EAC853 /* TeamView.c */,
 				CEAA78EA2775388700EAC853 /* TeamView.h */,
 				CEAA79542775396800EAC853 /* TeamView.json */,
@@ -3815,6 +3833,7 @@
 				CE12D56C1C5C58C300CD0B13 /* cg_hud.c */,
 				CE12D56D1C5C58C300CD0B13 /* cg_hud.h */,
 				CE12D5791C5C58C300CD0B13 /* cg_score.c */,
+				D1A5B0000000000000000201 /* cg_vote.c */,
 				CE12D57A1C5C58C300CD0B13 /* cg_score.h */,
 				CEC0FD002026010500000009 /* cg_hud_draw.c */,
 				CEB8D6241E00B72100043814 /* cg_input.h */,
@@ -3829,6 +3848,7 @@
 				CE12D5721C5C58C300CD0B13 /* cg_media.h */,
 				CE12D5721C5C58C300CD0D01 /* cg_ctf.c */,
 				CE12D5721C5C58C300CD0D02 /* cg_ctf.h */,
+				D1A5B0000000000000000213 /* cg_vote.h */,
 				CE12D5721C5C58C300CD0D03 /* cg_tech.c */,
 				CE12D5721C5C58C300CD0D04 /* cg_tech.h */,
 				CE12D5721C5C58C300CD0C21 /* cg_module.h */,
@@ -5447,6 +5467,7 @@
 				CE05B3F030224900C0DE003B /* StatsViewController.c in Sources */,
 				CE05B3F030224900C0DE003C /* TeamPlayerView.c in Sources */,
 				CE05B3F030224900C0DE003D /* TeamsViewController.c in Sources */,
+				D1A5B0000000000000000206 /* VoteViewController.c in Sources */,
 				CE05B3F030224900C0DE003E /* TeamView.c in Sources */,
 				CE05B3F030224900C0DE003F /* UpdateViewController.c in Sources */,
 				CE05B3F030224900C0DE0001 /* bg_item.c in Sources */,
@@ -5472,6 +5493,7 @@
 				CE05B3F030224900C0DE0015 /* cg_muzzle_flash.c in Sources */,
 				CE05B3F030224900C0DE0016 /* cg_predict.c in Sources */,
 				CE05B3F030224900C0DE0017 /* cg_score.c in Sources */,
+				D1A5B0000000000000000202 /* cg_vote.c in Sources */,
 				CE05B3F030224900C0DE0018 /* cg_sound.c in Sources */,
 				CE05B3F030224900C0DE0019 /* cg_sprite.c in Sources */,
 				CE05B3FC30224E3E0012870B /* cg_module.c in Sources */,
@@ -5564,6 +5586,7 @@
 				CEA9B3A36C6E4B3A9F010001 /* StatsViewController.c in Sources */,
 				CEFF1379277FB763001E1500 /* TeamPlayerView.c in Sources */,
 				CEAA781A2775337300EAC853 /* TeamsViewController.c in Sources */,
+				D1A5B0000000000000000207 /* VoteViewController.c in Sources */,
 				CEAA78ED2775388700EAC853 /* TeamView.c in Sources */,
 				CEAD8FBC2F93A4990087A850 /* UpdateViewController.c in Sources */,
 				CEFEED000000000000000004 /* bg_item.c in Sources */,
@@ -5588,6 +5611,7 @@
 				CE12D7F91C5C5E0200CD0B13 /* cg_muzzle_flash.c in Sources */,
 				CE12D7FB1C5C5E0200CD0B13 /* cg_predict.c in Sources */,
 				CE12D7FC1C5C5E0200CD0B13 /* cg_score.c in Sources */,
+				D1A5B0000000000000000203 /* cg_vote.c in Sources */,
 				CEBDD1B725A0C2710055860E /* cg_sound.c in Sources */,
 				CEAC32B9242124BB007E1253 /* cg_sprite.c in Sources */,
 				CE12D55D1C5C58C300CD0C12 /* cg_module.c in Sources */,
@@ -5985,6 +6009,7 @@
 				CEC0FF00202601030000019B /* StatsViewController.c in Sources */,
 				CEC0FF00202601030000019C /* TeamPlayerView.c in Sources */,
 				CEC0FF00202601030000019E /* TeamsViewController.c in Sources */,
+				D1A5B0000000000000000208 /* VoteViewController.c in Sources */,
 				CEC0FF00202601030000019D /* TeamView.c in Sources */,
 				CEC0FF00202601030000019F /* UpdateViewController.c in Sources */,
 				CEFEED000000000000000005 /* bg_item.c in Sources */,
@@ -6011,6 +6036,7 @@
 				CEC0FF0020260103000001F0 /* cg_muzzle_flash.c in Sources */,
 				CEC0FF0020260103000001F1 /* cg_predict.c in Sources */,
 				CEC0FD002026010500000006 /* cg_score.c in Sources */,
+				D1A5B0000000000000000204 /* cg_vote.c in Sources */,
 				CEC0FF0020260103000001F3 /* cg_sound.c in Sources */,
 				CEC0FF0020260103000001F4 /* cg_sprite.c in Sources */,
 				CEC0FF0020260103000000A2 /* cg_module.c in Sources */,

--- a/doc/game-module-hooks.md
+++ b/doc/game-module-hooks.md
@@ -369,6 +369,7 @@ and make the block additive instead.
 | `FilterEntity` | `cg_entity.c` | — |
 | `DescribeGameMode` | `cg_discord.c` | — |
 | `DrawScores` | `cg_score.c` | — |
+| `ListVoteTypes` | `cg_vote.c` | — |
 
 `cg_hud_layout_t.draw_time` lets a module that arranges the whole HUD keep the
 clock or place it itself, where it used to have to push `stat_y` off screen.

--- a/src/cgame/common/cg_local.h
+++ b/src/cgame/common/cg_local.h
@@ -63,4 +63,5 @@
 #include "cg_types.h"
 #include "cg_ui.h"
 #include "cg_view.h"
+#include "cg_vote.h"
 #include "cg_weapon.h"

--- a/src/cgame/common/cg_main.c
+++ b/src/cgame/common/cg_main.c
@@ -195,6 +195,8 @@ static void Cg_Init(void) {
   Cg_Ctf_Init();
 #endif
 
+  Cg_Vote_Init();
+
   Cg_Module_Init();
 
   cgi.Print("Client game module initialized\n");

--- a/src/cgame/common/cg_module.h
+++ b/src/cgame/common/cg_module.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include "cg_types.h"
+#include "bg_vote.h"
 
 #if defined(__CG_LOCAL_H__)
 
@@ -340,6 +341,18 @@ extern DescribeGameMode Cg_DescribeGameMode;
 typedef void (*DrawScores)(const player_state_t *ps);
 
 extern DrawScores Cg_DrawScores;
+
+/**
+ * @brief The kinds of vote the Vote screen offers. The default is the common
+ * list in `bg_vote.h`.
+ * @details Not chained: a module with votes of its own returns a list holding
+ * the common ones and its own, so that the screen shows everything the game
+ * accepts, and the game's `PrepareVote` chain must accept every name listed.
+ * The list MUST be static storage; the screen keeps pointers into it.
+ */
+typedef const vote_type_t *(*ListVoteTypes)(size_t *count);
+
+extern ListVoteTypes Cg_ListVoteTypes;
 
 /**
  * @}

--- a/src/cgame/common/cg_types.h
+++ b/src/cgame/common/cg_types.h
@@ -205,6 +205,18 @@ typedef struct {
    * @brief The view angles to snap to.
    */
   vec3_t snap_view_angles;
+
+  /**
+   * @brief The vote in progress, from `CS_VOTE`.
+   */
+  struct {
+    bool active;
+    char type[MAX_QPATH];
+    char arg[MAX_QPATH];
+    char initiator[MAX_QPATH];
+    int32_t yes, no, eligible;
+    uint32_t deadline;
+  } vote;
 } cg_state_t;
 
 extern cg_state_t cg_state;

--- a/src/cgame/common/cg_vote.c
+++ b/src/cgame/common/cg_vote.c
@@ -1,0 +1,159 @@
+/*
+ * Copyright(c) 1997-2001 id Software, Inc.
+ * Copyright(c) 2002 The Quakeforge Project.
+ * Copyright(c) 2006 Quetoo.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+#include "cg_local.h"
+#include "bg_vote.h"
+
+static struct {
+  ParseConfigString ParseConfigString;
+  DrawHudElements DrawHudElements;
+} previous;
+
+/**
+ * @brief The tail of the `Cg_ListVoteTypes` hook: the common votes.
+ */
+static const vote_type_t *Cg_ListVoteTypes_Common(size_t *count) {
+  *count = lengthof(vote_types_common);
+  return vote_types_common;
+}
+
+ListVoteTypes Cg_ListVoteTypes = Cg_ListVoteTypes_Common;
+
+/**
+ * @brief Reads `CS_VOTE` into `cg_state.vote`.
+ */
+static bool Cg_ParseConfigString_Vote(int32_t index) {
+
+  if (index != CS_VOTE) {
+    return previous.ParseConfigString(index);
+  }
+
+  const char *s = cgi.ConfigString(index);
+
+  memset(&cg_state.vote, 0, sizeof(cg_state.vote));
+
+  if (!*s) {
+    return true;
+  }
+
+  char buf[MAX_STRING_CHARS];
+  q_strlcpy(buf, s, sizeof(buf));
+
+  // split positionally, since a field may be empty
+  char *fields[VOTE_CS_FIELDS] = { NULL };
+  size_t count = 0;
+
+  for (char *c = buf; count < VOTE_CS_FIELDS; ) {
+    fields[count++] = c;
+
+    char *sep = strchr(c, '\\');
+    if (!sep) {
+      break;
+    }
+    *sep = '\0';
+    c = sep + 1;
+  }
+
+  if (count != VOTE_CS_FIELDS) {
+    Cg_Warn("Invalid vote: %s\n", s);
+    return true;
+  }
+
+  cg_state.vote.active = true;
+  q_strlcpy(cg_state.vote.type, fields[VOTE_CS_TYPE], sizeof(cg_state.vote.type));
+  q_strlcpy(cg_state.vote.arg, fields[VOTE_CS_ARG], sizeof(cg_state.vote.arg));
+  cg_state.vote.yes = (int32_t) strtol(fields[VOTE_CS_YES], NULL, 10);
+  cg_state.vote.no = (int32_t) strtol(fields[VOTE_CS_NO], NULL, 10);
+  cg_state.vote.eligible = (int32_t) strtol(fields[VOTE_CS_ELIGIBLE], NULL, 10);
+  cg_state.vote.deadline = (uint32_t) strtoul(fields[VOTE_CS_DEADLINE], NULL, 10);
+  q_strlcpy(cg_state.vote.initiator, fields[VOTE_CS_INITIATOR], sizeof(cg_state.vote.initiator));
+
+  return true;
+}
+
+/**
+ * @brief Draws the vote in progress beneath the center of the screen.
+ */
+static void Cg_DrawHudElements_Vote(const player_state_t *ps, cg_hud_layout_t *layout) {
+
+  previous.DrawHudElements(ps, layout);
+
+  if (!cg_state.vote.active) {
+    return;
+  }
+
+  int32_t ch;
+  cgi.BindFont("small", NULL, &ch);
+
+  const uint32_t time = cgi.client->time;
+  const uint32_t left = cg_state.vote.deadline > time ? (cg_state.vote.deadline - time) / 1000 : 0;
+
+  const char *lines[] = {
+    va("%s called a vote: %s%s%s", cg_state.vote.initiator, cg_state.vote.type,
+       *cg_state.vote.arg ? " " : "", cg_state.vote.arg),
+    va("Yes %d  No %d  of %d  %us", cg_state.vote.yes, cg_state.vote.no, cg_state.vote.eligible, left),
+  };
+
+  int32_t y = cgi.context->h / 2 + 4 * ch;
+
+  for (size_t i = 0; i < lengthof(lines); i++) {
+    const int32_t x = (cgi.context->w - cgi.StringWidth(lines[i])) / 2;
+    cgi.Draw2DString(x, y, lines[i], i ? color_white : color_green);
+    y += ch;
+  }
+
+  cgi.BindFont(NULL, NULL, NULL);
+}
+
+/**
+ * @see cg_vote.h
+ */
+void Cg_Vote_Cast(bool yes) {
+  cgi.Cbuf(va("vote %s\n", yes ? "yes" : "no"));
+}
+
+/**
+ * @see cg_vote.h
+ */
+void Cg_Vote_Call(const char *type, const char *arg) {
+  cgi.Cbuf(va("vote %s \"%s\"\n", type, arg));
+}
+
+/**
+ * @brief Installs voting over the hooks it needs, once per module image.
+ */
+void Cg_Vote_Init(void) {
+  static bool installed;
+
+  cgi.AddCmd("vote", NULL, CMD_CGAME, "Call a vote, or cast one: vote <type> [argument], vote yes, vote no");
+
+  if (installed) {
+    return;
+  }
+
+  previous.ParseConfigString = Cg_ParseConfigString;
+  Cg_ParseConfigString = Cg_ParseConfigString_Vote;
+
+  previous.DrawHudElements = Cg_DrawHudElements;
+  Cg_DrawHudElements = Cg_DrawHudElements_Vote;
+
+  installed = true;
+}

--- a/src/cgame/common/cg_vote.h
+++ b/src/cgame/common/cg_vote.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright(c) 1997-2001 id Software, Inc.
+ * Copyright(c) 2002 The Quakeforge Project.
+ * Copyright(c) 2006 Quetoo.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+#pragma once
+
+#include "cg_types.h"
+
+#if defined(__CG_LOCAL_H__)
+void Cg_Vote_Init(void);
+void Cg_Vote_Cast(bool yes);
+void Cg_Vote_Call(const char *type, const char *arg);
+#endif

--- a/src/cgame/common/ui/main/MainViewController.c
+++ b/src/cgame/common/ui/main/MainViewController.c
@@ -30,6 +30,7 @@
 #include "SettingsViewController.h"
 
 #include "TeamsViewController.h"
+#include "VoteViewController.h"
 
 #include "DialogViewController.h"
 
@@ -190,6 +191,12 @@ static void loadView(ViewController *self) {
     .didClick = didClickNavigateViewController,
     .self = self,
     .data = _TeamsViewController()
+  });
+
+  $(this, secondaryButton, "Vote", &(const ButtonDelegate) {
+    .didClick = didClickNavigateViewController,
+    .self = self,
+    .data = _VoteViewController()
   });
 
   $(this, secondaryButton, "Disconnect", &(const ButtonDelegate) {

--- a/src/cgame/common/ui/vote/VoteViewController.c
+++ b/src/cgame/common/ui/vote/VoteViewController.c
@@ -1,0 +1,237 @@
+/*
+ * Copyright(c) 1997-2001 id Software, Inc.
+ * Copyright(c) 2002 The Quakeforge Project.
+ * Copyright(c) 2006 Quetoo.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+#include "cg_local.h"
+#include "bg_vote.h"
+
+#include "VoteViewController.h"
+
+#define _Class _VoteViewController
+
+#pragma mark - Delegates
+
+static void didClickYes(Button *button) {
+  Cg_Vote_Cast(true);
+  cgi.SetKeyDest(KEY_GAME);
+}
+
+static void didClickNo(Button *button) {
+  Cg_Vote_Cast(false);
+  cgi.SetKeyDest(KEY_GAME);
+}
+
+/**
+ * @brief Shows the argument control the selected vote type takes.
+ */
+static void didSelectType(Select *select, Option *option) {
+
+  VoteViewController *this = select->delegate.self;
+  const vote_type_t *type = option->value;
+
+  ((View *) this->map)->superview->hidden = type->arg != VOTE_ARG_MAP;
+  ((View *) this->client)->superview->hidden = type->arg != VOTE_ARG_CLIENT;
+  ((View *) this->value)->superview->hidden = type->arg != VOTE_ARG_INTEGER;
+
+  if (type->arg == VOTE_ARG_INTEGER) {
+    this->value->min = type->min;
+    this->value->max = type->max;
+    this->value->step = 1.0;
+    $(this->value, setValue, Clampf(this->value->value, type->min, type->max));
+  }
+}
+
+static void didClickCall(Button *button) {
+
+  VoteViewController *this = button->delegate.self;
+
+  const Option *selected = $(this->type, selectedOption);
+  if (!selected) {
+    return;
+  }
+
+  const vote_type_t *type = selected->value;
+  const char *arg = "";
+
+  switch (type->arg) {
+    case VOTE_ARG_NONE:
+      break;
+    case VOTE_ARG_MAP: {
+      const Option *option = $(this->map, selectedOption);
+      if (!option) {
+        return;
+      }
+      arg = option->title->text;
+      break;
+    }
+    case VOTE_ARG_CLIENT: {
+      const Option *option = $(this->client, selectedOption);
+      if (!option) {
+        return;
+      }
+      arg = option->title->text;
+      break;
+    }
+    case VOTE_ARG_INTEGER:
+      arg = va("%d", (int32_t) this->value->value);
+      break;
+  }
+
+  Cg_Vote_Call(type->name, arg);
+  cgi.SetKeyDest(KEY_GAME);
+}
+
+#pragma mark - Options
+
+/**
+ * @brief Fs_Enumerator adding each installed map to the map select.
+ */
+static void enumerateMaps(const char *path, void *data) {
+
+  Select *select = data;
+
+  char name[MAX_QPATH];
+  StripExtension(Basename(path), name);
+
+  $(select, addOption, name, NULL);
+}
+
+static void refreshClients(VoteViewController *this) {
+
+  $(this->client, removeAllOptions);
+
+  for (int32_t i = 0; i < cg_state.max_clients; i++) {
+    const cg_client_info_t *ci = &cg_state.clients[i];
+    if (*ci->name) {
+      $(this->client, addOption, ci->name, NULL);
+    }
+  }
+}
+
+static void refreshStatus(VoteViewController *this) {
+
+  const bool active = cg_state.vote.active;
+
+  if (active) {
+    $(this->status->text, setText, va("%s called a vote: %s%s%s  (Yes %d  No %d of %d)",
+                                      cg_state.vote.initiator, cg_state.vote.type,
+                                      *cg_state.vote.arg ? " " : "", cg_state.vote.arg,
+                                      cg_state.vote.yes, cg_state.vote.no, cg_state.vote.eligible));
+  } else {
+    $(this->status->text, setText, "No vote is in progress");
+  }
+
+  this->yes->control.view.hidden = !active;
+  this->no->control.view.hidden = !active;
+}
+
+#pragma mark - ViewController
+
+static void loadView(ViewController *self) {
+
+  super(ViewController, self, loadView);
+
+  VoteViewController *this = (VoteViewController *) self;
+
+  Outlet outlets[] = MakeOutlets(
+    MakeOutlet("status", &this->status),
+    MakeOutlet("yes", &this->yes),
+    MakeOutlet("no", &this->no),
+    MakeOutlet("type", &this->type),
+    MakeOutlet("map", &this->map),
+    MakeOutlet("client", &this->client),
+    MakeOutlet("value", &this->value),
+    MakeOutlet("call", &this->call)
+  );
+
+  View *view = $$(View, viewWithResourceName, "ui/vote/VoteViewController.json", outlets);
+  assert(view);
+
+  this->yes->delegate.didClick = didClickYes;
+  this->yes->delegate.self = self;
+
+  this->no->delegate.didClick = didClickNo;
+  this->no->delegate.self = self;
+
+  this->call->delegate.didClick = didClickCall;
+  this->call->delegate.self = self;
+
+  this->type->delegate.didSelectOption = didSelectType;
+  this->type->delegate.self = self;
+
+  size_t count;
+  const vote_type_t *types = Cg_ListVoteTypes(&count);
+  for (size_t i = 0; i < count; i++) {
+    $(this->type, addOption, types[i].title, (ident) &types[i]);
+  }
+
+  $(this->map, addOption, "next", NULL);
+  cgi.EnumerateFiles("maps/*.bsp", enumerateMaps, this->map);
+
+  this->value->labelFormat = "%.0f";
+
+  $(self, setView, view);
+  release(view);
+
+  self->view->stylesheet = $$(Stylesheet, stylesheetWithResourceName, "ui/vote/VoteViewController.css");
+  assert(self->view->stylesheet);
+}
+
+static void viewWillAppear(ViewController *self) {
+
+  super(ViewController, self, viewWillAppear);
+
+  VoteViewController *this = (VoteViewController *) self;
+
+  refreshStatus(this);
+  refreshClients(this);
+
+  const Option *selected = $(this->type, selectedOption);
+  if (selected) {
+    didSelectType(this->type, (Option *) selected);
+  }
+}
+
+#pragma mark - Class lifecycle
+
+static void initialize(Class *clazz) {
+  ((ViewControllerInterface *) clazz->interface)->loadView = loadView;
+  ((ViewControllerInterface *) clazz->interface)->viewWillAppear = viewWillAppear;
+}
+
+Class *_VoteViewController(void) {
+  static Class *clazz;
+  static Once once;
+
+  do_once(&once, {
+    clazz = _initialize(&(const ClassDef) {
+      .name = "VoteViewController",
+      .superclass = _ViewController(),
+      .instanceSize = sizeof(VoteViewController),
+      .interfaceOffset = offsetof(VoteViewController, interface),
+      .interfaceSize = sizeof(VoteViewControllerInterface),
+      .initialize = initialize,
+    });
+  });
+
+  return clazz;
+}
+
+#undef _Class

--- a/src/cgame/common/ui/vote/VoteViewController.css
+++ b/src/cgame/common/ui/vote/VoteViewController.css
@@ -1,0 +1,9 @@
+Panel#vote > .contentView .container {
+  axis: vertical;
+  spacing: 16;
+}
+
+Panel#vote .ballots {
+  axis: horizontal;
+  spacing: 16;
+}

--- a/src/cgame/common/ui/vote/VoteViewController.h
+++ b/src/cgame/common/ui/vote/VoteViewController.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright(c) 1997-2001 id Software, Inc.
+ * Copyright(c) 2002 The Quakeforge Project.
+ * Copyright(c) 2006 Quetoo.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+#pragma once
+
+#include <ObjectivelyMVC/ViewController.h>
+
+/**
+ * @file
+ * @brief The Vote screen: the vote in progress, and calling a new one.
+ */
+
+typedef struct VoteViewController VoteViewController;
+typedef struct VoteViewControllerInterface VoteViewControllerInterface;
+
+struct VoteViewController {
+
+  /**
+   * @brief The superclass.
+   */
+  ViewController viewController;
+
+  /**
+   * @brief The interface.
+   * @protected
+   */
+  VoteViewControllerInterface *interface;
+
+  Label *status;
+  Button *yes, *no;
+
+  Select *type;
+  Select *map;
+  Select *client;
+  Slider *value;
+  Button *call;
+};
+
+struct VoteViewControllerInterface {
+
+  /**
+   * @brief The superclass interface.
+   */
+  ViewControllerInterface viewControllerInterface;
+};
+
+/**
+ * @fn Class *VoteViewController::_VoteViewController(void)
+ * @memberof VoteViewController
+ */
+CGAME_EXPORT Class *_VoteViewController(void);

--- a/src/cgame/common/ui/vote/VoteViewController.json
+++ b/src/cgame/common/ui/vote/VoteViewController.json
@@ -1,0 +1,122 @@
+{
+  "class": "Panel",
+  "identifier": "vote",
+  "classNames": [
+    "menu"
+  ],
+  "contentView": {
+    "subviews": [
+      {
+        "class": "StackView",
+        "classNames": [
+          "container"
+        ],
+        "subviews": [
+          {
+            "class": "Label",
+            "identifier": "status",
+            "text": {
+              "text": "No vote is in progress"
+            }
+          },
+          {
+            "class": "StackView",
+            "classNames": [
+              "ballots"
+            ],
+            "subviews": [
+              {
+                "class": "Button",
+                "identifier": "yes",
+                "title": {
+                  "text": "Yes"
+                }
+              },
+              {
+                "class": "Button",
+                "identifier": "no",
+                "title": {
+                  "text": "No"
+                }
+              }
+            ]
+          },
+          {
+            "class": "Box",
+            "label": {
+              "text": {
+                "text": "Call a vote"
+              }
+            },
+            "contentView": {
+              "subviews": [
+                {
+                  "class": "Input",
+                  "label": {
+                    "text": {
+                      "text": "Vote"
+                    }
+                  },
+                  "control": {
+                    "class": "Select",
+                    "identifier": "type"
+                  }
+                },
+                {
+                  "class": "Input",
+                  "label": {
+                    "text": {
+                      "text": "Map"
+                    }
+                  },
+                  "control": {
+                    "class": "Select",
+                    "identifier": "map"
+                  }
+                },
+                {
+                  "class": "Input",
+                  "label": {
+                    "text": {
+                      "text": "Player"
+                    }
+                  },
+                  "control": {
+                    "class": "Select",
+                    "identifier": "client"
+                  }
+                },
+                {
+                  "class": "Input",
+                  "label": {
+                    "text": {
+                      "text": "Value"
+                    }
+                  },
+                  "control": {
+                    "class": "Slider",
+                    "identifier": "value"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    ]
+  },
+  "accessoryView": {
+    "style": {
+      "hidden": false
+    },
+    "subviews": [
+      {
+        "class": "Button",
+        "identifier": "call",
+        "title": {
+          "text": "Call"
+        }
+      }
+    ]
+  }
+}

--- a/src/cgame/ctf/Makefile.am
+++ b/src/cgame/ctf/Makefile.am
@@ -21,6 +21,7 @@ AM_CPPFLAGS = \
 	-I$(CGAME_COMMON_DIR)/ui/play \
 	-I$(CGAME_COMMON_DIR)/ui/settings \
 	-I$(CGAME_COMMON_DIR)/ui/teams \
+	-I$(CGAME_COMMON_DIR)/ui/vote \
 	-I$(GAME_DIR) \
 	-I$(GAME_COMMON_DIR)
 
@@ -71,6 +72,7 @@ cgame_la_SOURCES = \
 	cg_temp_entity.c \
 	cg_ui.c \
 	cg_view.c \
+	cg_vote.c \
 	cg_weapon.c \
 	ui/BindTextView.c \
 	ui/CvarCheckbox.c \
@@ -105,7 +107,8 @@ cgame_la_SOURCES = \
 	ui/settings/SettingsViewController.c \
 	ui/teams/TeamPlayerView.c \
 	ui/teams/TeamView.c \
-	ui/teams/TeamsViewController.c
+	ui/teams/TeamsViewController.c \
+	ui/vote/VoteViewController.c
 
 cgame_la_LDFLAGS = \
 	-avoid-version \

--- a/src/cgame/default/Makefile.am
+++ b/src/cgame/default/Makefile.am
@@ -18,6 +18,7 @@ AM_CPPFLAGS = \
 	-I$(CGAME_COMMON_DIR)/ui/play \
 	-I$(CGAME_COMMON_DIR)/ui/settings \
 	-I$(CGAME_COMMON_DIR)/ui/teams \
+	-I$(CGAME_COMMON_DIR)/ui/vote \
 	-I$(GAME_DIR) \
 	-I$(GAME_COMMON_DIR)
 
@@ -147,6 +148,13 @@ cguiteams_DATA = \
 	$(CGUI_DIR)/teams/TeamsViewController.css \
 	$(CGUI_DIR)/teams/TeamsViewController.json
 
+cguivotedir = \
+	@PKGLIBDIR@/default/ui/vote
+
+cguivote_DATA = \
+	$(CGUI_DIR)/vote/VoteViewController.css \
+	$(CGUI_DIR)/vote/VoteViewController.json
+
 cgamelibdir = \
 	@PKGLIBDIR@/default
 
@@ -182,6 +190,7 @@ cgame_la_SOURCES = \
 	cg_temp_entity.c \
 	cg_ui.c \
 	cg_view.c \
+	cg_vote.c \
 	cg_weapon.c \
 	ui/BindTextView.c \
 	ui/CvarCheckbox.c \
@@ -216,7 +225,8 @@ cgame_la_SOURCES = \
 	ui/settings/SettingsViewController.c \
 	ui/teams/TeamPlayerView.c \
 	ui/teams/TeamView.c \
-	ui/teams/TeamsViewController.c
+	ui/teams/TeamsViewController.c \
+	ui/vote/VoteViewController.c
 
 cgame_la_LDFLAGS = \
 	-avoid-version \

--- a/src/cgame/lithium/Makefile.am
+++ b/src/cgame/lithium/Makefile.am
@@ -20,6 +20,7 @@ AM_CPPFLAGS = \
 	-I$(CGAME_COMMON_DIR)/ui/play \
 	-I$(CGAME_COMMON_DIR)/ui/settings \
 	-I$(CGAME_COMMON_DIR)/ui/teams \
+	-I$(CGAME_COMMON_DIR)/ui/vote \
 	-I$(GAME_DIR) \
 	-I$(GAME_COMMON_DIR)
 
@@ -69,6 +70,7 @@ cgame_la_SOURCES = \
 	cg_temp_entity.c \
 	cg_ui.c \
 	cg_view.c \
+	cg_vote.c \
 	cg_weapon.c \
 	ui/BindTextView.c \
 	ui/CvarCheckbox.c \
@@ -103,7 +105,8 @@ cgame_la_SOURCES = \
 	ui/settings/SettingsViewController.c \
 	ui/teams/TeamPlayerView.c \
 	ui/teams/TeamView.c \
-	ui/teams/TeamsViewController.c
+	ui/teams/TeamsViewController.c \
+	ui/vote/VoteViewController.c
 
 cgame_la_LDFLAGS = \
 	-avoid-version \


### PR DESCRIPTION
## Summary

The client half of voting (D10 / D16 on #963); with #984 this closes #865.

- `cg_vote.c`, a common cgame feature installed from `Cg_Init` like `cg_ctf.c`: reads `CS_VOTE` into `cg_state.vote` through `ParseConfigString` (split positionally so an empty argument keeps its place), and draws the vote in progress beneath the crosshair through the `DrawHudElements` chain — initiator, kind, Yes / No / eligible and seconds left on the level clock.
- The Vote screen (`ui/vote/VoteViewController`), reached from a **Vote** button in the main menu's secondary menu between Teams and Disconnect: the vote in progress with Yes and No, and "Call a vote" — a kind from `ListVoteTypes`, then a map from those installed (or `next`), a player by name, or a number within the kind's range.
- `ListVoteTypes` in `cg_module.h` (not chained) so a module lists its own kinds; `vote` registered as a cgame command for completion.
- Registered in autotools (sources, include dir, `cgui_DATA`), MSVS (props, include dirs, filters) and Xcode (sources, headers, CopyFiles); `verify_projects.py` 6/6.

## Test plan

- [x] all cgame modules build with no warnings
- [ ] CI
- [ ] Needs a GUI session to exercise end to end: open Vote from the menu, call `map next`, see the overlay count down, cast from another client

🤖 Generated with [Claude Code](https://claude.com/claude-code)