### PR TITLE
Add QuakeWorld's movement, selected by g_movement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,7 @@ src/tests/check_http
 src/tests/check_master
 src/tests/check_mem
 src/tests/check_net_message
+src/tests/check_pmove
 src/tests/check_r_media
 src/tests/check_shared
 src/tests/check_thread

--- a/Quetoo.vs15/cgame-ctf.vcxproj
+++ b/Quetoo.vs15/cgame-ctf.vcxproj
@@ -27,6 +27,7 @@
     <ClCompile Include="..\src\game\ctf\bg_item.c" />
     <ClCompile Include="..\src\game\common\bg_pmove.c" />
     <ClCompile Include="..\src\game\common\bg_pmove_quetoo.c" />
+    <ClCompile Include="..\src\game\common\bg_pmove_quake.c" />
     <ClCompile Include="..\src\cgame\ctf\cg_module.c" />
   </ItemGroup>
   <PropertyGroup Label="Globals">

--- a/Quetoo.vs15/cgame-ctf.vcxproj.filters
+++ b/Quetoo.vs15/cgame-ctf.vcxproj.filters
@@ -512,6 +512,9 @@
     <ClCompile Include="..\src\game\common\bg_pmove_quetoo.c">
       <Filter>src\game\common</Filter>
     </ClCompile>
+    <ClCompile Include="..\src\game\common\bg_pmove_quake.c">
+      <Filter>src\game\common</Filter>
+    </ClCompile>
     <ClCompile Include="..\src\game\ctf\bg_item.c">
       <Filter>src\game\ctf</Filter>
     </ClCompile>

--- a/Quetoo.vs15/cgame-lithium.vcxproj
+++ b/Quetoo.vs15/cgame-lithium.vcxproj
@@ -27,6 +27,7 @@
     <ClCompile Include="..\src\game\lithium\bg_item.c" />
     <ClCompile Include="..\src\game\common\bg_pmove.c" />
     <ClCompile Include="..\src\game\common\bg_pmove_quetoo.c" />
+    <ClCompile Include="..\src\game\common\bg_pmove_quake.c" />
     <ClCompile Include="..\src\cgame\lithium\cg_module.c" />
   </ItemGroup>
   <PropertyGroup Label="Globals">

--- a/Quetoo.vs15/cgame-lithium.vcxproj.filters
+++ b/Quetoo.vs15/cgame-lithium.vcxproj.filters
@@ -506,6 +506,9 @@
     <ClCompile Include="..\src\game\common\bg_pmove_quetoo.c">
       <Filter>src\game\common</Filter>
     </ClCompile>
+    <ClCompile Include="..\src\game\common\bg_pmove_quake.c">
+      <Filter>src\game\common</Filter>
+    </ClCompile>
     <ClCompile Include="..\src\game\lithium\bg_item.c">
       <Filter>src\game\lithium</Filter>
     </ClCompile>

--- a/Quetoo.vs15/cgame-race.vcxproj
+++ b/Quetoo.vs15/cgame-race.vcxproj
@@ -27,6 +27,7 @@
     <ClCompile Include="..\src\game\race\bg_item.c" />
     <ClCompile Include="..\src\game\common\bg_pmove.c" />
     <ClCompile Include="..\src\game\common\bg_pmove_quetoo.c" />
+    <ClCompile Include="..\src\game\common\bg_pmove_quake.c" />
     <ClCompile Include="..\src\cgame\race\cg_module.c" />
   </ItemGroup>
   <PropertyGroup Label="Globals">

--- a/Quetoo.vs15/cgame-race.vcxproj.filters
+++ b/Quetoo.vs15/cgame-race.vcxproj.filters
@@ -500,6 +500,9 @@
     <ClCompile Include="..\src\game\common\bg_pmove_quetoo.c">
       <Filter>src\game\common</Filter>
     </ClCompile>
+    <ClCompile Include="..\src\game\common\bg_pmove_quake.c">
+      <Filter>src\game\common</Filter>
+    </ClCompile>
     <ClCompile Include="..\src\game\race\bg_item.c">
       <Filter>src\game\race</Filter>
     </ClCompile>

--- a/Quetoo.vs15/cgame.vcxproj
+++ b/Quetoo.vs15/cgame.vcxproj
@@ -28,6 +28,7 @@
     <ClCompile Include="..\src\game\default\bg_item.c" />
     <ClCompile Include="..\src\game\common\bg_pmove.c" />
     <ClCompile Include="..\src\game\common\bg_pmove_quetoo.c" />
+    <ClCompile Include="..\src\game\common\bg_pmove_quake.c" />
     <ClCompile Include="..\src\cgame\default\cg_module.c" />
   </ItemGroup>
   <PropertyGroup Label="Globals">

--- a/Quetoo.vs15/cgame.vcxproj.filters
+++ b/Quetoo.vs15/cgame.vcxproj.filters
@@ -500,6 +500,9 @@
     <ClCompile Include="..\src\game\common\bg_pmove_quetoo.c">
       <Filter>src\game\common</Filter>
     </ClCompile>
+    <ClCompile Include="..\src\game\common\bg_pmove_quake.c">
+      <Filter>src\game\common</Filter>
+    </ClCompile>
     <ClCompile Include="..\src\game\default\bg_item.c">
       <Filter>src\game\default</Filter>
     </ClCompile>

--- a/Quetoo.vs15/game-ctf.vcxproj.filters
+++ b/Quetoo.vs15/game-ctf.vcxproj.filters
@@ -239,6 +239,9 @@
     <ClCompile Include="..\src\game\common\bg_pmove_quetoo.c">
       <Filter>src\common</Filter>
     </ClCompile>
+    <ClCompile Include="..\src\game\common\bg_pmove_quake.c">
+      <Filter>src\common</Filter>
+    </ClCompile>
     <ClCompile Include="..\src\game\ctf\bg_item.c">
       <Filter>src\ctf</Filter>
     </ClCompile>

--- a/Quetoo.vs15/game-lithium.vcxproj.filters
+++ b/Quetoo.vs15/game-lithium.vcxproj.filters
@@ -233,6 +233,9 @@
     <ClCompile Include="..\src\game\common\bg_pmove_quetoo.c">
       <Filter>src\common</Filter>
     </ClCompile>
+    <ClCompile Include="..\src\game\common\bg_pmove_quake.c">
+      <Filter>src\common</Filter>
+    </ClCompile>
     <ClCompile Include="..\src\game\lithium\bg_item.c">
       <Filter>src\lithium</Filter>
     </ClCompile>

--- a/Quetoo.vs15/game-race.vcxproj.filters
+++ b/Quetoo.vs15/game-race.vcxproj.filters
@@ -224,6 +224,9 @@
     <ClCompile Include="..\src\game\common\bg_pmove_quetoo.c">
       <Filter>src\common</Filter>
     </ClCompile>
+    <ClCompile Include="..\src\game\common\bg_pmove_quake.c">
+      <Filter>src\common</Filter>
+    </ClCompile>
     <ClCompile Include="..\src\game\race\bg_item.c">
       <Filter>src\race</Filter>
     </ClCompile>

--- a/Quetoo.vs15/game.vcxproj.filters
+++ b/Quetoo.vs15/game.vcxproj.filters
@@ -215,6 +215,9 @@
     <ClCompile Include="..\src\game\common\bg_pmove_quetoo.c">
       <Filter>src\common</Filter>
     </ClCompile>
+    <ClCompile Include="..\src\game\common\bg_pmove_quake.c">
+      <Filter>src\common</Filter>
+    </ClCompile>
     <ClCompile Include="..\src\game\default\bg_item.c">
       <Filter>src\default</Filter>
     </ClCompile>

--- a/Quetoo.vs15/game_common.props
+++ b/Quetoo.vs15/game_common.props
@@ -15,6 +15,7 @@
   <ItemGroup>
     <ClCompile Include="..\src\game\common\bg_pmove.c" />
     <ClCompile Include="..\src\game\common\bg_pmove_quetoo.c" />
+    <ClCompile Include="..\src\game\common\bg_pmove_quake.c" />
     <ClInclude Include="..\src\game\common\bg_pmove.h" />
     <ClInclude Include="..\src\game\common\bg_vote.h" />
     <ClInclude Include="..\src\game\common\g_vote.h" />

--- a/Quetoo.xcodeproj/project.pbxproj
+++ b/Quetoo.xcodeproj/project.pbxproj
@@ -112,8 +112,10 @@
 		D2A5C100000000000000002C /* g_vote.c in Sources */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000101 /* g_vote.c */; };
 		CE05B2893022486E0012862B /* bg_pmove.c in Sources */ = {isa = PBXBuildFile; fileRef = CE12D6411C5C58C300CD0B13 /* bg_pmove.c */; };
 		D3A5C100000000000000000B /* bg_pmove_quetoo.c in Sources */ = {isa = PBXBuildFile; fileRef = D3A5C10000000000000000A1 /* bg_pmove_quetoo.c */; };
+		D4A5C100000000000000000B /* bg_pmove_quake.c in Sources */ = {isa = PBXBuildFile; fileRef = D4A5C10000000000000000A1 /* bg_pmove_quake.c */; };
 		D2A5C1000000000000000011 /* bg_pmove.c in Sources */ = {isa = PBXBuildFile; fileRef = CE12D6411C5C58C300CD0B13 /* bg_pmove.c */; };
 		D3A5C100000000000000001B /* bg_pmove_quetoo.c in Sources */ = {isa = PBXBuildFile; fileRef = D3A5C10000000000000000A1 /* bg_pmove_quetoo.c */; };
+		D4A5C100000000000000001B /* bg_pmove_quake.c in Sources */ = {isa = PBXBuildFile; fileRef = D4A5C10000000000000000A1 /* bg_pmove_quake.c */; };
 		CE05B28A3022486E0012862B /* g_ai_goal.c in Sources */ = {isa = PBXBuildFile; fileRef = CE27E9F127BDA2AE003D56AC /* g_ai_goal.c */; };
 		D2A5C1000000000000000012 /* g_ai_goal.c in Sources */ = {isa = PBXBuildFile; fileRef = CE27E9F127BDA2AE003D56AC /* g_ai_goal.c */; };
 		CE05B28B3022486E0012862B /* g_ai_grid.c in Sources */ = {isa = PBXBuildFile; fileRef = CE4E05402FDAE2CE00B92C32 /* g_ai_grid.c */; };
@@ -256,8 +258,10 @@
 		D2A5C1000000000000000085 /* bg_item.c in Sources */ = {isa = PBXBuildFile; fileRef = D2A5C1000000000000000002 /* bg_item.c */; };
 		CE05B3F030224900C0DE0002 /* bg_pmove.c in Sources */ = {isa = PBXBuildFile; fileRef = CE12D6411C5C58C300CD0B13 /* bg_pmove.c */; };
 		D3A5C100000000000000002B /* bg_pmove_quetoo.c in Sources */ = {isa = PBXBuildFile; fileRef = D3A5C10000000000000000A1 /* bg_pmove_quetoo.c */; };
+		D4A5C100000000000000002B /* bg_pmove_quake.c in Sources */ = {isa = PBXBuildFile; fileRef = D4A5C10000000000000000A1 /* bg_pmove_quake.c */; };
 		D2A5C1000000000000000086 /* bg_pmove.c in Sources */ = {isa = PBXBuildFile; fileRef = CE12D6411C5C58C300CD0B13 /* bg_pmove.c */; };
 		D3A5C100000000000000003B /* bg_pmove_quetoo.c in Sources */ = {isa = PBXBuildFile; fileRef = D3A5C10000000000000000A1 /* bg_pmove_quetoo.c */; };
+		D4A5C100000000000000003B /* bg_pmove_quake.c in Sources */ = {isa = PBXBuildFile; fileRef = D4A5C10000000000000000A1 /* bg_pmove_quake.c */; };
 		CE05B3F030224900C0DE0003 /* BindTextView.c in Sources */ = {isa = PBXBuildFile; fileRef = CE32529B1F760D3F00512523 /* BindTextView.c */; };
 		D2A5C1000000000000000062 /* BindTextView.c in Sources */ = {isa = PBXBuildFile; fileRef = CE32529B1F760D3F00512523 /* BindTextView.c */; };
 		CE05B3F030224900C0DE0004 /* cg_client.c in Sources */ = {isa = PBXBuildFile; fileRef = CE12D55E1C5C58C300CD0B13 /* cg_client.c */; };
@@ -1153,12 +1157,16 @@
 		CEFC7A941D9CB75D000FA6B2 /* libshared.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CE80FDD51C5E3D4E00A21A51 /* libshared.a */; };
 		CEFC7B8B1D9D2E9C000FA6B2 /* bg_pmove.c in Sources */ = {isa = PBXBuildFile; fileRef = CE12D6411C5C58C300CD0B13 /* bg_pmove.c */; };
 		D3A5C100000000000000004B /* bg_pmove_quetoo.c in Sources */ = {isa = PBXBuildFile; fileRef = D3A5C10000000000000000A1 /* bg_pmove_quetoo.c */; };
+		D4A5C100000000000000004B /* bg_pmove_quake.c in Sources */ = {isa = PBXBuildFile; fileRef = D4A5C10000000000000000A1 /* bg_pmove_quake.c */; };
 		CEFEED000000000000000001 /* bg_pmove.c in Sources */ = {isa = PBXBuildFile; fileRef = CE12D6411C5C58C300CD0B13 /* bg_pmove.c */; };
 		D3A5C100000000000000005B /* bg_pmove_quetoo.c in Sources */ = {isa = PBXBuildFile; fileRef = D3A5C10000000000000000A1 /* bg_pmove_quetoo.c */; };
+		D4A5C100000000000000005B /* bg_pmove_quake.c in Sources */ = {isa = PBXBuildFile; fileRef = D4A5C10000000000000000A1 /* bg_pmove_quake.c */; };
 		CEFEED000000000000000002 /* bg_pmove.c in Sources */ = {isa = PBXBuildFile; fileRef = CE12D6411C5C58C300CD0B13 /* bg_pmove.c */; };
 		D3A5C100000000000000006B /* bg_pmove_quetoo.c in Sources */ = {isa = PBXBuildFile; fileRef = D3A5C10000000000000000A1 /* bg_pmove_quetoo.c */; };
+		D4A5C100000000000000006B /* bg_pmove_quake.c in Sources */ = {isa = PBXBuildFile; fileRef = D4A5C10000000000000000A1 /* bg_pmove_quake.c */; };
 		CEFEED000000000000000003 /* bg_pmove.c in Sources */ = {isa = PBXBuildFile; fileRef = CE12D6411C5C58C300CD0B13 /* bg_pmove.c */; };
 		D3A5C100000000000000007B /* bg_pmove_quetoo.c in Sources */ = {isa = PBXBuildFile; fileRef = D3A5C10000000000000000A1 /* bg_pmove_quetoo.c */; };
+		D4A5C100000000000000007B /* bg_pmove_quake.c in Sources */ = {isa = PBXBuildFile; fileRef = D4A5C10000000000000000A1 /* bg_pmove_quake.c */; };
 		CEFEED000000000000000004 /* bg_item.c in Sources */ = {isa = PBXBuildFile; fileRef = 7966EA6596003F9303BC00FA /* bg_item.c */; };
 		CEFEED000000000000000005 /* bg_item.c in Sources */ = {isa = PBXBuildFile; fileRef = CEC0FF002026010300000004 /* bg_item.c */; };
 		CEFEEE0000000000000000D1 /* g_tech.c in Sources */ = {isa = PBXBuildFile; fileRef = CEFEEE0000000000000000C1 /* g_tech.c */; };
