### PR TITLE
Set the vote slider's label format through its setter

### DIFF
--- a/src/cgame/common/ui/vote/VoteViewController.c
+++ b/src/cgame/common/ui/vote/VoteViewController.c
@@ -185,7 +185,7 @@ static void loadView(ViewController *self) {
   $(this->map, addOption, "next", NULL);
   cgi.EnumerateFiles("maps/*.bsp", enumerateMaps, this->map);
 
-  this->value->labelFormat = "%.0f";
+  $(this->value, setLabelFormat, "%.0f");
 
   $(self, setView, view);
   release(view);


### PR DESCRIPTION
## Summary

Quitting after opening the Vote screen aborted in `Slider::dealloc` (`Slider.c:51`), which frees `labelFormat`; #986 assigned a string literal to the field. Use `setLabelFormat`, which copies.

## Test plan

- [x] cgame modules build with no warnings
- [ ] Open the Vote screen, quit — no abort

🤖 Generated with [Claude Code](https://claude.com/claude-code)