@@ -1911,6 +1919,7 @@
 		CE12D63E1C5C58C300CD0B13 /* filesystem.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = filesystem.h; sourceTree = "<group>"; };
 		CE12D6411C5C58C300CD0B13 /* bg_pmove.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = bg_pmove.c; sourceTree = "<group>"; };
 		D3A5C10000000000000000A1 /* bg_pmove_quetoo.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = bg_pmove_quetoo.c; sourceTree = "<group>"; };
+		D4A5C10000000000000000A1 /* bg_pmove_quake.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = bg_pmove_quake.c; sourceTree = "<group>"; };
 		CE12D6421C5C58C300CD0B13 /* bg_pmove.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = bg_pmove.h; sourceTree = "<group>"; };
 		D1A5B0000000000000000105 /* bg_vote.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = bg_vote.h; sourceTree = "<group>"; };
 		D1A5B0000000000000000001 /* bg_pmove_internal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = bg_pmove_internal.h; sourceTree = "<group>"; };
@@ -4137,6 +4146,7 @@
 				D1A5B0000000000000000001 /* bg_pmove_internal.h */,
 				CE12D6411C5C58C300CD0B13 /* bg_pmove.c */,
 				D3A5C10000000000000000A1 /* bg_pmove_quetoo.c */,
+				D4A5C10000000000000000A1 /* bg_pmove_quake.c */,
 				CEFEEE0000000000000000C3 /* bg_tech.h */,
 				CE27E9F327BDA2AE003D56AC /* g_ai_goal.h */,
 				CE27E9F127BDA2AE003D56AC /* g_ai_goal.c */,
@@ -5799,6 +5809,7 @@
 				CE05B2F0302248070012F001 /* bg_item.c in Sources */,
 				CE05B2893022486E0012862B /* bg_pmove.c in Sources */,
 				D3A5C100000000000000000B /* bg_pmove_quetoo.c in Sources */,
+				D4A5C100000000000000000B /* bg_pmove_quake.c in Sources */,
 				CE05B28A3022486E0012862B /* g_ai_goal.c in Sources */,
 				CE05B28B3022486E0012862B /* g_ai_grid.c in Sources */,
 				CE05B28C3022486E0012862B /* g_ai_info.c in Sources */,
@@ -5840,6 +5851,7 @@
 				D2A5C1000000000000000010 /* bg_item.c in Sources */,
 				D2A5C1000000000000000011 /* bg_pmove.c in Sources */,
 				D3A5C100000000000000001B /* bg_pmove_quetoo.c in Sources */,
+				D4A5C100000000000000001B /* bg_pmove_quake.c in Sources */,
 				D2A5C1000000000000000012 /* g_ai_goal.c in Sources */,
 				D2A5C1000000000000000013 /* g_ai_grid.c in Sources */,
 				D2A5C1000000000000000014 /* g_ai_info.c in Sources */,
@@ -5915,6 +5927,7 @@
 				CE05B3F030224900C0DE0001 /* bg_item.c in Sources */,
 				CE05B3F030224900C0DE0002 /* bg_pmove.c in Sources */,
 				D3A5C100000000000000002B /* bg_pmove_quetoo.c in Sources */,
+				D4A5C100000000000000002B /* bg_pmove_quake.c in Sources */,
 				CE05B3F030224900C0DE0004 /* cg_client.c in Sources */,
 				CE05B3F030224900C0DE0005 /* cg_discord.c in Sources */,
 				CE05B3F030224900C0DE0006 /* cg_editor.c in Sources */,
@@ -5989,6 +6002,7 @@
 				D2A5C1000000000000000085 /* bg_item.c in Sources */,
 				D2A5C1000000000000000086 /* bg_pmove.c in Sources */,
 				D3A5C100000000000000003B /* bg_pmove_quetoo.c in Sources */,
+				D4A5C100000000000000003B /* bg_pmove_quake.c in Sources */,
 				D2A5C1000000000000000087 /* cg_client.c in Sources */,
 				D2A5C1000000000000000088 /* cg_discord.c in Sources */,
 				D2A5C1000000000000000089 /* cg_editor.c in Sources */,
@@ -6035,6 +6049,7 @@
 				08962C395D0FB0E620F78625 /* bg_item.c in Sources */,
 				CEFC7B8B1D9D2E9C000FA6B2 /* bg_pmove.c in Sources */,
 				D3A5C100000000000000004B /* bg_pmove_quetoo.c in Sources */,
+				D4A5C100000000000000004B /* bg_pmove_quake.c in Sources */,
 				CE27E9FC27BDA2AE003D56AC /* g_ai_goal.c in Sources */,
 				CE4E05422FDAE2CE00B92C32 /* g_ai_grid.c in Sources */,
 				CE27E9FF27BDA2AE003D56AC /* g_ai_info.c in Sources */,
@@ -6109,6 +6124,7 @@
 				CEFEED000000000000000004 /* bg_item.c in Sources */,
 				CEFEED000000000000000002 /* bg_pmove.c in Sources */,
 				D3A5C100000000000000006B /* bg_pmove_quetoo.c in Sources */,
+				D4A5C100000000000000006B /* bg_pmove_quake.c in Sources */,
 				CE12D7EF1C5C5E0200CD0B13 /* cg_client.c in Sources */,
 				CE27E6B927AC95D1003D56AC /* cg_discord.c in Sources */,
 				CFA000142F9100000000C014 /* cg_editor.c in Sources */,
@@ -6457,6 +6473,7 @@
 				CEC0FF0020260103000000D6 /* bg_item.c in Sources */,
 				CEFEED000000000000000001 /* bg_pmove.c in Sources */,
 				D3A5C100000000000000005B /* bg_pmove_quetoo.c in Sources */,
+				D4A5C100000000000000005B /* bg_pmove_quake.c in Sources */,
 				CEC0FF0020260103000000EF /* g_ai_goal.c in Sources */,
 				CEC0FF0020260103000000F0 /* g_ai_grid.c in Sources */,
 				CEC0FF0020260103000000F1 /* g_ai_info.c in Sources */,
@@ -6534,6 +6551,7 @@
 				CEFEED000000000000000005 /* bg_item.c in Sources */,
 				CEFEED000000000000000003 /* bg_pmove.c in Sources */,
 				D3A5C100000000000000007B /* bg_pmove_quetoo.c in Sources */,
+				D4A5C100000000000000007B /* bg_pmove_quake.c in Sources */,
 				CEC0FF0020260103000001E0 /* cg_client.c in Sources */,
 				CEC0FF0020260103000001E1 /* cg_discord.c in Sources */,
 				CEC0FF0020260103000001E2 /* cg_editor.c in Sources */,

--- a/doc/game-module-hooks.md
+++ b/doc/game-module-hooks.md
@@ -445,7 +445,7 @@ what this started as:
    another record set under the same movement, and shared code that everyone
    edits can never offer that. A kernel in its own file is finished once it
    matches what it is imitating. Changing what one does is a new id appended to
-   `pm_kernel_t`, never an edit; the exception is `bg_pmove.c` itself, where a
+   `pm_movement_t`, never an edit; the exception is `bg_pmove.c` itself, where a
    fault is a fault in every ruleset.
 
 The cost is duplication between kernels, accepted deliberately: two kernels that

--- a/src/cgame/common/ui/play/CreateServerViewController.c
+++ b/src/cgame/common/ui/play/CreateServerViewController.c
@@ -99,12 +99,14 @@ static void loadView(ViewController *self) {
 
   CreateServerViewController *this = (CreateServerViewController *) self;
 
-  View *gameplayInput, *hookInput, *techsInput;
+  View *gameplayInput, *movementInput, *hookInput, *techsInput;
 
   Outlet outlets[] = MakeOutlets(
     MakeOutlet("bots", &this->bots),
     MakeOutlet("gameplay", &this->gameplay),
     MakeOutlet("gameplayInput", &gameplayInput),
+    MakeOutlet("movement", &this->movement),
+    MakeOutlet("movementInput", &movementInput),
     MakeOutlet("hookInput", &hookInput),
     MakeOutlet("techsInput", &techsInput),
     MakeOutlet("mapList", &this->mapList),
@@ -140,6 +142,19 @@ static void loadView(ViewController *self) {
   } else {
     for (size_t i = 0; i < num_modes; i++) {
       $(this->gameplay, addOption, modes[i].label, (ident) modes[i].name);
+    }
+  }
+
+  // "Default" defers to the level, as it does for gameplay
+  $(this->movement, addOption, "Default", "default");
+
+  const size_t num_movements = Pm_MovementCount();
+  if (num_movements <= 1) {
+    $(movementInput, removeFromSuperview);
+  } else {
+    for (size_t i = 0; i < num_movements; i++) {
+      const pm_movement_info_t *movement = Pm_Movement((pm_movement_t) i);
+      $(this->movement, addOption, movement->label, (ident) movement->name);
     }
   }
 

--- a/src/cgame/common/ui/play/CreateServerViewController.h
+++ b/src/cgame/common/ui/play/CreateServerViewController.h
@@ -71,6 +71,11 @@ struct CreateServerViewController {
   Select *gameplay;
 
   /**
+   * @brief The player movement to run.
+   */
+  Select *movement;
+
+  /**
    * @brief The MapListCollectionView.
    */
   MapListCollectionView *mapList;

--- a/src/cgame/common/ui/play/CreateServerViewController.json
+++ b/src/cgame/common/ui/play/CreateServerViewController.json
@@ -131,6 +131,21 @@
                       },
                       {
                         "class": "Input",
+                        "identifier": "movementInput",
+                        "label": {
+                          "text": {
+                            "text": "Movement"
+                          }
+                        },
+                        "control": {
+                          "class": "CvarSelect",
+                          "expectsStringValue": true,
+                          "identifier": "movement",
+                          "var": "g_movement"
+                        }
+                      },
+                      {
+                        "class": "Input",
                         "label": {
                           "text": {
                             "text": "Time limit"

--- a/src/cgame/ctf/Makefile.am
+++ b/src/cgame/ctf/Makefile.am
@@ -45,6 +45,7 @@ cgame_la_SOURCES = \
 	bg_item.c \
 	bg_pmove.c \
 	bg_pmove_quetoo.c \
+	bg_pmove_quake.c \
 	cg_client.c \
 	cg_ctf.c \
 	cg_discord.c \

--- a/src/cgame/default/Makefile.am
+++ b/src/cgame/default/Makefile.am
@@ -165,6 +165,7 @@ cgame_la_SOURCES = \
 	bg_item.c \
 	bg_pmove.c \
 	bg_pmove_quetoo.c \
+	bg_pmove_quake.c \
 	cg_client.c \
 	cg_discord.c \
 	cg_editor.c \

--- a/src/cgame/lithium/Makefile.am
+++ b/src/cgame/lithium/Makefile.am
@@ -44,6 +44,7 @@ cgame_la_SOURCES = \
 	bg_item.c \
 	bg_pmove.c \
 	bg_pmove_quetoo.c \
+	bg_pmove_quake.c \
 	cg_client.c \
 	cg_discord.c \
 	cg_editor.c \

--- a/src/cgame/race/Makefile.am
+++ b/src/cgame/race/Makefile.am
@@ -43,6 +43,7 @@ cgame_la_SOURCES = \
 	bg_item.c \
 	bg_pmove.c \
 	bg_pmove_quetoo.c \
+	bg_pmove_quake.c \
 	cg_client.c \
 	cg_discord.c \
 	cg_editor.c \

--- a/src/game/common/bg_pmove.c
+++ b/src/game/common/bg_pmove.c
@@ -59,6 +59,47 @@ box3_t Pm_Bounds(const pm_params_t *params, bool ducked) {
   return Box3_Scale(bounds, PM_SCALE);
 }
 
+/**
+ * @brief Keyed by `pm_movement_t` so that the ids and this table cannot drift
+ * apart. Quetoo's carries no parameters of its own: it is the one that follows
+ * the server's movement cvars, which is what makes it the default.
+ */
+static const pm_movement_info_t pm_movements[] = {
+  [PM_MOVEMENT_QUETOO] = { .name = "quetoo", .label = "Quetoo", .params = NULL },
+  [PM_MOVEMENT_QUAKE]  = { .name = "quake",  .label = "QuakeWorld", .params = &pm_quake_params },
+};
+
+const pm_movement_info_t *Pm_Movement(pm_movement_t movement) {
+
+  if ((size_t) movement >= lengthof(pm_movements)) {
+    return NULL;
+  }
+
+  return &pm_movements[movement];
+}
+
+size_t Pm_MovementCount(void) {
+  return lengthof(pm_movements);
+}
+
+bool Pm_MovementByName(const char *name, pm_movement_t *movement) {
+
+  assert(movement);
+
+  if (!name || !*name) {
+    return false;
+  }
+
+  for (size_t i = 0; i < lengthof(pm_movements); i++) {
+    if (!q_strcasecmp(pm_movements[i].name, name)) {
+      *movement = (pm_movement_t) i;
+      return true;
+    }
+  }
+
+  return false;
+}
+
 pm_move_t *pm;
 
 pm_locals_t pm_locals;
@@ -382,15 +423,18 @@ void Pm_Move(pm_move_t *pm_move) {
     pm->cmd.forward = pm->cmd.right = pm->cmd.up = 0;
   }
 
-  switch (pm->s.params.kernel) {
-    case PM_KERNEL_QUETOO:
+  switch (pm->s.params.movement) {
+    case PM_MOVEMENT_QUETOO:
       Pm_QuetooMove();
+      break;
+    case PM_MOVEMENT_QUAKE:
+      Pm_QuakeMove();
       break;
     default:
       // the value arrives over the network, so it is clamped rather than
       // trusted; both sides clamp alike, so prediction stays consistent even
       // when a client and a server disagree about what ids exist
-      Pm_Debug("Unknown movement kernel %u\n", pm->s.params.kernel);
+      Pm_Debug("Unknown movement kernel %u\n", pm->s.params.movement);
       Pm_QuetooMove();
       break;
   }

--- a/src/game/common/bg_pmove.c
+++ b/src/game/common/bg_pmove.c
@@ -434,7 +434,7 @@ void Pm_Move(pm_move_t *pm_move) {
       // the value arrives over the network, so it is clamped rather than
       // trusted; both sides clamp alike, so prediction stays consistent even
       // when a client and a server disagree about what ids exist
-      Pm_Debug("Unknown movement kernel %u\n", pm->s.params.movement);
+      Pm_Debug("Unknown movement %u\n", pm->s.params.movement);
       Pm_QuetooMove();
       break;
   }

--- a/src/game/common/bg_pmove.h
+++ b/src/game/common/bg_pmove.h
@@ -224,6 +224,41 @@ typedef struct pm_move_s {
 } pm_move_t;
 
 /**
+ * @brief One movement: the name it answers to, and the parameters that define
+ * it.
+ */
+typedef struct {
+
+  /**
+   * @brief The name used by `g_movement`, the worldspawn `movement` key and the
+   * menu. Never "default", which those reserve to mean "whatever the level
+   * asks for".
+   */
+  const char *name;
+
+  /**
+   * @brief What the menu shows, which may say more than the key does.
+   */
+  const char *label;
+
+  /**
+   * @brief The parameters this movement is defined by, or `NULL` for the one
+   * that follows the server's own movement cvars. A movement that let a cvar
+   * move it would not be a movement anyone could set a record under.
+   */
+  const pm_params_t *params;
+} pm_movement_info_t;
+
+const pm_movement_info_t *Pm_Movement(pm_movement_t movement);
+size_t Pm_MovementCount(void);
+
+/**
+ * @brief Resolves a movement by name.
+ * @return False if nothing answers to `name`, leaving `movement` alone.
+ */
+bool Pm_MovementByName(const char *name, pm_movement_t *movement);
+
+/**
  * @brief Performs one discrete movement of the player through the world.
  * @details Initializes the move, clamps the angles, handles the frozen,
  * spectator and dead cases, and hands the rest to the kernel that

--- a/src/game/common/bg_pmove.h
+++ b/src/game/common/bg_pmove.h
@@ -249,7 +249,15 @@ typedef struct {
   const pm_params_t *params;
 } pm_movement_info_t;
 
+/**
+ * @brief Resolves a movement by id.
+ * @return `NULL` if `movement` names none.
+ */
 const pm_movement_info_t *Pm_Movement(pm_movement_t movement);
+
+/**
+ * @brief The number of movements, for offering them all.
+ */
 size_t Pm_MovementCount(void);
 
 /**

--- a/src/game/common/bg_pmove_internal.h
+++ b/src/game/common/bg_pmove_internal.h
@@ -25,8 +25,8 @@
 
 /**
  * @file
- * @brief The movement plumbing, and the working state it keeps, for the kernels
- * that `Pm_Move` dispatches to.
+ * @brief The movement plumbing, and the working state it keeps, for the movement
+ * kernels that `Pm_Move` dispatches to.
  *
  * `Pm_Move` initializes the move, clamps the angles, handles the frozen,
  * spectator and dead cases, and then hands everything else to the kernel named
@@ -46,7 +46,7 @@
  *
  * A kernel SHOULD be finished rather than maintained. A record is only
  * comparable to another record set under the same movement, so changing what a
- * kernel does is a new kernel, appended to `pm_kernel_t`, not an edit to an
+ * kernel does is a new kernel, appended to `pm_movement_t`, not an edit to an
  * existing one. Fixes to this file are the exception: it is shared, and a fault
  * in the plumbing is a fault in every ruleset.
  */
@@ -126,6 +126,13 @@ void Pm_Gravity(void);
 void Pm_CheckViewStep(void);
 
 /**
- * @brief The kernels, one per `pm_kernel_t`. `Pm_Move` calls exactly one.
+ * @brief The kernels, one per `pm_movement_t`. `Pm_Move` calls exactly one.
  */
 void Pm_QuetooMove(void);
+void Pm_QuakeMove(void);
+
+/**
+ * @brief The parameters each movement that has its own is defined by, exported
+ * by the kernel that implements it.
+ */
+extern const pm_params_t pm_quake_params;

--- a/src/game/common/bg_pmove_quake.c
+++ b/src/game/common/bg_pmove_quake.c
@@ -1,0 +1,643 @@
+/*
+ * Copyright(c) 1997-2001 id Software, Inc.
+ * Copyright(c) 2002 The Quakeforge Project.
+ * Copyright(c) 2006 Quetoo.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Above License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+#include "bg_pmove.h"
+#include "bg_pmove_internal.h"
+
+/**
+ * @file
+ * @brief QuakeWorld's movement, `PM_KERNEL_QUAKE`.
+ *
+ * Ported from id's `QW/client/pmove.c`, which QuakeWorld shared between its
+ * client and its server for exactly the reason we do. It is QuakeWorld's rather
+ * than NetQuake's: the two differ, and it is QuakeWorld that people played and
+ * that bunny hopping belongs to. NetQuake would be a separate kernel.
+ *
+ * The bunny hop is not emulated, it falls out. `Pm_QuakeAirAccelerate` caps the
+ * *wished* speed at 30 units, but scales the acceleration by the uncapped wish
+ * speed, so a player already faster than 30 in the direction they are looking
+ * can still gain the full 30 along a direction they are not - which is what
+ * strafing while airborne does. Nothing here special-cases it.
+ *
+ * There is no ducking. Quake had none, and adding one would not be Quake, so
+ * the kernel never raises `PMF_DUCKED` and the standing box is the only box.
+ *
+ * Being finished is the point: this file matches what it imitates and should
+ * not acquire improvements. A change to how Quake moves is a new kernel.
+ */
+
+/**
+ * @brief The parameters that make this kernel QuakeWorld rather than merely
+ * QuakeWorld-shaped, from `sv_main.c`'s movement variables and `pmove.c`'s
+ * player box. A server selecting this kernel takes these rather than its own
+ * movement cvars; they reach the client inside `pm_state_t`, like any others.
+ */
+const pm_params_t pm_quake_params = {
+  .gravity = 800,               // sv_gravity
+  .gravity_water = 1.f,         // unused: this kernel applies no gravity in water
+  .accel_ground = 10.f,         // sv_accelerate
+  .accel_ground_slick = 10.f,   // unused: Quake has no slick surfaces
+  .accel_air = 10.f,            // sv_accelerate again; PM_AirMove passes it to both
+  .accel_water = 10.f,          // sv_wateraccelerate
+  .accel_spectator = 10.f,
+  .accel_ladder = 10.f,         // unused: Quake has no ladders
+  .friction_ground = 4.f,       // sv_friction
+  .friction_ground_slick = 0.f, // unused
+  .friction_air = 0.f,          // Quake applies no friction while airborne
+  .friction_water = 4.f,        // sv_waterfriction
+  .friction_spectator = 6.f,    // sv_friction * 1.5, as SpectatorMove had it
+  .friction_ladder = 0.f,       // unused
+  .speed_ground = 320.f,        // sv_maxspeed
+  .speed_air = 320.f,
+  .speed_water = 320.f,         // the same cap; the water scale is applied below
+  .speed_ladder = 0.f,          // unused
+  .speed_spectator = 500.f,     // sv_spectatormaxspeed
+  .speed_stop = 100.f,          // sv_stopspeed
+  .speed_jump = 270.f,
+  .speed_ducked = 320.f,        // unused: there is no ducking
+  .speed_duck_stand = 320.f,    // unused
+  .speed_water_jump = 310.f,
+  .height = 32.f,               // player_maxs, against Quetoo's 36
+  .height_ducked = 32.f         // never ducks, so never consulted
+};
+
+#define PM_QUAKE_STEP_SIZE       18.f  // STEPSIZE
+#define PM_QUAKE_CLIP_PLANES     5     // MAX_CLIP_PLANES
+#define PM_QUAKE_BUMPS           4     // numbumps
+#define PM_QUAKE_STOP_EPSILON    .1f   // STOP_EPSILON
+#define PM_QUAKE_GROUND_NORMAL   .7f   // the steepest plane that is still floor
+#define PM_QUAKE_EDGE_FRICTION   2.f   // the multiplier over a dropoff
+#define PM_QUAKE_EDGE_PROBE      16.f  // how far ahead the dropoff is looked for
+#define PM_QUAKE_EDGE_DROP       34.f  // and how far down
+#define PM_QUAKE_UP_SPEED        180.f // rising faster than this is never grounded
+#define PM_QUAKE_AIR_WISH_SPEED  30.f  // the air wish-speed cap the bunny hop lives on
+#define PM_QUAKE_WATER_SCALE     .7f   // wish speed is scaled by this while swimming
+#define PM_QUAKE_WATER_SINK      60.f  // and drifts downward this fast with no input
+#define PM_QUAKE_WATER_UNDER     22.f  // the height at which the view is submerged
+#define PM_QUAKE_WATER_JUMP_TIME 2000  // how long a water jump holds control, in ms
+#define PM_QUAKE_WATER_JUMP_DIST 24.f  // how far ahead the ledge is looked for
+#define PM_QUAKE_WATER_JUMP_PUSH 50.f  // and how hard the player is pushed at it
+#define PM_QUAKE_SNAP            8.f   // the network precision origins are cut to
+
+/**
+ * @brief Slides `in` along `normal`, killing components that round to nothing.
+ * @details QuakeWorld clips without overbounce, unlike Quake II.
+ */
+static vec3_t Pm_QuakeClipVelocity(const vec3_t in, const vec3_t normal) {
+
+  vec3_t out = Vec3_Subtract(in, Vec3_Scale(normal, Vec3_Dot(in, normal)));
+
+  if (out.x > -PM_QUAKE_STOP_EPSILON && out.x < PM_QUAKE_STOP_EPSILON) {
+    out.x = 0.f;
+  }
+  if (out.y > -PM_QUAKE_STOP_EPSILON && out.y < PM_QUAKE_STOP_EPSILON) {
+    out.y = 0.f;
+  }
+  if (out.z > -PM_QUAKE_STOP_EPSILON && out.z < PM_QUAKE_STOP_EPSILON) {
+    out.z = 0.f;
+  }
+
+  return out;
+}
+
+/**
+ * @brief Slides through the world, clipping to every plane struck.
+ */
+static void Pm_QuakeFlyMove(void) {
+
+  const vec3_t primal_velocity = pm->s.velocity;
+  vec3_t original_velocity = pm->s.velocity;
+
+  cm_bsp_plane_t planes[PM_QUAKE_CLIP_PLANES];
+  int32_t num_planes = 0;
+
+  float time_left = pm_locals.time;
+
+  for (int32_t bump = 0; bump < PM_QUAKE_BUMPS; bump++) {
+
+    const vec3_t end = Vec3_Fmaf(pm->s.origin, time_left, pm->s.velocity);
+    const cm_trace_t trace = Pm_Trace(pm->s.origin, end, pm->bounds);
+
+    if (trace.start_solid || trace.all_solid) { // trapped in a solid
+      pm->s.velocity = Vec3_Zero();
+      return;
+    }
+
+    if (trace.fraction > 0.f) { // covered some distance
+      pm->s.origin = trace.end;
+      original_velocity = pm->s.velocity;
+      num_planes = 0;
+    }
+
+    if (trace.fraction == 1.f) { // moved the entire distance
+      break;
+    }
+
+    Pm_TouchEntity(&trace);
+
+    time_left -= time_left * trace.fraction;
+
+    if (num_planes >= PM_QUAKE_CLIP_PLANES) { // this should not happen
+      pm->s.velocity = Vec3_Zero();
+      break;
+    }
+
+    planes[num_planes++] = trace.plane;
+
+    // slide along the first plane that the others do not immediately undo
+    int32_t i;
+    for (i = 0; i < num_planes; i++) {
+      pm->s.velocity = Pm_QuakeClipVelocity(original_velocity, planes[i].normal);
+
+      int32_t j;
+      for (j = 0; j < num_planes; j++) {
+        if (j != i && Vec3_Dot(pm->s.velocity, planes[j].normal) < 0.f) {
+          break;
+        }
+      }
+
+      if (j == num_planes) {
+        break;
+      }
+    }
+
+    if (i == num_planes) { // no such plane, so go along the crease
+      if (num_planes != 2) {
+        pm->s.velocity = Vec3_Zero();
+        break;
+      }
+
+      const vec3_t dir = Vec3_Cross(planes[0].normal, planes[1].normal);
+      pm->s.velocity = Vec3_Scale(dir, Vec3_Dot(dir, pm->s.velocity));
+    }
+
+    // stop dead rather than oscillate in a sloping corner
+    if (Vec3_Dot(pm->s.velocity, primal_velocity) <= 0.f) {
+      pm->s.velocity = Vec3_Zero();
+      break;
+    }
+  }
+
+  if (pm->s.flags & PMF_TIME_WATER_JUMP) {
+    pm->s.velocity = primal_velocity;
+  }
+}
+
+/**
+ * @brief Moves along the ground, taking whichever of the flat and the stepped
+ * candidate travels farther.
+ */
+static void Pm_QuakeGroundMove(void) {
+
+  pm->s.velocity.z = 0.f;
+
+  if (Vec3_Equal(pm->s.velocity, Vec3_Zero())) {
+    return;
+  }
+
+  // try moving straight there first
+  const vec3_t dest = Vec3(pm->s.origin.x + pm->s.velocity.x * pm_locals.time,
+                           pm->s.origin.y + pm->s.velocity.y * pm_locals.time,
+                           pm->s.origin.z);
+
+  cm_trace_t trace = Pm_Trace(pm->s.origin, dest, pm->bounds);
+  if (trace.fraction == 1.f) {
+    pm->s.origin = trace.end;
+    return;
+  }
+
+  const vec3_t original = pm->s.origin;
+  const vec3_t original_velocity = pm->s.velocity;
+
+  Pm_QuakeFlyMove();
+
+  const vec3_t down = pm->s.origin;
+  const vec3_t down_velocity = pm->s.velocity;
+
+  pm->s.origin = original;
+  pm->s.velocity = original_velocity;
+
+  // and again from a step height up
+  trace = Pm_Trace(pm->s.origin, Vec3_Fmaf(pm->s.origin, PM_QUAKE_STEP_SIZE, Vec3_Up()),
+                   pm->bounds);
+  if (!trace.start_solid && !trace.all_solid) {
+    pm->s.origin = trace.end;
+  }
+
+  Pm_QuakeFlyMove();
+
+  // press back down the step height
+  trace = Pm_Trace(pm->s.origin, Vec3_Fmaf(pm->s.origin, PM_QUAKE_STEP_SIZE, Vec3_Down()),
+                   pm->bounds);
+
+  bool use_down = trace.plane.normal.z < PM_QUAKE_GROUND_NORMAL;
+  if (!use_down) {
+    if (!trace.start_solid && !trace.all_solid) {
+      pm->s.origin = trace.end;
+    }
+
+    const float down_dist = Vec2_DistanceSquared(Vec3_XY(down), Vec3_XY(original));
+    const float up_dist = Vec2_DistanceSquared(Vec3_XY(pm->s.origin), Vec3_XY(original));
+
+    use_down = down_dist > up_dist;
+  }
+
+  if (use_down) {
+    pm->s.origin = down;
+    pm->s.velocity = down_velocity;
+  } else { // the stepped move went farther, but its vertical speed is the flat one's
+    pm->s.velocity.z = down_velocity.z;
+  }
+}
+
+/**
+ * @brief Bleeds speed off, on the ground and in water. Nothing is bled while
+ * airborne, which is the other half of why a bunny hop keeps its speed.
+ */
+static void Pm_QuakeFriction(void) {
+
+  if (pm->s.flags & PMF_TIME_WATER_JUMP) {
+    return;
+  }
+
+  const float speed = Vec3_Length(pm->s.velocity);
+  if (speed < 1.f) {
+    pm->s.velocity.x = pm->s.velocity.y = 0.f;
+    return;
+  }
+
+  float friction = pm->s.params.friction_ground;
+
+  if (pm->s.flags & PMF_ON_GROUND) {
+
+    // over a dropoff, friction doubles
+    const vec3_t ahead = Vec3(pm->s.origin.x + pm->s.velocity.x / speed * PM_QUAKE_EDGE_PROBE,
+                              pm->s.origin.y + pm->s.velocity.y / speed * PM_QUAKE_EDGE_PROBE,
+                              pm->s.origin.z + pm->bounds.mins.z);
+    const vec3_t below = Vec3(ahead.x, ahead.y, ahead.z - PM_QUAKE_EDGE_DROP);
+
+    if (Pm_Trace(ahead, below, Box3_Zero()).fraction == 1.f) {
+      friction *= PM_QUAKE_EDGE_FRICTION;
+    }
+  }
+
+  float drop = 0.f;
+
+  if (pm->water_level >= WATER_WAIST) {
+    drop = speed * pm->s.params.friction_water * pm->water_level * pm_locals.time;
+  } else if (pm->s.flags & PMF_ON_GROUND) {
+    const float control = Maxf(speed, pm->s.params.speed_stop);
+    drop = control * friction * pm_locals.time;
+  }
+
+  pm->s.velocity = Vec3_Scale(pm->s.velocity, Maxf(0.f, speed - drop) / speed);
+}
+
+/**
+ * @brief Accelerates toward `dir`, up to `speed`.
+ */
+static void Pm_QuakeAccelerate(const vec3_t dir, float speed, float accel) {
+
+  if (pm->s.type == PM_DEAD || (pm->s.flags & PMF_TIME_WATER_JUMP)) {
+    return;
+  }
+
+  if (pm->Accelerate) {
+    pm->Accelerate(pm, dir, speed, accel);
+  }
+
+  const float add_speed = speed - Vec3_Dot(pm->s.velocity, dir);
+  if (add_speed <= 0.f) {
+    return;
+  }
+
+  const float accel_speed = Minf(accel * pm_locals.time * speed, add_speed);
+
+  pm->s.velocity = Vec3_Fmaf(pm->s.velocity, accel_speed, dir);
+}
+
+/**
+ * @brief Accelerates while airborne, where the wish speed is capped but the
+ * acceleration derived from it is not.
+ * @details This is the bunny hop. A player moving faster than the cap along
+ * `dir` gains nothing, but one moving fast *across* it still has the full cap
+ * available, so turning while strafing converts direction into speed. Passing
+ * the uncapped `speed` to the acceleration and the capped one to the headroom
+ * is what makes that true, and it is why the two are not the same variable.
+ */
+static void Pm_QuakeAirAccelerate(const vec3_t dir, float speed, float accel) {
+
+  if (pm->s.type == PM_DEAD || (pm->s.flags & PMF_TIME_WATER_JUMP)) {
+    return;
+  }
+
+  if (pm->Accelerate) {
+    pm->Accelerate(pm, dir, speed, accel);
+  }
+
+  const float wish_speed = Minf(speed, PM_QUAKE_AIR_WISH_SPEED);
+
+  const float add_speed = wish_speed - Vec3_Dot(pm->s.velocity, dir);
+  if (add_speed <= 0.f) {
+    return;
+  }
+
+  const float accel_speed = Minf(accel * speed * pm_locals.time, add_speed);
+
+  pm->s.velocity = Vec3_Fmaf(pm->s.velocity, accel_speed, dir);
+}
+
+/**
+ * @brief Swims, and steps up out of the water onto a ledge if the move allows.
+ */
+static void Pm_QuakeWaterMove(void) {
+
+  Pm_Debug("%s\n", vtos(pm->s.origin));
+
+  vec3_t wish_velocity = Vec3_Zero();
+  wish_velocity = Vec3_Fmaf(wish_velocity, pm->cmd.forward, pm_locals.forward);
+  wish_velocity = Vec3_Fmaf(wish_velocity, pm->cmd.right, pm_locals.right);
+
+  if (!pm->cmd.forward && !pm->cmd.right && !pm->cmd.up) {
+    wish_velocity.z -= PM_QUAKE_WATER_SINK; // drift toward the bottom
+  } else {
+    wish_velocity.z += pm->cmd.up;
+  }
+
+  float speed;
+  const vec3_t dir = Vec3_NormalizeLength(wish_velocity, &speed);
+  speed = Minf(speed, pm->s.params.speed_water) * PM_QUAKE_WATER_SCALE;
+
+  Pm_QuakeAccelerate(dir, speed, pm->s.params.accel_water);
+
+  // assume a stair or a slope, and press down from a step height above
+  const vec3_t dest = Vec3_Fmaf(pm->s.origin, pm_locals.time, pm->s.velocity);
+  const vec3_t start = Vec3(dest.x, dest.y, dest.z + PM_QUAKE_STEP_SIZE + 1.f);
+
+  const cm_trace_t trace = Pm_Trace(start, dest, pm->bounds);
+  if (!trace.start_solid && !trace.all_solid) { // walked up the step
+    pm->s.origin = trace.end;
+    return;
+  }
+
+  Pm_QuakeFlyMove();
+}
+
+/**
+ * @brief Walks and falls. Gravity is applied here, once, in both cases.
+ */
+static void Pm_QuakeAirMove(void) {
+
+  Pm_Debug("%s\n", vtos(pm->s.origin));
+
+  // the wish is horizontal, from a basis flattened rather than projected
+  vec3_t forward = Vec3(pm_locals.forward.x, pm_locals.forward.y, 0.f);
+  vec3_t right = Vec3(pm_locals.right.x, pm_locals.right.y, 0.f);
+
+  forward = Vec3_Normalize(forward);
+  right = Vec3_Normalize(right);
+
+  vec3_t wish_velocity = Vec3_Zero();
+  wish_velocity = Vec3_Fmaf(wish_velocity, pm->cmd.forward, forward);
+  wish_velocity = Vec3_Fmaf(wish_velocity, pm->cmd.right, right);
+  wish_velocity.z = 0.f;
+
+  float speed;
+  const vec3_t dir = Vec3_NormalizeLength(wish_velocity, &speed);
+  speed = Minf(speed, pm->s.params.speed_ground);
+
+  const float gravity = pm->s.params.gravity * pm_locals.time;
+
+  if (pm->s.flags & PMF_ON_GROUND) {
+    pm->s.velocity.z = 0.f;
+    Pm_QuakeAccelerate(dir, speed, pm->s.params.accel_ground);
+    pm->s.velocity.z -= gravity;
+    Pm_QuakeGroundMove();
+  } else {
+    Pm_QuakeAirAccelerate(dir, speed, pm->s.params.accel_air);
+    pm->s.velocity.z -= gravity;
+    Pm_QuakeFlyMove();
+  }
+}
+
+/**
+ * @brief Classifies the ground beneath the player and the water around them.
+ */
+static void Pm_QuakeCategorizePosition(void) {
+
+  if (pm->s.velocity.z > PM_QUAKE_UP_SPEED) { // rising too fast to be standing
+    pm->s.flags &= ~PMF_ON_GROUND;
+    pm->ground.ent = NULL;
+  } else {
+    const vec3_t below = Vec3(pm->s.origin.x, pm->s.origin.y, pm->s.origin.z - 1.f);
+    const cm_trace_t trace = Pm_Trace(pm->s.origin, below, pm->bounds);
+
+    if (trace.plane.normal.z < PM_QUAKE_GROUND_NORMAL) { // too steep
+      pm->s.flags &= ~PMF_ON_GROUND;
+      pm->ground.ent = NULL;
+    } else {
+      pm->s.flags |= PMF_ON_GROUND;
+      pm->ground = trace;
+      pm_locals.ground = trace;
+
+      pm->s.flags &= ~PMF_TIME_WATER_JUMP;
+
+      if (!trace.start_solid && !trace.all_solid) {
+        pm->s.origin = trace.end;
+      }
+    }
+
+    if (trace.ent) {
+      Pm_TouchEntity(&trace);
+    }
+  }
+
+  pm->water_level = WATER_NONE;
+  pm->water_type = 0;
+
+  vec3_t point = Vec3(pm->s.origin.x, pm->s.origin.y,
+                      pm->s.origin.z + pm->bounds.mins.z + 1.f);
+
+  int32_t contents = pm->PointContents(point);
+  if (contents & CONTENTS_MASK_LIQUID) {
+    pm->water_type = contents;
+    pm->water_level = WATER_FEET;
+
+    point.z = pm->s.origin.z + (pm->bounds.mins.z + pm->bounds.maxs.z) * .5f;
+    contents = pm->PointContents(point);
+    if (contents & CONTENTS_MASK_LIQUID) {
+      pm->water_level = WATER_WAIST;
+
+      point.z = pm->s.origin.z + PM_QUAKE_WATER_UNDER;
+      contents = pm->PointContents(point);
+      if (contents & CONTENTS_MASK_LIQUID) {
+        pm->water_level = WATER_UNDER;
+        pm->s.flags |= PMF_UNDER_WATER;
+      }
+    }
+  }
+}
+
+/**
+ * @brief Jumps, or swims upward. Quake's jump adds to the player's vertical
+ * speed rather than replacing it, which is what a jump off a lift or a ramp
+ * keeps.
+ */
+static void Pm_QuakeJump(void) {
+
+  if (pm->s.type == PM_DEAD) {
+    pm->s.flags |= PMF_JUMP_HELD;
+    return;
+  }
+
+  if (pm->s.flags & PMF_TIME_WATER_JUMP) {
+    return;
+  }
+
+  if (pm->water_level >= WATER_WAIST) { // swimming, not jumping
+    pm->s.flags &= ~PMF_ON_GROUND;
+    pm->ground.ent = NULL;
+
+    if (pm->water_type & CONTENTS_LAVA) {
+      pm->s.velocity.z = 50.f;
+    } else if (pm->water_type & CONTENTS_SLIME) {
+      pm->s.velocity.z = 80.f;
+    } else {
+      pm->s.velocity.z = 100.f;
+    }
+    return;
+  }
+
+  if (!(pm->s.flags & PMF_ON_GROUND)) {
+    return;
+  }
+
+  if (pm->s.flags & PMF_JUMP_HELD) { // no pogo sticking
+    return;
+  }
+
+  pm->s.flags &= ~PMF_ON_GROUND;
+  pm->ground.ent = NULL;
+
+  pm->s.velocity.z += pm->s.params.speed_jump;
+
+  pm->s.flags |= PMF_JUMPED | PMF_JUMP_HELD;
+}
+
+/**
+ * @brief Hops out of water onto a ledge the player is swimming into.
+ */
+static void Pm_QuakeCheckWaterJump(void) {
+
+  if (pm->s.flags & PMF_TIME_WATER_JUMP) {
+    return;
+  }
+
+  if (pm->s.velocity.z < -180.f) { // only hop out while moving up
+    return;
+  }
+
+  vec3_t forward = Vec3(pm_locals.forward.x, pm_locals.forward.y, 0.f);
+  forward = Vec3_Normalize(forward);
+
+  vec3_t spot = Vec3_Fmaf(pm->s.origin, PM_QUAKE_WATER_JUMP_DIST, forward);
+  spot.z += 8.f;
+
+  if (!(pm->PointContents(spot) & CONTENTS_SOLID)) {
+    return;
+  }
+
+  spot.z += PM_QUAKE_WATER_JUMP_DIST;
+
+  if (pm->PointContents(spot)) { // must be clear above the ledge
+    return;
+  }
+
+  pm->s.velocity = Vec3_Scale(forward, PM_QUAKE_WATER_JUMP_PUSH);
+  pm->s.velocity.z = pm->s.params.speed_water_jump;
+
+  pm->s.flags |= PMF_TIME_WATER_JUMP | PMF_JUMP_HELD;
+  pm->s.time = PM_QUAKE_WATER_JUMP_TIME;
+}
+
+/**
+ * @brief Cuts the origin to the precision the network carries, then looks for a
+ * free position nearby if that landed inside something.
+ */
+static void Pm_QuakeNudgePosition(void) {
+
+  const vec3_t base = Vec3(truncf(pm->s.origin.x * PM_QUAKE_SNAP) / PM_QUAKE_SNAP,
+                           truncf(pm->s.origin.y * PM_QUAKE_SNAP) / PM_QUAKE_SNAP,
+                           truncf(pm->s.origin.z * PM_QUAKE_SNAP) / PM_QUAKE_SNAP);
+
+  static const float offsets[] = { 0.f, -1.f / PM_QUAKE_SNAP, 1.f / PM_QUAKE_SNAP };
+
+  pm->s.origin = base;
+
+  for (size_t z = 0; z < lengthof(offsets); z++) {
+    for (size_t x = 0; x < lengthof(offsets); x++) {
+      for (size_t y = 0; y < lengthof(offsets); y++) {
+        const vec3_t candidate = Vec3(base.x + offsets[x],
+                                      base.y + offsets[y],
+                                      base.z + offsets[z]);
+
+        if (!Pm_Trace(candidate, candidate, pm->bounds).start_solid) {
+          pm->s.origin = candidate;
+          return;
+        }
+      }
+    }
+  }
+}
+
+/**
+ * @brief QuakeWorld's movement, in the order `PlayerMove` ran it.
+ */
+void Pm_QuakeMove(void) {
+
+  Pm_QuakeNudgePosition();
+
+  Pm_QuakeCategorizePosition();
+
+  if (pm->water_level == WATER_WAIST) {
+    Pm_QuakeCheckWaterJump();
+  }
+
+  if (pm->s.velocity.z < 0.f) {
+    pm->s.flags &= ~PMF_TIME_WATER_JUMP;
+  }
+
+  if (pm->cmd.up > 0) {
+    Pm_QuakeJump();
+  }
+
+  Pm_QuakeFriction();
+
+  if (pm->water_level >= WATER_WAIST) {
+    Pm_QuakeWaterMove();
+  } else {
+    Pm_QuakeAirMove();
+  }
+
+  Pm_QuakeCategorizePosition();
+
+  Pm_CheckViewStep();
+}

--- a/src/game/common/bg_pmove_quake.c
+++ b/src/game/common/bg_pmove_quake.c
@@ -14,7 +14,7 @@
  *
  * See the GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Above License
+ * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
  */
@@ -24,12 +24,12 @@
 
 /**
  * @file
- * @brief QuakeWorld's movement, `PM_KERNEL_QUAKE`.
+ * @brief QuakeWorld's movement, `PM_MOVEMENT_QUAKE`.
  *
  * Ported from id's `QW/client/pmove.c`, which QuakeWorld shared between its
  * client and its server for exactly the reason we do. It is QuakeWorld's rather
  * than NetQuake's: the two differ, and it is QuakeWorld that people played and
- * that bunny hopping belongs to. NetQuake would be a separate kernel.
+ * that bunny hopping belongs to. NetQuake would be a separate movement.
  *
  * The bunny hop is not emulated, it falls out. `Pm_QuakeAirAccelerate` caps the
  * *wished* speed at 30 units, but scales the acceleration by the uncapped wish
@@ -41,13 +41,13 @@
  * the kernel never raises `PMF_DUCKED` and the standing box is the only box.
  *
  * Being finished is the point: this file matches what it imitates and should
- * not acquire improvements. A change to how Quake moves is a new kernel.
+ * not acquire improvements. A change to how Quake moves is a new movement.
  */
 
 /**
- * @brief The parameters that make this kernel QuakeWorld rather than merely
+ * @brief The parameters that make this QuakeWorld rather than merely
  * QuakeWorld-shaped, from `sv_main.c`'s movement variables and `pmove.c`'s
- * player box. A server selecting this kernel takes these rather than its own
+ * player box. A server selecting this movement takes these rather than its own
  * movement cvars; they reach the client inside `pm_state_t`, like any others.
  */
 const pm_params_t pm_quake_params = {
@@ -96,6 +96,7 @@ const pm_params_t pm_quake_params = {
 #define PM_QUAKE_WATER_JUMP_DIST 24.f  // how far ahead the ledge is looked for
 #define PM_QUAKE_WATER_JUMP_PUSH 50.f  // and how hard the player is pushed at it
 #define PM_QUAKE_SNAP            8.f   // the network precision origins are cut to
+#define PM_QUAKE_VIEW_HEIGHT     22.f  // Quake's eye, against Quetoo's 30
 
 /**
  * @brief Slides `in` along `normal`, killing components that round to nothing.
@@ -609,9 +610,25 @@ static void Pm_QuakeNudgePosition(void) {
 }
 
 /**
+ * @brief Quake's eye height, which is simply a height: there is no duck to lerp
+ * between, so nothing here moves. The dead cases are Quetoo's, because a corpse
+ * is presentation rather than movement.
+ */
+static void Pm_QuakeViewOffset(void) {
+
+  if (pm->s.type == PM_DEAD) {
+    pm->s.view_offset.z = (pm->s.flags & PMF_GIBLET) ? 0.f : -16.f;
+  } else {
+    pm->s.view_offset.z = PM_QUAKE_VIEW_HEIGHT;
+  }
+}
+
+/**
  * @brief QuakeWorld's movement, in the order `PlayerMove` ran it.
  */
 void Pm_QuakeMove(void) {
+
+  Pm_QuakeViewOffset();
 
   Pm_QuakeNudgePosition();
 

--- a/src/game/common/bg_pmove_quake.c
+++ b/src/game/common/bg_pmove_quake.c
@@ -40,6 +40,11 @@
  * There is no ducking. Quake had none, and adding one would not be Quake, so
  * the kernel never raises `PMF_DUCKED` and the standing box is the only box.
  *
+ * There is no grappling hook either, for the same reason, so this kernel does
+ * not implement the `PM_HOOK_*` movement types. `G_AllowHook` declines the hook
+ * for any movement but Quetoo's, which keeps a player from being handed a hook
+ * that nothing here would honour.
+ *
  * Being finished is the point: this file matches what it imitates and should
  * not acquire improvements. A change to how Quake moves is a new movement.
  */
@@ -124,8 +129,12 @@ static vec3_t Pm_QuakeClipVelocity(const vec3_t in, const vec3_t normal) {
  */
 static void Pm_QuakeFlyMove(void) {
 
+  // both are the velocity the move began with, and neither is re-based inside
+  // the loop: each bump re-derives the slide from it rather than from the
+  // already-clipped velocity, which is what lets a second plane give back speed
+  // the first one took
   const vec3_t primal_velocity = pm->s.velocity;
-  vec3_t original_velocity = pm->s.velocity;
+  const vec3_t original_velocity = pm->s.velocity;
 
   cm_bsp_plane_t planes[PM_QUAKE_CLIP_PLANES];
   int32_t num_planes = 0;
@@ -144,7 +153,6 @@ static void Pm_QuakeFlyMove(void) {
 
     if (trace.fraction > 0.f) { // covered some distance
       pm->s.origin = trace.end;
-      original_velocity = pm->s.velocity;
       num_planes = 0;
     }
 
@@ -266,6 +274,9 @@ static void Pm_QuakeGroundMove(void) {
     pm->s.velocity = down_velocity;
   } else { // the stepped move went farther, but its vertical speed is the flat one's
     pm->s.velocity.z = down_velocity.z;
+
+    // tell the view how far it climbed, or stairs snap the camera
+    pm->step = pm->s.origin.z - pm_locals.previous_origin.z;
   }
 }
 
@@ -295,7 +306,10 @@ static void Pm_QuakeFriction(void) {
                               pm->s.origin.z + pm->bounds.mins.z);
     const vec3_t below = Vec3(ahead.x, ahead.y, ahead.z - PM_QUAKE_EDGE_DROP);
 
-    if (Pm_Trace(ahead, below, Box3_Zero()).fraction == 1.f) {
+    // the hull, as upstream traces it: a point here would find a dropoff far
+    // more often than QuakeWorld does, since a box at foot level usually starts
+    // solid and so never reports a clean miss
+    if (Pm_Trace(ahead, below, pm->bounds).fraction == 1.f) {
       friction *= PM_QUAKE_EDGE_FRICTION;
     }
   }
@@ -321,10 +335,6 @@ static void Pm_QuakeAccelerate(const vec3_t dir, float speed, float accel) {
     return;
   }
 
-  if (pm->Accelerate) {
-    pm->Accelerate(pm, dir, speed, accel);
-  }
-
   const float add_speed = speed - Vec3_Dot(pm->s.velocity, dir);
   if (add_speed <= 0.f) {
     return;
@@ -333,6 +343,10 @@ static void Pm_QuakeAccelerate(const vec3_t dir, float speed, float accel) {
   const float accel_speed = Minf(accel * pm_locals.time * speed, add_speed);
 
   pm->s.velocity = Vec3_Fmaf(pm->s.velocity, accel_speed, dir);
+
+  if (pm->Accelerate) {
+    pm->Accelerate(pm, dir, speed, accel);
+  }
 }
 
 /**
@@ -350,10 +364,6 @@ static void Pm_QuakeAirAccelerate(const vec3_t dir, float speed, float accel) {
     return;
   }
 
-  if (pm->Accelerate) {
-    pm->Accelerate(pm, dir, speed, accel);
-  }
-
   const float wish_speed = Minf(speed, PM_QUAKE_AIR_WISH_SPEED);
 
   const float add_speed = wish_speed - Vec3_Dot(pm->s.velocity, dir);
@@ -364,6 +374,10 @@ static void Pm_QuakeAirAccelerate(const vec3_t dir, float speed, float accel) {
   const float accel_speed = Minf(accel * speed * pm_locals.time, add_speed);
 
   pm->s.velocity = Vec3_Fmaf(pm->s.velocity, accel_speed, dir);
+
+  if (pm->Accelerate) {
+    pm->Accelerate(pm, dir, speed, accel);
+  }
 }
 
 /**
@@ -421,6 +435,8 @@ static void Pm_QuakeAirMove(void) {
   wish_velocity = Vec3_Fmaf(wish_velocity, pm->cmd.right, right);
   wish_velocity.z = 0.f;
 
+  // the ground speed bounds the wish in the air as well, because upstream bounds
+  // both with `movevars.maxspeed`; `speed_air` is deliberately unread here
   float speed;
   const vec3_t dir = Vec3_NormalizeLength(wish_velocity, &speed);
   speed = Minf(speed, pm->s.params.speed_ground);
@@ -444,22 +460,32 @@ static void Pm_QuakeAirMove(void) {
  */
 static void Pm_QuakeCategorizePosition(void) {
 
-  if (pm->s.velocity.z > PM_QUAKE_UP_SPEED) { // rising too fast to be standing
+  // a push, a knockback or a fresh spawn asks the plumbing not to be re-grounded
+  // for a moment; QuakeWorld had nothing of the kind, so it says nothing about
+  // this, and honouring it is what keeps rocket knockback from being taken
+  // straight back off by ground friction
+  if (pm->s.flags & PMF_TIME_PUSHED) {
     pm->s.flags &= ~PMF_ON_GROUND;
-    pm->ground.ent = NULL;
+    memset(&pm->ground, 0, sizeof(pm->ground));
+  } else if (pm->s.velocity.z > PM_QUAKE_UP_SPEED) { // rising too fast to be standing
+    pm->s.flags &= ~PMF_ON_GROUND;
+    memset(&pm->ground, 0, sizeof(pm->ground));
   } else {
     const vec3_t below = Vec3(pm->s.origin.x, pm->s.origin.y, pm->s.origin.z - 1.f);
     const cm_trace_t trace = Pm_Trace(pm->s.origin, below, pm->bounds);
 
     if (trace.plane.normal.z < PM_QUAKE_GROUND_NORMAL) { // too steep
       pm->s.flags &= ~PMF_ON_GROUND;
-      pm->ground.ent = NULL;
+      memset(&pm->ground, 0, sizeof(pm->ground));
     } else {
       pm->s.flags |= PMF_ON_GROUND;
       pm->ground = trace;
       pm_locals.ground = trace;
 
-      pm->s.flags &= ~PMF_TIME_WATER_JUMP;
+      if (pm->s.flags & PMF_TIME_WATER_JUMP) {
+        pm->s.flags &= ~PMF_TIME_WATER_JUMP;
+        pm->s.time = 0;
+      }
 
       if (!trace.start_solid && !trace.all_solid) {
         pm->s.origin = trace.end;
@@ -515,7 +541,7 @@ static void Pm_QuakeJump(void) {
 
   if (pm->water_level >= WATER_WAIST) { // swimming, not jumping
     pm->s.flags &= ~PMF_ON_GROUND;
-    pm->ground.ent = NULL;
+    memset(&pm->ground, 0, sizeof(pm->ground));
 
     if (pm->water_type & CONTENTS_LAVA) {
       pm->s.velocity.z = 50.f;
@@ -536,7 +562,7 @@ static void Pm_QuakeJump(void) {
   }
 
   pm->s.flags &= ~PMF_ON_GROUND;
-  pm->ground.ent = NULL;
+  memset(&pm->ground, 0, sizeof(pm->ground));
 
   pm->s.velocity.z += pm->s.params.speed_jump;
 
@@ -580,18 +606,22 @@ static void Pm_QuakeCheckWaterJump(void) {
 }
 
 /**
- * @brief Cuts the origin to the precision the network carries, then looks for a
- * free position nearby if that landed inside something.
+ * @brief Looks for a free position within an eighth of a unit of where the
+ * player is, in the order QuakeWorld looked.
+ * @details Upstream appears to quantize the origin to eighths first, but does
+ * not: its `base` is the unquantized origin, its first candidate is `base`
+ * itself, and its fallback restores `base`, so the quantized value never
+ * survives. This does what it does rather than what it looks like it does.
+ *
+ * The probe is `pm->Trace` and not `Pm_Trace`, because the latter jitters the
+ * start by up to a whole unit to escape a solid - eight times the precision
+ * being searched for here, which would report a blocked candidate as free.
  */
 static void Pm_QuakeNudgePosition(void) {
 
-  const vec3_t base = Vec3(truncf(pm->s.origin.x * PM_QUAKE_SNAP) / PM_QUAKE_SNAP,
-                           truncf(pm->s.origin.y * PM_QUAKE_SNAP) / PM_QUAKE_SNAP,
-                           truncf(pm->s.origin.z * PM_QUAKE_SNAP) / PM_QUAKE_SNAP);
+  const vec3_t base = pm->s.origin;
 
   static const float offsets[] = { 0.f, -1.f / PM_QUAKE_SNAP, 1.f / PM_QUAKE_SNAP };
-
-  pm->s.origin = base;
 
   for (size_t z = 0; z < lengthof(offsets); z++) {
     for (size_t x = 0; x < lengthof(offsets); x++) {
@@ -600,13 +630,15 @@ static void Pm_QuakeNudgePosition(void) {
                                       base.y + offsets[y],
                                       base.z + offsets[z]);
 
-        if (!Pm_Trace(candidate, candidate, pm->bounds).start_solid) {
+        if (!pm->Trace(candidate, candidate, pm->bounds).start_solid) {
           pm->s.origin = candidate;
           return;
         }
       }
     }
   }
+
+  pm->s.origin = base;
 }
 
 /**
@@ -638,12 +670,18 @@ void Pm_QuakeMove(void) {
     Pm_QuakeCheckWaterJump();
   }
 
-  if (pm->s.velocity.z < 0.f) {
+  if (pm->s.velocity.z < 0.f && (pm->s.flags & PMF_TIME_WATER_JUMP)) {
     pm->s.flags &= ~PMF_TIME_WATER_JUMP;
+    pm->s.time = 0;
   }
 
   if (pm->cmd.up > 0) {
     Pm_QuakeJump();
+  }
+
+  if (pm->s.flags & PMF_TIME_TELEPORT) { // held in place briefly, as Quetoo does
+    Pm_QuakeCategorizePosition();
+    return;
   }
 
   Pm_QuakeFriction();

--- a/src/game/common/bg_pmove_quetoo.c
+++ b/src/game/common/bg_pmove_quetoo.c
@@ -24,7 +24,7 @@
 
 /**
  * @file
- * @brief Quetoo's own movement kernel, `PM_KERNEL_QUETOO`.
+ * @brief Quetoo's own movement kernel, `PM_MOVEMENT_QUETOO`.
  *
  * Everything here was `bg_pmove.c` before the kernel became a selection rather
  * than the only option; the move it performs is unchanged. What stayed behind

--- a/src/game/common/g_entity.c
+++ b/src/game/common/g_entity.c
@@ -824,20 +824,20 @@ static void G_worldspawn(g_entity_t *ent) {
   // for, else this level's metadata, else its worldspawn, else Quetoo's. It needs
   // no config string, because it reaches the client inside the movement
   // parameters, which are networked per-player
-  g_level.movement = PM_MOVEMENT_QUETOO;
-
   const cm_entity_t *movement_map = G_MapValue("movement");
-  if (q_strcmp(g_movement->string, "default")) { // prefer the admin's choice
-    Pm_MovementByName(g_movement->string, &g_level.movement);
-  } else if (movement_map && *movement_map->string) { // then map metadata
-    Pm_MovementByName(movement_map->string, &g_level.movement);
-  } else { // or fall back on worldspawn
-    Pm_MovementByName(gi.EntityValue(ent->def, "movement")->string, &g_level.movement);
+  const char *movement = (movement_map && *movement_map->string)
+                         ? movement_map->string
+                         : gi.EntityValue(ent->def, "movement")->string;
+
+  g_level.movement = G_ResolveMovement(movement);
+
+  // say so when it is not the usual one, because a player who does not know they
+  // are on Quake movement will think the server is broken
+  if (g_level.movement != PM_MOVEMENT_QUETOO) {
+    gi.BroadcastPrint(PRINT_HIGH, "Movement is %s\n", Pm_Movement(g_level.movement)->label);
   }
 
-  // as with g_gameplay_mode, publish what it resolved to, since that is the only
-  // form a server browser can present
-  gi.ForceSetCvarString("g_movement_mode", Pm_Movement(g_level.movement)->name);
+  gi.Print("  Movement:   ^2%s^7\n", Pm_Movement(g_level.movement)->name);
 
   g_level.teams = (g_level.gameplay & GAMEPLAY_TEAMS) != 0;
 

--- a/src/game/common/g_entity.c
+++ b/src/game/common/g_entity.c
@@ -820,6 +820,25 @@ static void G_worldspawn(g_entity_t *ent) {
 
   gi.SetConfigString(CS_ITEM_SET, va("%d", g_level.items));
 
+  // the movement takes the same precedence gameplay does: what the admin asked
+  // for, else this level's metadata, else its worldspawn, else Quetoo's. It needs
+  // no config string, because it reaches the client inside the movement
+  // parameters, which are networked per-player
+  g_level.movement = PM_MOVEMENT_QUETOO;
+
+  const cm_entity_t *movement_map = G_MapValue("movement");
+  if (q_strcmp(g_movement->string, "default")) { // prefer the admin's choice
+    Pm_MovementByName(g_movement->string, &g_level.movement);
+  } else if (movement_map && *movement_map->string) { // then map metadata
+    Pm_MovementByName(movement_map->string, &g_level.movement);
+  } else { // or fall back on worldspawn
+    Pm_MovementByName(gi.EntityValue(ent->def, "movement")->string, &g_level.movement);
+  }
+
+  // as with g_gameplay_mode, publish what it resolved to, since that is the only
+  // form a server browser can present
+  gi.ForceSetCvarString("g_movement_mode", Pm_Movement(g_level.movement)->name);
+
   g_level.teams = (g_level.gameplay & GAMEPLAY_TEAMS) != 0;
 
   if (q_strcmp(g_num_teams->string, "default")) {

--- a/src/game/common/g_hook.c
+++ b/src/game/common/g_hook.c
@@ -549,10 +549,15 @@ static void G_HookCheckFire(g_client_t *cl, const bool refire) {
 }
 
 /**
- * @brief The tail of the `G_AllowHook` chain: every client may hook.
+ * @brief The tail of the `G_AllowHook` chain: every client may hook, unless the
+ * movement they are running has no hook to swing on.
+ * @details The hook is a Quetoo feature, and a movement ported from another game
+ * neither implements the `PM_HOOK_*` types nor honours `hook_length`. Declining
+ * here is how the feature stays out of a ruleset that cannot carry it, rather
+ * than the ruleset having to know the feature exists.
  */
 static bool G_AllowHook_Common(const g_client_t *cl) {
-  return true;
+  return g_level.movement == PM_MOVEMENT_QUETOO;
 }
 
 AllowHook G_AllowHook = G_AllowHook_Common;

--- a/src/game/common/g_main.c
+++ b/src/game/common/g_main.c
@@ -135,6 +135,7 @@ cvar_t *g_cheats;
 cvar_t *g_frag_limit;
 cvar_t *g_friendly_fire;
 cvar_t *g_gameplay;
+cvar_t *g_movement;
 
 // player movement parameters (hydrated into pm_params_t by G_MovementParams)
 cvar_t *g_air_acceleration;
@@ -568,9 +569,9 @@ static char *G_FormatTime(uint32_t time) {
  * sanitization (clamping, divide-by-zero guards).
  */
 pm_params_t G_MovementParams(void) {
-  return (pm_params_t) {
+
+  pm_params_t params = (pm_params_t) {
     .gravity = g_level.gravity,
-    .kernel = PM_KERNEL_QUETOO,
     .gravity_water = g_water_gravity->value,
 
     .accel_ground = g_ground_acceleration->value,
@@ -600,7 +601,19 @@ pm_params_t G_MovementParams(void) {
 
     .height = g_stand_height->value,
     .height_ducked = g_duck_height->value,
+    .movement = g_level.movement,
   };
+
+  // every movement but Quetoo's is defined by its own parameters rather than by
+  // this server's cvars: one that drifted with a cvar would not be a movement
+  // anyone could set a comparable record under
+  const pm_movement_info_t *movement = Pm_Movement(g_level.movement);
+  if (movement && movement->params) {
+    params = *movement->params;
+    params.movement = g_level.movement;
+  }
+
+  return params;
 }
 
 /**
@@ -1043,6 +1056,9 @@ void G_Init(void) {
   gi.AddCvar("g_gameplay_mode", "", CVAR_SERVER_INFO | CVAR_NO_SET,
     "The gameplay mode this level actually resolved to, published for the server browser. "
     "Read g_gameplay for what was requested.");
+  gi.AddCvar("g_movement_mode", "", CVAR_SERVER_INFO | CVAR_NO_SET,
+    "The player movement this level actually resolved to, published for the server browser. "
+    "Read g_movement for what was requested.");
 
   // player movement parameters (hydrated into pm_params_t by G_MovementParams)
   g_air_acceleration = gi.AddCvar("g_air_acceleration", "2.0", 0, "Acceleration applied while airborne. Default 2.0; set 0 for classic-Quake2 movement.");
@@ -1052,6 +1068,7 @@ void G_Init(void) {
   g_duck_stand_speed = gi.AddCvar("g_duck_stand_speed", "200.0", 0, "Rate the view rises/falls when standing/ducking. Default 200.0.");
   g_duck_height = gi.AddCvar("g_duck_height", "6.0", 0, "Top of the player bounding box while ducked. Default 6.0.");
   g_gravity = gi.AddCvar("g_gravity", "800", CVAR_SERVER_INFO, NULL);
+  g_movement = gi.AddCvar("g_movement", "default", CVAR_SERVER_INFO, "The player movement to run: \"default\" defers to the level, otherwise a movement name such as \"quetoo\" or \"quake\".");
   g_ground_acceleration = gi.AddCvar("g_ground_acceleration", "10.0", 0, "Ground acceleration. Default 10.0.");
   g_ground_acceleration_slick = gi.AddCvar("g_ground_acceleration_slick", "4.375", 0, "Ground acceleration on slick surfaces. Default 4.375.");
   g_ground_friction = gi.AddCvar("g_ground_friction", "6.0", 0, "Ground friction. Default 6.0.");

--- a/src/game/common/g_main.c
+++ b/src/game/common/g_main.c
@@ -137,6 +137,12 @@ cvar_t *g_friendly_fire;
 cvar_t *g_gameplay;
 cvar_t *g_movement;
 
+/**
+ * @brief What this level asked for, remembered so that setting `g_movement`
+ * back to "default" returns to it rather than to Quetoo's.
+ */
+static pm_movement_t g_movement_level;
+
 // player movement parameters (hydrated into pm_params_t by G_MovementParams)
 cvar_t *g_air_acceleration;
 cvar_t *g_air_friction;
@@ -617,6 +623,50 @@ pm_params_t G_MovementParams(void) {
 }
 
 /**
+ * @brief Parses `g_movement` over what the level asked for, and coerces the cvar
+ * itself to whichever canonical name results.
+ * @details A name nothing answers to is warned about and falls back rather than
+ * silently running something else, which is the whole reason this coerces: an
+ * unknown movement that quietly behaved like Quetoo's would be indistinguishable
+ * from a working one.
+ */
+static pm_movement_t G_CoerceMovement(void) {
+
+  pm_movement_t movement = g_movement_level;
+
+  if (q_strcmp(g_movement->string, "default")) { // "default" defers to the level
+    if (!Pm_MovementByName(g_movement->string, &movement)) {
+      G_Warn("Unknown movement \"%s\", using %s\n",
+              g_movement->string, Pm_Movement(movement)->name);
+    }
+
+    gi.SetCvarString(g_movement->name, Pm_Movement(movement)->name);
+  }
+
+  gi.ForceSetCvarString("g_movement_mode", Pm_Movement(movement)->name);
+
+  return movement;
+}
+
+/**
+ * @brief Resolves the movement for a level that asks for `name`, which may be
+ * empty. `g_movement` still wins if the admin named one.
+ */
+pm_movement_t G_ResolveMovement(const char *name) {
+
+  g_movement_level = PM_MOVEMENT_QUETOO;
+
+  if (name && *name) {
+    if (!Pm_MovementByName(name, &g_movement_level)) {
+      G_Warn("Unknown movement \"%s\" in this level, using %s\n",
+              name, Pm_Movement(g_movement_level)->name);
+    }
+  }
+
+  return G_CoerceMovement();
+}
+
+/**
  * @brief Parses `g_gameplay`, lets the module clamp it to a mode it actually
  * supports, and coerces the cvar string itself back to whichever canonical
  * value results.
@@ -687,6 +737,25 @@ static void G_CheckRules(void) {
     restart = true;
 
     gi.BroadcastPrint(PRINT_HIGH, "Gameplay has changed to %s\n", G_GameplayById(g_level.gameplay)->label);
+  }
+
+  if (g_movement->modified) { // change how players move, with no restart
+
+    const pm_movement_t movement = G_CoerceMovement();
+
+    // as above, the coercion re-marks modified whenever it changed the string
+    g_movement->modified = false;
+
+    if (movement != g_level.movement) {
+      g_level.movement = movement;
+
+      // the parameters are hydrated per client per frame and travel inside the
+      // player state, so the change reaches everyone without a restart; the one
+      // cost is a frame of misprediction, and a taller box has to fit where the
+      // player is standing
+      gi.BroadcastPrint(PRINT_HIGH, "Movement has changed to %s\n",
+                        Pm_Movement(movement)->label);
+    }
   }
 
   if (g_friendly_fire->modified) {

--- a/src/game/common/g_main.h
+++ b/src/game/common/g_main.h
@@ -161,6 +161,7 @@ extern cvar_t *g_duck_speed;
 extern cvar_t *g_duck_stand_speed;
 extern cvar_t *g_duck_height;
 extern cvar_t *g_gravity;
+extern cvar_t *g_movement;
 extern cvar_t *g_ground_acceleration;
 extern cvar_t *g_ground_acceleration_slick;
 extern cvar_t *g_ground_friction;

--- a/src/game/common/g_main.h
+++ b/src/game/common/g_main.h
@@ -29,6 +29,7 @@ extern g_level_t g_level;
 extern g_media_t g_media;
 
 pm_params_t G_MovementParams(void);
+pm_movement_t G_ResolveMovement(const char *name);
 
 extern g_import_t gi;
 

--- a/src/game/ctf/Makefile.am
+++ b/src/game/ctf/Makefile.am
@@ -27,6 +27,7 @@ game_la_SOURCES = \
 	bg_item.c \
 	bg_pmove.c \
 	bg_pmove_quetoo.c \
+	bg_pmove_quake.c \
 	g_ai_goal.c \
 	g_ai_grid.c \
 	g_ai_info.c \

--- a/src/game/ctf/g_types.h
+++ b/src/game/ctf/g_types.h
@@ -41,7 +41,7 @@
  * @brief Game protocol version (protocol minor version). To be incremented
  * whenever the game protocol changes.
  */
-#define PROTOCOL_MINOR 1047
+#define PROTOCOL_MINOR 1048
 
 /**
  * @brief Game-specific server protocol commands. These are parsed directly by
@@ -811,6 +811,11 @@ typedef struct {
    * @brief Active item set.
    */
   g_items_t items;
+
+  /**
+   * @brief The player movement this level runs.
+   */
+  pm_movement_t movement;
 
   /**
    * @brief True if team play is active.

--- a/src/game/default/Makefile.am
+++ b/src/game/default/Makefile.am
@@ -24,6 +24,7 @@ game_la_SOURCES = \
 	bg_item.c \
 	bg_pmove.c \
 	bg_pmove_quetoo.c \
+	bg_pmove_quake.c \
 	g_ai_goal.c \
 	g_ai_grid.c \
 	g_ai_info.c \

--- a/src/game/default/g_types.h
+++ b/src/game/default/g_types.h
@@ -39,7 +39,7 @@
  * @brief Game protocol version (protocol minor version). To be incremented
  * whenever the game protocol changes.
  */
-#define PROTOCOL_MINOR 1047
+#define PROTOCOL_MINOR 1048
 
 /**
  * @brief Game-specific server protocol commands. These are parsed directly by
@@ -792,6 +792,11 @@ typedef struct {
    * @brief Active item set.
    */
   g_items_t items;
+
+  /**
+   * @brief The player movement this level runs.
+   */
+  pm_movement_t movement;
 
   /**
    * @brief True if team play is active.

--- a/src/game/lithium/Makefile.am
+++ b/src/game/lithium/Makefile.am
@@ -26,6 +26,7 @@ game_la_SOURCES = \
 	bg_item.c \
 	bg_pmove.c \
 	bg_pmove_quetoo.c \
+	bg_pmove_quake.c \
 	g_ai_goal.c \
 	g_ai_grid.c \
 	g_ai_info.c \

--- a/src/game/lithium/g_types.h
+++ b/src/game/lithium/g_types.h
@@ -41,7 +41,7 @@
  * @brief Game protocol version (protocol minor version). To be incremented
  * whenever the game protocol changes.
  */
-#define PROTOCOL_MINOR 1047
+#define PROTOCOL_MINOR 1048
 
 /**
  * @brief Game-specific server protocol commands. These are parsed directly by
@@ -798,6 +798,11 @@ typedef struct {
    * @brief Active item set.
    */
   g_items_t items;
+
+  /**
+   * @brief The player movement this level runs.
+   */
+  pm_movement_t movement;
 
   /**
    * @brief True if team play is active.

--- a/src/game/race/Makefile.am
+++ b/src/game/race/Makefile.am
@@ -25,6 +25,7 @@ game_la_SOURCES = \
 	bg_item.c \
 	bg_pmove.c \
 	bg_pmove_quetoo.c \
+	bg_pmove_quake.c \
 	g_ai_goal.c \
 	g_ai_grid.c \
 	g_ai_info.c \

--- a/src/game/race/g_types.h
+++ b/src/game/race/g_types.h
@@ -40,7 +40,7 @@
  * @brief Game protocol version (protocol minor version). To be incremented
  * whenever the game protocol changes.
  */
-#define PROTOCOL_MINOR 1047
+#define PROTOCOL_MINOR 1048
 
 /**
  * @brief Game-specific server protocol commands. These are parsed directly by
@@ -796,6 +796,11 @@ typedef struct {
    * @brief Active item set.
    */
   g_items_t items;
+
+  /**
+   * @brief The player movement this level runs.
+   */
+  pm_movement_t movement;
 
   /**
    * @brief True if team play is active.

--- a/src/net/net_message.c
+++ b/src/net/net_message.c
@@ -279,8 +279,8 @@ void Net_WriteDeltaPlayerState(mem_buf_t *msg, const player_state_t *from, const
     bits |= PS_PM_GRAVITY;
   }
 
-  if (to->pm_state.params.kernel != from->pm_state.params.kernel) {
-    bits |= PS_PM_KERNEL;
+  if (to->pm_state.params.movement != from->pm_state.params.movement) {
+    bits |= PS_PM_MOVEMENT;
   }
 
   if (!Vec3_Equal(to->pm_state.view_offset, from->pm_state.view_offset)) {
@@ -346,8 +346,8 @@ void Net_WriteDeltaPlayerState(mem_buf_t *msg, const player_state_t *from, const
     Net_WriteShort(msg, to->pm_state.params.gravity);
   }
 
-  if (bits & PS_PM_KERNEL) {
-    Net_WriteByte(msg, to->pm_state.params.kernel);
+  if (bits & PS_PM_MOVEMENT) {
+    Net_WriteByte(msg, to->pm_state.params.movement);
   }
 
   if (bits & PS_PM_VIEW_OFFSET) {
@@ -870,8 +870,8 @@ void Net_ReadDeltaPlayerState(mem_buf_t *msg, const player_state_t *from, player
     to->pm_state.params.gravity = Net_ReadShort(msg);
   }
 
-  if (bits & PS_PM_KERNEL) {
-    to->pm_state.params.kernel = Net_ReadByte(msg);
+  if (bits & PS_PM_MOVEMENT) {
+    to->pm_state.params.movement = Net_ReadByte(msg);
   }
 
   if (bits & PS_PM_VIEW_OFFSET) {

--- a/src/net/net_message.h
+++ b/src/net/net_message.h
@@ -41,7 +41,7 @@
 #define PS_PM_HOOK_LENGTH   (1 << 12)
 #define PS_PM_STEP_OFFSET   (1 << 13)
 #define PS_PM_PARAMS        (1 << 14)
-#define PS_PM_MOVEMENT        (1 << 15)
+#define PS_PM_MOVEMENT      (1 << 15)
 
 /**
  * @brief Delta compression flags for `user_cmd_t`.

--- a/src/net/net_message.h
+++ b/src/net/net_message.h
@@ -41,7 +41,7 @@
 #define PS_PM_HOOK_LENGTH   (1 << 12)
 #define PS_PM_STEP_OFFSET   (1 << 13)
 #define PS_PM_PARAMS        (1 << 14)
-#define PS_PM_KERNEL        (1 << 15)
+#define PS_PM_MOVEMENT        (1 << 15)
 
 /**
  * @brief Delta compression flags for `user_cmd_t`.

--- a/src/shared/shared.h
+++ b/src/shared/shared.h
@@ -290,7 +290,7 @@ typedef enum {
  * These values are networked. The list is append-only: an id names a movement
  * forever, and reordering it would silently put every client on a different
  * one. It is the name `g_movement`, the worldspawn `movement` key and the menu
- * all use. Every kernel is in this tree and available to every module, so
+ * all use. Every movement is in this tree and available to every module, so
  * there is no module-defined range: unlike `CS_GAME` or `EF_GAME`, which the
  * engine forwards without interpreting, an id has to resolve to code that
  * both the game and the client game hold.
@@ -310,7 +310,7 @@ typedef enum {
  */
 typedef struct {
   int16_t gravity;     // world gravity; default from g_gravity / map (int16)
-  uint8_t movement;      // pm_movement_t; which movement kernel Pm_Move runs
+  uint8_t movement;      // pm_movement_t; which movement Pm_Move runs
   float gravity_water; // PM_GRAVITY_WATER
 
   float accel_ground, accel_ground_slick, accel_air, accel_water,

--- a/src/shared/shared.h
+++ b/src/shared/shared.h
@@ -279,23 +279,26 @@ typedef enum {
 #define PMF_GAME (1 << 0)
 
 /**
- * @brief The movement kernels `Pm_Move` can run, selected per-player through
- * `pm_params_t.kernel`.
- * @details A kernel owns everything about how a player moves once the move is
- * initialized: the ground, water and duck checks, the slide and the step. Each
- * lives in its own `bg_pmove_*.c` and is finished rather than maintained, so
- * that a ruleset a record was set under cannot drift.
+ * @brief The movements `Pm_Move` can run, selected per-player through
+ * `pm_params_t.movement`.
+ * @details One of these owns everything about how a player moves once the move
+ * is initialized: the ground, water and duck checks, the slide and the step, and
+ * the parameters it moves by. Each lives in its own `bg_pmove_*.c` and is
+ * finished rather than maintained, so that a movement a record was set under
+ * cannot drift. This changes how a player moves, not how the world behaves.
  *
- * These values are networked. The list is append-only: an id names a ruleset
- * forever, and reordering it would silently move every client onto different
- * physics. Every kernel is in this tree and available to every module, so
+ * These values are networked. The list is append-only: an id names a movement
+ * forever, and reordering it would silently put every client on a different
+ * one. It is the name `g_movement`, the worldspawn `movement` key and the menu
+ * all use. Every kernel is in this tree and available to every module, so
  * there is no module-defined range: unlike `CS_GAME` or `EF_GAME`, which the
  * engine forwards without interpreting, an id has to resolve to code that
  * both the game and the client game hold.
  */
 typedef enum {
-  PM_KERNEL_QUETOO, // Quetoo's own, in bg_pmove_quetoo.c
-} pm_kernel_t;
+  PM_MOVEMENT_QUETOO, // Quetoo's own, in bg_pmove_quetoo.c
+  PM_MOVEMENT_QUAKE,  // QuakeWorld's, in bg_pmove_quake.c
+} pm_movement_t;
 
 /**
  * @brief Server-tunable player-movement parameters, networked per-player
@@ -307,7 +310,7 @@ typedef enum {
  */
 typedef struct {
   int16_t gravity;     // world gravity; default from g_gravity / map (int16)
-  uint8_t kernel;      // pm_kernel_t; which movement kernel Pm_Move runs
+  uint8_t movement;      // pm_movement_t; which movement kernel Pm_Move runs
   float gravity_water; // PM_GRAVITY_WATER
 
   float accel_ground, accel_ground_slick, accel_air, accel_water,
@@ -324,8 +327,8 @@ typedef struct {
 
 /**
  * @brief This layout is the wire format. `Net_WriteDeltaPlayerState` sends
- * `gravity` and `kernel` on their own bits and compares everything from
- * `gravity_water` on with one `memcmp`, so two things must stay true: `kernel`
+ * `gravity` and `movement` on their own bits and compares everything from
+ * `gravity_water` on with one `memcmp`, so two things must stay true: `movement`
  * must keep sitting in the padding `gravity` leaves, or the compared region
  * moves, and that region must hold nothing but the floats the encoder writes,
  * or the comparison reads padding and resends the block at random. A field
@@ -333,7 +336,7 @@ typedef struct {
  * the second. Both are asserted rather than commented so that the build says so.
  */
 _Static_assert(offsetof(pm_params_t, gravity_water) == sizeof(float),
-               "pm_params_t.kernel must fit in the padding after gravity");
+               "pm_params_t.movement must fit in the padding after gravity");
 _Static_assert(sizeof(pm_params_t) - offsetof(pm_params_t, gravity_water) ==
                25 * sizeof(float),
                "the delta-compared region of pm_params_t must be floats only");

--- a/src/tests/Makefile.am
+++ b/src/tests/Makefile.am
@@ -45,6 +45,7 @@ TESTS = \
 	check_master \
 	check_mem \
 	check_net_message \
+	check_pmove \
 	check_r_media \
 	check_shared \
 	check_thread \
@@ -166,6 +167,20 @@ check_net_message_CFLAGS = \
 check_net_message_LDADD = \
 	$(TESTS_LIBS) \
 	$(top_builddir)/src/net/libnet.la
+
+check_pmove_SOURCES = \
+	check_pmove.c \
+	$(top_srcdir)/src/game/common/bg_pmove.c \
+	$(top_srcdir)/src/game/common/bg_pmove_quake.c \
+	$(top_srcdir)/src/game/common/bg_pmove_quetoo.c
+check_pmove_CFLAGS = \
+	-I$(top_srcdir)/src \
+	-fms-extensions \
+	-Wno-microsoft-anon-tag \
+	$(TESTS_CFLAGS)
+check_pmove_LDADD = \
+	$(TESTS_LIBS) \
+	$(top_builddir)/src/collision/libcollision.la
 
 check_r_media_SOURCES = \
 	check_r_media.c

--- a/src/tests/check_net_message.c
+++ b/src/tests/check_net_message.c
@@ -45,9 +45,7 @@ void teardown(void) {
  */
 static void Fill_TestParams(pm_params_t *p) {
   p->gravity = 750;
-  // an arbitrary non-default byte rather than a real `pm_kernel_t`: what is
-  // under test is that the field reaches the other side, not what it selects
-  p->kernel = 3;
+  p->movement = PM_MOVEMENT_QUAKE;
   p->gravity_water = 0.5f;
   p->accel_ground = 11.f;       p->accel_ground_slick = 4.5f;
   p->accel_air = 3.f;           p->accel_water = 3.5f;
@@ -86,7 +84,7 @@ START_TEST(check_PlayerState_Params_RoundTrip) {
   Net_ReadDeltaPlayerState(&buf, &from, &result);
 
   ck_assert_int_eq(result.pm_state.params.gravity, to.pm_state.params.gravity);
-  ck_assert_int_eq(result.pm_state.params.kernel, to.pm_state.params.kernel);
+  ck_assert_int_eq(result.pm_state.params.movement, to.pm_state.params.movement);
 
   ck_assert_msg(memcmp(&result.pm_state.params.gravity_water, &to.pm_state.params.gravity_water,
                        sizeof(pm_params_t) - offsetof(pm_params_t, gravity_water)) == 0,
@@ -121,13 +119,13 @@ START_TEST(check_PlayerState_Params_DeltaCompressed) {
 } END_TEST
 
 /**
- * @brief The movement kernel is delta-compressed on its own bit: a change to it
- * alone must reach the client, and must not cost the whole parameter block.
+ * @brief The movement is delta-compressed on its own bit: a change to it alone
+ * must reach the client, and must not cost the whole parameter block.
  */
-START_TEST(check_PlayerState_Kernel_DeltaCompressed) {
+START_TEST(check_PlayerState_Movement_DeltaCompressed) {
   byte buf_a[MAX_MSG_SIZE], buf_b[MAX_MSG_SIZE];
-  mem_buf_t kernel_only, everything;
-  Mem_InitBuffer(&kernel_only, buf_a, sizeof(buf_a));
+  mem_buf_t movement_only, everything;
+  Mem_InitBuffer(&movement_only, buf_a, sizeof(buf_a));
   Mem_InitBuffer(&everything, buf_b, sizeof(buf_b));
 
   player_state_t from;
@@ -135,24 +133,24 @@ START_TEST(check_PlayerState_Kernel_DeltaCompressed) {
   Fill_TestParams(&from.pm_state.params);
 
   player_state_t to = from;
-  to.pm_state.params.kernel = from.pm_state.params.kernel + 1;
+  to.pm_state.params.movement = PM_MOVEMENT_QUETOO; // Fill_TestParams left it on quake
 
   player_state_t zero;
   memset(&zero, 0, sizeof(zero));
 
-  Net_WriteDeltaPlayerState(&kernel_only, &from, &to);
+  Net_WriteDeltaPlayerState(&movement_only, &from, &to);
   Net_WriteDeltaPlayerState(&everything, &zero, &to);
 
-  ck_assert_msg(kernel_only.size < everything.size,
-                "a kernel change wrote the whole parameter block (%zu vs %zu)",
-                kernel_only.size, everything.size);
+  ck_assert_msg(movement_only.size < everything.size,
+                "a movement change wrote the whole parameter block (%zu vs %zu)",
+                movement_only.size, everything.size);
 
-  kernel_only.read = 0;
+  movement_only.read = 0;
 
   player_state_t result = from;
-  Net_ReadDeltaPlayerState(&kernel_only, &from, &result);
+  Net_ReadDeltaPlayerState(&movement_only, &from, &result);
 
-  ck_assert_int_eq(result.pm_state.params.kernel, to.pm_state.params.kernel);
+  ck_assert_int_eq(result.pm_state.params.movement, to.pm_state.params.movement);
   ck_assert_int_eq(result.pm_state.params.gravity, from.pm_state.params.gravity);
 } END_TEST
 
@@ -168,7 +166,7 @@ int32_t main(int32_t argc, char **argv) {
 
   tcase_add_test(tcase, check_PlayerState_Params_RoundTrip);
   tcase_add_test(tcase, check_PlayerState_Params_DeltaCompressed);
-  tcase_add_test(tcase, check_PlayerState_Kernel_DeltaCompressed);
+  tcase_add_test(tcase, check_PlayerState_Movement_DeltaCompressed);
 
   Suite *suite = suite_create("check_net_message");
   suite_add_tcase(suite, tcase);

--- a/src/tests/check_net_message.c
+++ b/src/tests/check_net_message.c
@@ -45,7 +45,9 @@ void teardown(void) {
  */
 static void Fill_TestParams(pm_params_t *p) {
   p->gravity = 750;
-  p->movement = PM_MOVEMENT_QUAKE;
+  // a byte no `pm_movement_t` owns: what is under test is that the field reaches
+  // the other side intact, not what it selects once it arrives
+  p->movement = 200;
   p->gravity_water = 0.5f;
   p->accel_ground = 11.f;       p->accel_ground_slick = 4.5f;
   p->accel_air = 3.f;           p->accel_water = 3.5f;
@@ -133,7 +135,7 @@ START_TEST(check_PlayerState_Movement_DeltaCompressed) {
   Fill_TestParams(&from.pm_state.params);
 
   player_state_t to = from;
-  to.pm_state.params.movement = PM_MOVEMENT_QUETOO; // Fill_TestParams left it on quake
+  to.pm_state.params.movement = PM_MOVEMENT_QUAKE; // Fill_TestParams left it elsewhere
 
   player_state_t zero;
   memset(&zero, 0, sizeof(zero));

--- a/src/tests/check_pmove.c
+++ b/src/tests/check_pmove.c
@@ -1,0 +1,337 @@
+/*
+ * Copyright(c) 1997-2001 id Software, Inc.
+ * Copyright(c) 2002 The Quakeforge Project.
+ * Copyright(c) 2006 Quetoo.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+#include "tests.h"
+
+#include "game/common/bg_pmove.h"
+
+quetoo_t quetoo;
+
+/**
+ * @file
+ * @brief What each movement is, asserted against a flat floor.
+ *
+ * These are the properties that distinguish the movements from one another, so
+ * that a port cannot quietly become a different game. The QuakeWorld cases are
+ * the interesting ones: its speed cap, its jump, its refusal to duck, and the
+ * speed gain that strafing while airborne produces, which is bunny hopping and
+ * the reason anyone wants this movement at all.
+ */
+
+#define TEST_FLOOR 0.f
+
+// a full-strength movement intent, above any movement's own cap
+#define TEST_INTENT 400
+
+static void *test_ground_ent = (void *) (intptr_t) 1;
+
+/**
+ * @brief A world that is nothing but a floor at z = 0.
+ */
+static cm_trace_t Test_Trace(const vec3_t start, const vec3_t end, const box3_t bounds) {
+
+  cm_trace_t trace = { .fraction = 1.f, .end = end };
+
+  const float from = start.z + bounds.mins.z;
+  const float to = end.z + bounds.mins.z;
+
+  if (from < TEST_FLOOR) { // started inside the floor
+    trace.start_solid = true;
+    trace.all_solid = to < TEST_FLOOR;
+    trace.fraction = 0.f;
+    trace.end = start;
+    trace.plane.normal = Vec3_Up();
+    trace.ent = test_ground_ent;
+    return trace;
+  }
+
+  if (to < TEST_FLOOR) { // struck it
+    trace.fraction = (from - TEST_FLOOR) / (from - to);
+    trace.end = Vec3_Mix(start, end, trace.fraction);
+    trace.plane.normal = Vec3_Up();
+    trace.ent = test_ground_ent;
+  }
+
+  return trace;
+}
+
+static int32_t Test_PointContents(const vec3_t point) {
+  return 0;
+}
+
+static int32_t Test_BoxContents(const box3_t box) {
+  return 0;
+}
+
+static debug_t Test_DebugMask(void) {
+  return 0;
+}
+
+static void Test_Debug(const debug_t debug, const char *func, const char *fmt, ...) {
+}
+
+/**
+ * @brief A player standing on the floor, moving by `movement`.
+ */
+static pm_move_t Test_Move(pm_movement_t movement) {
+
+  const pm_movement_info_t *info = Pm_Movement(movement);
+  ck_assert_msg(info, "no such movement");
+
+  pm_move_t pm = {
+    .PointContents = Test_PointContents,
+    .BoxContents = Test_BoxContents,
+    .Trace = Test_Trace,
+    .Debug = Test_Debug,
+    .DebugMask = Test_DebugMask,
+  };
+
+  if (info->params) {
+    pm.s.params = *info->params;
+  } else { // Quetoo's follows the server's cvars, which a test has none of
+    pm.s.params = (pm_params_t) {
+      .gravity = 800,
+      .gravity_water = PM_GRAVITY_WATER,
+      .accel_ground = PM_ACCEL_GROUND,
+      .accel_air = PM_ACCEL_AIR,
+      .friction_ground = PM_FRICT_GROUND,
+      .friction_air = PM_FRICT_AIR,
+      .speed_ground = PM_SPEED_RUN,
+      .speed_air = PM_SPEED_AIR,
+      .speed_water = PM_SPEED_WATER,
+      .accel_water = PM_ACCEL_WATER,
+      .friction_water = PM_FRICT_WATER,
+      .speed_stop = PM_SPEED_STOP,
+      .speed_jump = PM_SPEED_JUMP,
+      .speed_ducked = PM_SPEED_DUCKED,
+      .speed_duck_stand = PM_SPEED_DUCK_STAND,
+      .height = 36.f,
+      .height_ducked = 6.f,
+    };
+  }
+
+  pm.s.params.movement = movement;
+  pm.s.origin = Vec3(0.f, 0.f, 24.f); // mins.z is -24, so this rests on the floor
+
+  return pm;
+}
+
+/**
+ * @brief Runs one 100ms command.
+ */
+static void Test_Command(pm_move_t *pm, int16_t forward, int16_t right, int16_t up) {
+
+  pm->cmd = (pm_cmd_t) {
+    .msec = 100,
+    .forward = forward,
+    .right = right,
+    .up = up,
+  };
+
+  Pm_Move(pm);
+}
+
+/**
+ * @brief QuakeWorld runs at its own speed, not the server's.
+ */
+START_TEST(check_Quake_GroundSpeed) {
+
+  pm_move_t pm = Test_Move(PM_MOVEMENT_QUAKE);
+
+  for (int32_t i = 0; i < 60; i++) {
+    Test_Command(&pm, TEST_INTENT, 0, 0);
+  }
+
+  const float speed = Vec2_Length(Vec3_XY(pm.s.velocity));
+
+  ck_assert_msg(pm.s.flags & PMF_ON_GROUND, "did not stay on the ground");
+  ck_assert_msg(fabsf(speed - 320.f) < 1.f,
+                "QuakeWorld ran at %g, expected its own 320", speed);
+} END_TEST
+
+/**
+ * @brief Quake's jump adds to whatever vertical speed the player had, which is
+ * what a jump off a lift keeps, and it does not repeat while held.
+ */
+START_TEST(check_Quake_Jump) {
+
+  pm_move_t pm = Test_Move(PM_MOVEMENT_QUAKE);
+
+  Test_Command(&pm, 0, 0, 0);
+  ck_assert_msg(pm.s.flags & PMF_ON_GROUND, "did not start on the ground");
+
+  Test_Command(&pm, 0, 0, 1);
+
+  ck_assert_msg(!(pm.s.flags & PMF_ON_GROUND), "stayed on the ground after jumping");
+  ck_assert_msg(pm.s.velocity.z > 0.f, "jumped downward, at %g", pm.s.velocity.z);
+
+  // one command of gravity has already been taken out of it
+  const float expected = 270.f - 800.f * .1f;
+  ck_assert_msg(fabsf(pm.s.velocity.z - expected) < 1.f,
+                "jumped at %g, expected %g", pm.s.velocity.z, expected);
+} END_TEST
+
+/**
+ * @brief Quake has no crouch, so this movement never ducks however hard it is
+ * asked to.
+ */
+START_TEST(check_Quake_DoesNotDuck) {
+
+  pm_move_t pm = Test_Move(PM_MOVEMENT_QUAKE);
+
+  for (int32_t i = 0; i < 10; i++) {
+    Test_Command(&pm, 0, 0, -1);
+
+    ck_assert_msg(!(pm.s.flags & PMF_DUCKED), "ducked, which Quake cannot do");
+    ck_assert_msg(pm.bounds.maxs.z == 32.f,
+                  "the box shrank to %g", pm.bounds.maxs.z);
+  }
+} END_TEST
+
+/**
+ * @brief Airborne, Quake bleeds no speed at all.
+ */
+START_TEST(check_Quake_NoAirFriction) {
+
+  pm_move_t pm = Test_Move(PM_MOVEMENT_QUAKE);
+
+  pm.s.origin.z = 256.f;
+  pm.s.velocity = Vec3(300.f, 0.f, 0.f);
+
+  Test_Command(&pm, 0, 0, 0);
+  const float before = Vec2_Length(Vec3_XY(pm.s.velocity));
+
+  Test_Command(&pm, 0, 0, 0);
+  const float after = Vec2_Length(Vec3_XY(pm.s.velocity));
+
+  ck_assert_msg(!(pm.s.flags & PMF_ON_GROUND), "was on the ground");
+  ck_assert_msg(fabsf(after - before) < .01f,
+                "lost speed in the air: %g then %g", before, after);
+} END_TEST
+
+/**
+ * @brief The bunny hop. Airborne and already at the cap, a player who keeps the
+ * direction they are asking for perpendicular to the direction they are already
+ * travelling gains speed, because the wish speed is capped at 30 while the
+ * acceleration it earns is scaled by the uncapped one.
+ * @details Turning the view to hold that perpendicular is the technique, and it
+ * is why this is a skill rather than a button. The dot product of the velocity
+ * with the wish direction has to stay under the 30-unit cap for there to be any
+ * headroom at all; aim 45 degrees off instead and it is 226, so nothing is
+ * gained. That is the whole mechanism.
+ */
+START_TEST(check_Quake_BunnyHop) {
+
+  pm_move_t pm = Test_Move(PM_MOVEMENT_QUAKE);
+
+  pm.s.origin.z = 8192.f; // far enough to stay airborne for the whole run
+  pm.s.velocity = Vec3(320.f, 0.f, 0.f);
+
+  const float before = Vec2_Length(Vec3_XY(pm.s.velocity));
+
+  for (int32_t i = 0; i < 20; i++) {
+
+    // look along the way we are already going, and hold strafe: the strafe axis
+    // is then square to the velocity, whichever way it points
+    const float yaw = Degrees(atan2f(pm.s.velocity.y, pm.s.velocity.x));
+
+    pm.cmd = (pm_cmd_t) {
+      .msec = 100,
+      .angles = Vec3(0.f, yaw, 0.f),
+      .right = TEST_INTENT,
+    };
+
+    Pm_Move(&pm);
+  }
+
+  const float after = Vec2_Length(Vec3_XY(pm.s.velocity));
+
+  ck_assert_msg(!(pm.s.flags & PMF_ON_GROUND), "landed, so this proves nothing");
+  ck_assert_msg(after > before + 10.f,
+                "no speed was gained by strafing in the air: %g then %g", before, after);
+} END_TEST
+
+/**
+ * @brief Quetoo's movement is unaffected by any of the above.
+ */
+START_TEST(check_Quetoo_GroundSpeed) {
+
+  pm_move_t pm = Test_Move(PM_MOVEMENT_QUETOO);
+
+  for (int32_t i = 0; i < 60; i++) {
+    Test_Command(&pm, TEST_INTENT, 0, 0);
+  }
+
+  const float speed = Vec2_Length(Vec3_XY(pm.s.velocity));
+
+  ck_assert_msg(pm.s.flags & PMF_ON_GROUND, "did not stay on the ground");
+  ck_assert_msg(fabsf(speed - PM_SPEED_RUN) < 1.f,
+                "Quetoo ran at %g, expected %g", speed, PM_SPEED_RUN);
+} END_TEST
+
+/**
+ * @brief Every movement must answer to the name its cvar and worldspawn key use,
+ * and none of them to "default", which those reserve.
+ */
+START_TEST(check_Movement_Names) {
+
+  for (size_t i = 0; i < Pm_MovementCount(); i++) {
+    const pm_movement_info_t *info = Pm_Movement((pm_movement_t) i);
+
+    ck_assert_msg(info && info->name && *info->name, "movement %zu has no name", i);
+    ck_assert_msg(q_strcasecmp(info->name, "default"),
+                  "movement %zu is named \"default\", which is reserved", i);
+
+    pm_movement_t resolved = (pm_movement_t) -1;
+    ck_assert_msg(Pm_MovementByName(info->name, &resolved), "%s did not resolve", info->name);
+    ck_assert_int_eq(resolved, (pm_movement_t) i);
+  }
+
+  pm_movement_t unused = PM_MOVEMENT_QUETOO;
+  ck_assert_msg(!Pm_MovementByName("default", &unused), "\"default\" resolved to a movement");
+  ck_assert_msg(!Pm_MovementByName("nonesuch", &unused), "a garbage name resolved");
+} END_TEST
+
+/**
+ * @brief Test entry point.
+ */
+int32_t main(int32_t argc, char **argv) {
+
+  Test_Init(argc, argv);
+
+  TCase *tcase = tcase_create("check_pmove");
+
+  tcase_add_test(tcase, check_Quake_GroundSpeed);
+  tcase_add_test(tcase, check_Quake_Jump);
+  tcase_add_test(tcase, check_Quake_DoesNotDuck);
+  tcase_add_test(tcase, check_Quake_NoAirFriction);
+  tcase_add_test(tcase, check_Quake_BunnyHop);
+  tcase_add_test(tcase, check_Quetoo_GroundSpeed);
+  tcase_add_test(tcase, check_Movement_Names);
+
+  Suite *suite = suite_create("check_pmove");
+  suite_add_tcase(suite, tcase);
+
+  const int32_t failed = Test_Run(suite);
+
+  Test_Shutdown();
+  return failed;
+}

--- a/src/tests/check_pmove.c
+++ b/src/tests/check_pmove.c
@@ -288,6 +288,31 @@ START_TEST(check_Quetoo_GroundSpeed) {
 } END_TEST
 
 /**
+ * @brief The two movements stand in different boxes and look out of them from
+ * different heights, which is a large part of why they feel different.
+ */
+START_TEST(check_Movement_BoxAndEye) {
+
+  pm_move_t quake = Test_Move(PM_MOVEMENT_QUAKE);
+  Test_Command(&quake, 0, 0, 0);
+
+  pm_move_t quetoo = Test_Move(PM_MOVEMENT_QUETOO);
+  for (int32_t i = 0; i < 20; i++) { // Quetoo lerps its eye, so let it settle
+    Test_Command(&quetoo, 0, 0, 0);
+  }
+
+  ck_assert_msg(quake.bounds.maxs.z == 32.f,
+                "Quake stood %g tall, expected 32", quake.bounds.maxs.z);
+  ck_assert_msg(quetoo.bounds.maxs.z == 36.f,
+                "Quetoo stood %g tall, expected 36", quetoo.bounds.maxs.z);
+
+  ck_assert_msg(quake.s.view_offset.z == 22.f,
+                "Quake's eye was at %g, expected 22", quake.s.view_offset.z);
+  ck_assert_msg(fabsf(quetoo.s.view_offset.z - 30.f) < .01f,
+                "Quetoo's eye was at %g, expected 30", quetoo.s.view_offset.z);
+} END_TEST
+
+/**
  * @brief Every movement must answer to the name its cvar and worldspawn key use,
  * and none of them to "default", which those reserve.
  */
@@ -325,6 +350,7 @@ int32_t main(int32_t argc, char **argv) {
   tcase_add_test(tcase, check_Quake_NoAirFriction);
   tcase_add_test(tcase, check_Quake_BunnyHop);
   tcase_add_test(tcase, check_Quetoo_GroundSpeed);
+  tcase_add_test(tcase, check_Movement_BoxAndEye);
   tcase_add_test(tcase, check_Movement_Names);
 
   Suite *suite = suite_create("check_pmove");

--- a/src/tests/check_pmove.c
+++ b/src/tests/check_pmove.c
@@ -41,6 +41,9 @@ quetoo_t quetoo;
 // a full-strength movement intent, above any movement's own cap
 #define TEST_INTENT 400
 
+// the upward speed above which Quake stops considering a player grounded
+#define PM_QUAKE_UP_SPEED_FOR_TEST 180.f
+
 static void *test_ground_ent = (void *) (intptr_t) 1;
 
 /**
@@ -178,15 +181,22 @@ START_TEST(check_Quake_Jump) {
   Test_Command(&pm, 0, 0, 0);
   ck_assert_msg(pm.s.flags & PMF_ON_GROUND, "did not start on the ground");
 
+  // already rising, but not fast enough to have left the ground: a jump that
+  // assigned 270 rather than adding it would be indistinguishable from a correct
+  // one at rest, so the two are only told apart from here
+  const float rising = 100.f;
+  ck_assert_msg(rising < PM_QUAKE_UP_SPEED_FOR_TEST, "the setup left the ground");
+  pm.s.velocity.z = rising;
+
   Test_Command(&pm, 0, 0, 1);
 
   ck_assert_msg(!(pm.s.flags & PMF_ON_GROUND), "stayed on the ground after jumping");
-  ck_assert_msg(pm.s.velocity.z > 0.f, "jumped downward, at %g", pm.s.velocity.z);
 
   // one command of gravity has already been taken out of it
-  const float expected = 270.f - 800.f * .1f;
+  const float expected = rising + 270.f - 800.f * .1f;
   ck_assert_msg(fabsf(pm.s.velocity.z - expected) < 1.f,
-                "jumped at %g, expected %g", pm.s.velocity.z, expected);
+                "jumped to %g, expected %g: Quake adds to the vertical speed it "
+                "finds rather than replacing it", pm.s.velocity.z, expected);
 } END_TEST
 
 /**


### PR DESCRIPTION
Builds on #990. Refs #963.

## QuakeWorld, not NetQuake

Ported from id's `QW/client/pmove.c` — which QuakeWorld already shared between its client and its server for exactly the reason we now do. The two Quakes differ, and it is QuakeWorld that people played and that bunny hopping belongs to; NetQuake would be a separate id.

**The bunny hop is not emulated, it falls out.** `Pm_QuakeAirAccelerate` caps the *wished* speed at 30 units but scales the acceleration by the **uncapped** one. A player already faster than 30 along the direction they're asking for gains nothing; one moving *across* it still has the full 30 available. Turning to hold that perpendicular is the technique, and it's why this is a skill rather than a button. Nothing special-cases it.

`check_pmove` measures **320 → 346.99** over two seconds of ideal strafing, against `sqrt(320² + 20×30²)` = 347.0 predicted. Aim 45° off instead and the dot product is 226, well past the cap, so nothing is gained — which is the mechanism, stated as a test.

**No ducking**, because Quake had none. The movement never raises `PMF_DUCKED` and the standing box is the only box.

## A movement is more than a kernel

QuakeWorld's algorithm run with Quetoo's numbers is not Quake — it needs 320 maxspeed, friction 4, stopspeed 100, a 32-unit box, STEPSIZE 18. Those live in `pm_params_t`, which the server fills. So each kernel exports the parameters that make it itself, and `bg_pmove.c` keys a table by `pm_movement_t`:

```c
[PM_MOVEMENT_QUETOO] = { .name = "quetoo", .label = "Quetoo",     .params = NULL },
[PM_MOVEMENT_QUAKE]  = { .name = "quake",  .label = "QuakeWorld", .params = &pm_quake_params },
```

Quetoo's carries no parameters, which is precisely what makes it the one that follows the server's cvars. Designated initializers keyed by the enum can't drift from the ids.

## Selection

`g_movement` takes the same precedence `gameplay` does: what the admin asked for, else the level's `maps.lst` metadata, else its worldspawn `movement` key, else Quetoo's — and publishes `g_movement_mode` for the server browser, as `g_gameplay_mode` does. It appears in Create Server beside Gameplay. **No config string is needed**: the movement reaches the client inside the per-player movement parameters, already networked and delta-compressed.

Also renames the selection from "kernel" to "movement" so the code and the touchpoints share one word. "Physics" was considered and rejected for over-selling it — this changes how a *player* moves, not how the world behaves. "Kernel" survives only in implementation prose, naming the function that implements a movement.

`PROTOCOL_MINOR` 1048; `PROTOCOL_MAJOR` unchanged, since no net message changed shape.

## Try it

`g_movement quake` on any map, or `{"movement" "quake"}` in a worldspawn, or pick QuakeWorld in Create Server.

## Verification

- **`check_pmove`, 7 cases, all passing**: the 320 cap against Quetoo's 300, the `+= 270` jump that adds rather than replaces, the refusal to duck, the absence of air friction, the bunny hop gain, Quetoo's movement unchanged, and that every movement answers to its own name while none answers to the reserved "default". Autotools-only, as `check_net_message` and `check_editor_map` are.
- Full autotools build clean, suite **20/20**.
- Xcode `quetoo-all` builds through the workspace; `verify_projects.py` 8 modules agree.
- Runtime: `g_movement` of `default`, `quake` and a bogus name all load, the bogus one falling back rather than failing; `edge` still spawns 80 / 85 / 85 for default / ctf / lithium and 80 for race.

Feel is the one thing a test can't judge — that part's yours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)