### PR TITLE
Add the race run: a timer, its triggers, and the modes around it

### DIFF
--- a/Quetoo.vs15/game-race.vcxproj
+++ b/Quetoo.vs15/game-race.vcxproj
@@ -24,11 +24,14 @@
   <ItemGroup>
     <ClInclude Include="..\src\game\game.h" />
     <ClInclude Include="..\src\game\race\bg_item.h" />
+    <ClInclude Include="..\src\game\race\g_race.h" />
     <ClInclude Include="..\src\game\race\g_types.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\src\game\race\bg_item.c" />
     <ClCompile Include="..\src\game\race\g_module.c" />
+    <ClCompile Include="..\src\game\race\g_race.c" />
+    <ClCompile Include="..\src\game\race\g_race_entity.c" />
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{3c9e5fb2-6d74-4a1b-9153-8e4f7cab9d23}</ProjectGuid>

--- a/Quetoo.vs15/game-race.vcxproj.filters
+++ b/Quetoo.vs15/game-race.vcxproj.filters
@@ -42,6 +42,9 @@
     <ClInclude Include="..\src\game\common\g_main.h">
       <Filter>src\common</Filter>
     </ClInclude>
+    <ClInclude Include="..\src\game\race\g_race.h">
+      <Filter>src\race</Filter>
+    </ClInclude>
     <ClInclude Include="..\src\game\race\g_types.h">
       <Filter>src\race</Filter>
     </ClInclude>
@@ -240,6 +243,12 @@
       <Filter>src\race</Filter>
     </ClCompile>
     <ClCompile Include="..\src\game\race\g_module.c">
+      <Filter>src\race</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\game\race\g_race.c">
+      <Filter>src\race</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\game\race\g_race_entity.c">
       <Filter>src\race</Filter>
     </ClCompile>
   </ItemGroup>

--- a/Quetoo.xcodeproj/project.pbxproj
+++ b/Quetoo.xcodeproj/project.pbxproj
@@ -256,6 +256,8 @@
 		D2A5C1000000000000000010 /* bg_item.c in Sources */ = {isa = PBXBuildFile; fileRef = D2A5C1000000000000000002 /* bg_item.c */; };
 		CE05B2F0302248070012F002 /* g_module.c in Sources */ = {isa = PBXBuildFile; fileRef = CE05B271302248070012862B /* g_module.c */; };
 		D2A5C1000000000000000029 /* g_module.c in Sources */ = {isa = PBXBuildFile; fileRef = D2A5C1000000000000000003 /* g_module.c */; };
+		D8A5C100000000000000000B /* g_race.c in Sources */ = {isa = PBXBuildFile; fileRef = D8A5C10000000000000000A1 /* g_race.c */; };
+		D8A5C100000000000000000C /* g_race_entity.c in Sources */ = {isa = PBXBuildFile; fileRef = D8A5C10000000000000000A2 /* g_race_entity.c */; };
 		CE05B2F0302248070012F003 /* bg_item.h in Headers */ = {isa = PBXBuildFile; fileRef = CE05B23D302248070012862B /* bg_item.h */; };
 		D2A5C1000000000000000033 /* bg_item.h in Headers */ = {isa = PBXBuildFile; fileRef = D2A5C1000000000000000001 /* bg_item.h */; };
 		CE05B2F0302248070012F004 /* g_types.h in Headers */ = {isa = PBXBuildFile; fileRef = CE05B27C302248070012862B /* g_types.h */; };
@@ -1777,6 +1779,9 @@
 		D2A5C1000000000000000002 /* bg_item.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = bg_item.c; sourceTree = "<group>"; };
 		CE05B271302248070012862B /* g_module.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = g_module.c; sourceTree = "<group>"; };
 		D2A5C1000000000000000003 /* g_module.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = g_module.c; sourceTree = "<group>"; };
+		D8A5C10000000000000000A1 /* g_race.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = g_race.c; sourceTree = "<group>"; };
+		D8A5C10000000000000000A2 /* g_race_entity.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = g_race_entity.c; sourceTree = "<group>"; };
+		D8A5C10000000000000000A3 /* g_race.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = g_race.h; sourceTree = "<group>"; };
 		CE05B27C302248070012862B /* g_types.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = g_types.h; sourceTree = "<group>"; };
 		D2A5C1000000000000000004 /* g_types.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = g_types.h; sourceTree = "<group>"; };
 		CE05B283302248070012862B /* Makefile.am */ = {isa = PBXFileReference; lastKnownFileType = text; path = Makefile.am; sourceTree = "<group>"; };
@@ -3059,6 +3064,9 @@
 				D2A5C1000000000000000001 /* bg_item.h */,
 				D2A5C1000000000000000002 /* bg_item.c */,
 				D2A5C1000000000000000003 /* g_module.c */,
+				D8A5C10000000000000000A1 /* g_race.c */,
+				D8A5C10000000000000000A2 /* g_race_entity.c */,
+				D8A5C10000000000000000A3 /* g_race.h */,
 				D2A5C1000000000000000004 /* g_types.h */,
 				D2A5C1000000000000000005 /* Makefile.am */,
 			);
@@ -5912,6 +5920,8 @@
 				D2A5C1000000000000000027 /* g_item.c in Sources */,
 				D2A5C1000000000000000028 /* g_main.c in Sources */,
 				D2A5C1000000000000000029 /* g_module.c in Sources */,
+				D8A5C100000000000000000B /* g_race.c in Sources */,
+				D8A5C100000000000000000C /* g_race_entity.c in Sources */,
 				D2A5C100000000000000002A /* g_physics.c in Sources */,
 				D2A5C100000000000000002B /* g_rules.c in Sources */,
 				D2A5C100000000000000002C /* g_vote.c in Sources */,

--- a/src/game/common/bg_pmove.c
+++ b/src/game/common/bg_pmove.c
@@ -63,11 +63,11 @@ box3_t Pm_Bounds(const pm_params_t *params, bool ducked) {
  * the server's movement cvars, which is what makes it the default.
  */
 static const pm_movement_info_t pm_movements[] = {
-  [PM_MOVEMENT_QUETOO] = { .name = "quetoo", .label = "Quetoo",     .params = NULL },
-  [PM_MOVEMENT_QUAKE]  = { .name = "quake",  .label = "QuakeWorld", .params = &pm_quake_params },
-  [PM_MOVEMENT_QUAKE2] = { .name = "quake2", .label = "Quake II",   .params = &pm_quake2_params },
-  [PM_MOVEMENT_RACE]   = { .name = "race",   .label = "Race",       .params = &pm_race_params },
-  [PM_MOVEMENT_QUAKE3] = { .name = "quake3", .label = "Quake III",  .params = &pm_quake3_params },
+  [PM_MOVEMENT_QUETOO] = { .name = "quetoo", .label = "Quetoo",      .params = NULL },
+  [PM_MOVEMENT_RACE]   = { .name = "race",   .label = "Quetoo Race", .params = &pm_race_params },
+  [PM_MOVEMENT_QUAKE]  = { .name = "quake",  .label = "Quake",       .params = &pm_quake_params },
+  [PM_MOVEMENT_QUAKE2] = { .name = "quake2", .label = "Quake2",      .params = &pm_quake2_params },
+  [PM_MOVEMENT_QUAKE3] = { .name = "quake3", .label = "Quake3",      .params = &pm_quake3_params },
 };
 
 const pm_movement_info_t *Pm_Movement(pm_movement_t movement) {

--- a/src/game/race/Makefile.am
+++ b/src/game/race/Makefile.am
@@ -54,6 +54,8 @@ game_la_SOURCES = \
 	g_main.c \
 	g_module.c \
 	g_physics.c \
+	g_race.c \
+	g_race_entity.c \
 	g_rules.c \
 	g_sound.c \
 	g_util.c \

--- a/src/game/race/g_module.c
+++ b/src/game/race/g_module.c
@@ -19,12 +19,13 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
  */
 
-#include "g_local.h"
+#include "g_race.h"
 
 /**
  * @brief Module initialization and hook registration.
  */
 void G_Module_Init(void) {
+  G_Race_Init();
 }
 
 /**

--- a/src/game/race/g_race.c
+++ b/src/game/race/g_race.c
@@ -1,0 +1,676 @@
+/*
+ * Copyright(c) 1997-2001 id Software, Inc.
+ * Copyright(c) 2002 The Quakeforge Project.
+ * Copyright(c) 2006 Quetoo.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+#include "g_race.h"
+
+/**
+ * @file
+ * @brief The run and the rules. See g_race.h.
+ *
+ * A run is a sequence: start, checkpoints 1 through N in order, finish. The
+ * course says what N is and whether it has a start zone at all; a course with
+ * none starts the run on the client's first movement. Times are `g_level.time`,
+ * in milliseconds, and the run keeps its own so that the HUD can show it and a
+ * record can later be made of it.
+ *
+ * Two modes, chosen by the client. Racing is what counts: the grapple and
+ * noclip are refused, and a valid finish is announced. Practicing is for
+ * learning the course: everything is allowed, `store` remembers a position that
+ * `kill` returns to, and a finish is the client's business alone. Nobody is
+ * ever hurt: players pass through each other, another player's attack does
+ * nothing at all, and everything else - your own rockets, the world - keeps its
+ * knockback and loses its damage, because rocket jumps are half the point.
+ */
+
+// how quickly kill may be repeated, which racers do constantly
+#define RACE_KILL_INTERVAL 300
+
+static struct {
+  ConfigureLevel ConfigureLevel;
+  SpawnEntity SpawnEntity;
+  PrepareSpawn PrepareSpawn;
+  TossInventory TossInventory;
+  ModifyDamage ModifyDamage;
+  AllowHook AllowHook;
+  HandleClientCommand HandleClientCommand;
+  ClientWillThink ClientWillThink;
+  ClientDidMove ClientDidMove;
+  WriteStats WriteStats;
+} previous;
+
+static bool installed;
+
+g_race_mode_t G_Race_Mode(const g_client_t *cl) {
+
+  if (cl->persistent.spectator) {
+    return RACE_MODE_SPECTATOR;
+  }
+
+  return cl->persistent.race_mode == RACE_MODE_PRACTICE ? RACE_MODE_PRACTICE : RACE_MODE_RACE;
+}
+
+static const char *G_Race_ModeName(g_race_mode_t mode) {
+
+  switch (mode) {
+    case RACE_MODE_RACE:
+      return "racing";
+    case RACE_MODE_PRACTICE:
+      return "practicing";
+    default:
+      return "spectating";
+  }
+}
+
+/**
+ * @brief Whether `cl` is alive and taking part, which is what every step of a
+ * run requires.
+ */
+static bool G_Race_CanRun(const g_client_t *cl) {
+
+  return cl->entity && cl->entity->in_use && !cl->entity->dead && cl->entity->health > 0 &&
+         G_Race_Mode(cl) != RACE_MODE_SPECTATOR;
+}
+
+/**
+ * @brief Formats a run time for printing.
+ */
+static const char *G_Race_FormatTime(uint32_t ms) {
+  return va("%u:%02u.%03u", ms / 60000, ms / 1000 % 60, ms % 1000);
+}
+
+static void G_Race_Reset(g_client_t *cl) {
+
+  memset(&cl->race_run, 0, sizeof(cl->race_run));
+  cl->race_start = NULL;
+  cl->race_trigger = NULL;
+}
+
+// ---------------------------------------------------------------- the course
+
+void G_Race_AddStart(void) {
+  g_level.race_course.start_count++;
+}
+
+bool G_Race_AddCheckpoint(int32_t checkpoint) {
+
+  if (checkpoint < 1 || checkpoint > RACE_MAX_CHECKPOINTS) {
+    g_level.race_course.malformed = true;
+    return false;
+  }
+
+  g_level.race_course.checkpoints |= UINT64_C(1) << (checkpoint - 1);
+  return true;
+}
+
+void G_Race_AddFinish(void) {
+  g_level.race_course.finish_count++;
+}
+
+/**
+ * @brief A course is valid when its checkpoints are exactly 1 through N with
+ * none missing, and it has somewhere to finish.
+ */
+static void G_Race_ValidateCourse(void) {
+  g_race_course_t *course = &g_level.race_course;
+
+  course->checkpoint_count = 0;
+  for (int32_t i = RACE_MAX_CHECKPOINTS; i > 0; i--) {
+    if (course->checkpoints & (UINT64_C(1) << (i - 1))) {
+      course->checkpoint_count = i;
+      break;
+    }
+  }
+
+  const uint64_t expected = course->checkpoint_count == RACE_MAX_CHECKPOINTS
+                            ? UINT64_MAX
+                            : (UINT64_C(1) << course->checkpoint_count) - 1;
+
+  course->valid = !course->malformed && course->checkpoints == expected && course->finish_count > 0;
+}
+
+// ---------------------------------------------------------------- the run
+
+bool G_Race_Debounced(g_client_t *cl, const g_entity_t *ent, float wait) {
+
+  if (cl->race_trigger == ent && g_level.time - cl->race_trigger_time < wait * 1000.f) {
+    return true;
+  }
+
+  cl->race_trigger = ent;
+  cl->race_trigger_time = g_level.time;
+  return false;
+}
+
+bool G_Race_Start(g_client_t *cl) {
+
+  if (!G_Race_CanRun(cl)) {
+    return false;
+  }
+
+  if (!g_level.race_course.valid) {
+    gi.ClientPrint(cl, PRINT_HIGH, "This level has no valid course: it needs a finish and checkpoints 1 through N\n");
+    return false;
+  }
+
+  G_Race_Reset(cl);
+
+  g_race_run_t *run = &cl->race_run;
+  const float speed = Vec3_Length(cl->entity->velocity);
+
+  run->state = RACE_RUN_ACTIVE;
+  run->mode = G_Race_Mode(cl);
+  run->start_time = g_level.time;
+  run->start_speed = run->top_speed = speed;
+
+  if (cl->entity->move_type == MOVE_TYPE_NO_CLIP) {
+    run->invalid |= RACE_INVALID_NOCLIP;
+  }
+
+  gi.ClientPrint(cl, PRINT_HIGH, "^2Go!^7 %.0f ups\n", speed);
+  return true;
+}
+
+void G_Race_ArmStart(g_client_t *cl, const g_entity_t *start) {
+
+  if (cl->race_start == start) {
+    return;
+  }
+
+  // entering a start zone abandons whatever run was under way
+  if (cl->race_run.state != RACE_RUN_IDLE) {
+    G_Race_Reset(cl);
+  }
+
+  cl->race_start = start;
+}
+
+bool G_Race_Checkpoint(g_client_t *cl, uint16_t checkpoint) {
+  g_race_run_t *run = &cl->race_run;
+
+  if (!G_Race_CanRun(cl) || run->state != RACE_RUN_ACTIVE) {
+    return false;
+  }
+
+  const uint16_t expected = run->checkpoint_count + 1;
+
+  if (checkpoint < expected) { // already reached, so standing in it again means nothing
+    return false;
+  }
+
+  if (checkpoint > expected) {
+    gi.ClientPrint(cl, PRINT_HIGH, "Checkpoint %u skipped\n", expected);
+    return false;
+  }
+
+  run->checkpoint_times[run->checkpoint_count++] = g_level.time - run->start_time;
+
+  gi.ClientPrint(cl, PRINT_HIGH, "Checkpoint %u  %s\n", checkpoint,
+                 G_Race_FormatTime(run->checkpoint_times[checkpoint - 1]));
+
+  G_MulticastSound(&(const g_play_sound_t) {
+    .index = g_media.sounds.teleport,
+    .entity = cl->entity,
+  }, MULTICAST_PHS);
+
+  return true;
+}
+
+bool G_Race_Finish(g_client_t *cl) {
+  g_race_run_t *run = &cl->race_run;
+
+  if (!G_Race_CanRun(cl) || run->state != RACE_RUN_ACTIVE) {
+    return false;
+  }
+
+  const uint16_t remaining = g_level.race_course.checkpoint_count - run->checkpoint_count;
+  if (remaining) {
+    gi.ClientPrint(cl, PRINT_HIGH, "%u checkpoint%s remaining\n", remaining, remaining == 1 ? "" : "s");
+    return false;
+  }
+
+  if (cl->entity->move_type == MOVE_TYPE_NO_CLIP) {
+    run->invalid |= RACE_INVALID_NOCLIP;
+  }
+
+  run->state = RACE_RUN_FINISHED;
+  run->elapsed = g_level.time - run->start_time;
+  run->end_speed = Vec3_Length(cl->entity->velocity);
+  run->top_speed = Maxf(run->top_speed, run->end_speed);
+
+  const float average = run->speed_samples ? run->speed_sum / run->speed_samples : 0.f;
+  const char *time = G_Race_FormatTime(run->elapsed);
+
+  // it counts only if it was raced from start to finish with nothing to disqualify it
+  if (run->mode == RACE_MODE_RACE && G_Race_Mode(cl) == RACE_MODE_RACE && !run->invalid) {
+    gi.BroadcastPrint(PRINT_HIGH, "%s finished in %s\n", cl->persistent.net_name, time);
+  } else if (run->mode == RACE_MODE_PRACTICE) {
+    gi.ClientPrint(cl, PRINT_HIGH, "Finished in %s, practicing\n", time);
+  } else {
+    gi.ClientPrint(cl, PRINT_HIGH, "Finished in %s, but ^1it does not count^7\n", time);
+  }
+
+  gi.ClientPrint(cl, PRINT_HIGH, "  start %.0f  finish %.0f  top %.0f  average %.0f ups\n",
+                 run->start_speed, run->end_speed, run->top_speed, average);
+
+  G_MulticastSound(&(const g_play_sound_t) {
+    .index = g_media.sounds.teleport,
+    .entity = cl->entity,
+  }, MULTICAST_PHS);
+
+  return true;
+}
+
+// ---------------------------------------------------------------- the modes
+
+static void G_Race_SetMode(g_client_t *cl, g_race_mode_t mode) {
+
+  if (G_Race_Mode(cl) == mode) {
+    gi.ClientPrint(cl, PRINT_HIGH, "You are already %s\n", G_Race_ModeName(mode));
+    return;
+  }
+
+  if (g_level.time - cl->respawn_time < 1000) { // as spectate and join are
+    return;
+  }
+
+  if (mode == RACE_MODE_SPECTATOR) {
+    G_TossInventory(cl); // which resets the run
+    cl->persistent.spectator = true;
+    cl->persistent.race_spawn.set = false;
+  } else {
+    G_Race_Reset(cl);
+    cl->persistent.spectator = false;
+    cl->persistent.race_mode = mode;
+  }
+
+  gi.BroadcastPrint(PRINT_HIGH, "%s is %s\n", cl->persistent.net_name, G_Race_ModeName(mode));
+
+  if (mode == RACE_MODE_PRACTICE) {
+    gi.ClientPrint(cl, PRINT_HIGH, "Nothing counts while practicing. ^2store^7 remembers where you are; ^2kill^7 takes you back\n");
+  }
+
+  G_ClientRespawn(cl, false);
+}
+
+static void G_Race_Mode_f(g_client_t *cl) {
+
+  if (gi.Argc() < 2) {
+    gi.ClientPrint(cl, PRINT_HIGH, "You are %s. Use mode race|practice|spectator\n",
+                   G_Race_ModeName(G_Race_Mode(cl)));
+    return;
+  }
+
+  const char *name = gi.Argv(1);
+
+  if (!q_strcasecmp(name, "race")) {
+    G_Race_SetMode(cl, RACE_MODE_RACE);
+  } else if (!q_strcasecmp(name, "practice")) {
+    G_Race_SetMode(cl, RACE_MODE_PRACTICE);
+  } else if (!q_strcasecmp(name, "spectator") || !q_strcasecmp(name, "spectate")) {
+    G_Race_SetMode(cl, RACE_MODE_SPECTATOR);
+  } else {
+    gi.ClientPrint(cl, PRINT_HIGH, "Unknown mode \"%s\". Use race, practice or spectator\n", name);
+  }
+}
+
+/**
+ * @brief Remembers where a practicing client is standing, for `kill`.
+ */
+static void G_Race_Store_f(g_client_t *cl) {
+
+  if (G_Race_Mode(cl) != RACE_MODE_PRACTICE) {
+    gi.ClientPrint(cl, PRINT_HIGH, "Only while practicing\n");
+    return;
+  }
+
+  if (!G_Race_CanRun(cl)) {
+    return;
+  }
+
+  // in the spawn point's terms, so that respawning here puts the feet back
+  // exactly where they were
+  vec3_t origin = cl->entity->s.origin;
+  origin.z -= PM_STEP_HEIGHT;
+
+  cl->persistent.race_spawn = (g_race_spawn_t) {
+    .origin = origin,
+    .angles = cl->angles,
+    .set = true,
+  };
+
+  gi.ClientPrint(cl, PRINT_HIGH, "Stored. ^2kill^7 returns here\n");
+}
+
+/**
+ * @brief Respawns at once, with no corpse and no death: for racing, `kill`
+ * means "again", and it is pressed constantly.
+ */
+static void G_Race_Kill_f(g_client_t *cl) {
+
+  if (cl->persistent.spectator || !cl->entity || cl->entity->dead) {
+    return;
+  }
+
+  if (g_level.time - cl->respawn_time < RACE_KILL_INTERVAL) {
+    return;
+  }
+
+  G_Race_Reset(cl);
+  G_ClientRespawn(cl, false);
+}
+
+/**
+ * @brief Practicing allows noclip regardless of cheats; racing refuses it under
+ * the usual rule, and any run it touches does not count.
+ */
+static void G_Race_NoClip_f(g_client_t *cl) {
+
+  if (cl->persistent.spectator || !cl->entity) {
+    return;
+  }
+
+  const bool practicing = G_Race_Mode(cl) == RACE_MODE_PRACTICE;
+  const bool cheating = sv_max_clients->integer <= 1 || g_cheats->value;
+
+  if (!practicing && !cheating) {
+    gi.ClientPrint(cl, PRINT_HIGH, "Cheats are disabled\n");
+    return;
+  }
+
+  if (cl->entity->move_type == MOVE_TYPE_NO_CLIP) {
+    cl->entity->move_type = MOVE_TYPE_WALK;
+    gi.ClientPrint(cl, PRINT_HIGH, "no_clip disabled\n");
+  } else {
+    cl->entity->move_type = MOVE_TYPE_NO_CLIP;
+    cl->race_run.invalid |= RACE_INVALID_NOCLIP;
+    gi.ClientPrint(cl, PRINT_HIGH, "no_clip enabled\n");
+  }
+}
+
+static void G_Race_Status_f(g_client_t *cl) {
+  const g_race_run_t *run = &cl->race_run;
+  const g_race_course_t *course = &g_level.race_course;
+
+  gi.ClientPrint(cl, PRINT_HIGH, "Course: %u checkpoint%s, %u start%s, %u finish%s%s\n",
+                 course->checkpoint_count, course->checkpoint_count == 1 ? "" : "s",
+                 course->start_count, course->start_count == 1 ? "" : "s",
+                 course->finish_count, course->finish_count == 1 ? "" : "es",
+                 course->valid ? "" : " ^1(invalid)^7");
+
+  switch (run->state) {
+    case RACE_RUN_ACTIVE:
+      gi.ClientPrint(cl, PRINT_HIGH, "Running: %s, checkpoint %u of %u\n",
+                     G_Race_FormatTime(g_level.time - run->start_time),
+                     run->checkpoint_count, course->checkpoint_count);
+      break;
+    case RACE_RUN_FINISHED:
+      gi.ClientPrint(cl, PRINT_HIGH, "Finished: %s\n", G_Race_FormatTime(run->elapsed));
+      break;
+    default:
+      gi.ClientPrint(cl, PRINT_HIGH, "%s, not running\n", G_Race_ModeName(G_Race_Mode(cl)));
+      break;
+  }
+}
+
+// ---------------------------------------------------------------- the hooks
+
+static void G_ConfigureLevel_Race(void) {
+
+  previous.ConfigureLevel();
+
+  G_Race_ValidateCourse();
+
+  const g_race_course_t *course = &g_level.race_course;
+
+  gi.SetConfigString(CS_RACE_COURSE, va("%u\\%u\\%u", course->checkpoint_count,
+                                        course->finish_count, course->valid));
+
+  if (!course->valid) {
+    G_Warn("%s has no valid course: it needs a finish and checkpoints 1 through N\n", g_level.name);
+  }
+
+  // the course is new, and so is the ground a stored position stood on
+  G_ForEachClient(cl, {
+    G_Race_Reset(cl);
+    cl->persistent.race_spawn.set = false;
+  });
+}
+
+static bool G_SpawnEntity_Race(g_entity_t *ent) {
+
+  if (G_Race_SpawnEntity(ent)) {
+    return true;
+  }
+
+  return previous.SpawnEntity(ent);
+}
+
+/**
+ * @brief Players pass through each other and telefrag nobody, and a practicing
+ * client who has stored a position spawns there.
+ */
+static void G_PrepareSpawn_Race(g_client_t *cl, g_client_spawn_t *spawn) {
+
+  spawn->clip_mask &= ~CONTENTS_MONSTER;
+  spawn->kill_box = false;
+
+  if (G_Race_Mode(cl) == RACE_MODE_PRACTICE && cl->persistent.race_spawn.set) {
+    spawn->origin = cl->persistent.race_spawn.origin;
+    spawn->angles = cl->persistent.race_spawn.angles;
+  }
+
+  previous.PrepareSpawn(cl, spawn);
+}
+
+static void G_TossInventory_Race(g_client_t *cl) {
+
+  G_Race_Reset(cl);
+
+  previous.TossInventory(cl);
+}
+
+/**
+ * @brief Nobody is hurt. An attack from another player does nothing at all;
+ * anything else keeps its knockback and loses its damage, which is what a
+ * rocket jump needs and a lava pit does not get.
+ */
+static bool G_ModifyDamage_Race(const g_damage_t *dmg, int32_t *damage, int32_t *knockback) {
+
+  if (!dmg->target->client) {
+    return previous.ModifyDamage(dmg, damage, knockback);
+  }
+
+  if (dmg->attacker->client && dmg->attacker != dmg->target) {
+    return false;
+  }
+
+  if (!previous.ModifyDamage(dmg, damage, knockback)) {
+    return false;
+  }
+
+  *damage = 0;
+  return true;
+}
+
+static bool G_AllowHook_Race(const g_client_t *cl) {
+
+  if (G_Race_Mode(cl) != RACE_MODE_PRACTICE) {
+    return false;
+  }
+
+  return previous.AllowHook(cl);
+}
+
+static bool G_HandleClientCommand_Race(g_client_t *cl, const char *cmd, bool intermission) {
+
+  if (intermission) {
+    return previous.HandleClientCommand(cl, cmd, intermission);
+  }
+
+  if (!q_strcmp(cmd, "race")) {
+    G_Race_Status_f(cl);
+  } else if (!q_strcmp(cmd, "mode")) {
+    G_Race_Mode_f(cl);
+  } else if (!q_strcmp(cmd, "store")) {
+    G_Race_Store_f(cl);
+  } else if (!q_strcmp(cmd, "kill")) {
+    G_Race_Kill_f(cl);
+  } else if (!q_strcmp(cmd, "no_clip")) {
+    G_Race_NoClip_f(cl);
+  } else {
+    return previous.HandleClientCommand(cl, cmd, intermission);
+  }
+
+  return true;
+}
+
+/**
+ * @brief Whether `cl` is standing in `ent`. By bounds, because that is what a
+ * trigger's touch is: the server never traces against a SOLID_TRIGGER, so a
+ * clip against one reports nothing however deep inside it the box is.
+ */
+static bool G_Race_Inside(const g_client_t *cl, const g_entity_t *ent) {
+
+  return ent->in_use && Box3_Intersects(cl->entity->abs_bounds, ent->abs_bounds);
+}
+
+/**
+ * @brief The starts that begin on input: a jump out of a jump-mode zone, or the
+ * first movement when the course has no start zone at all. `cl->cmd` is still
+ * the previous command here, which is what makes the jump an edge.
+ */
+static void G_ClientWillThink_Race(g_client_t *cl, const pm_cmd_t *cmd) {
+
+  previous.ClientWillThink(cl, cmd);
+
+  if (!G_Race_CanRun(cl)) {
+    return;
+  }
+
+  if (cl->race_start) {
+    if (cl->race_start->count == RACE_START_JUMP && cmd->up > 0 && cl->cmd.up <= 0) {
+      const g_entity_t *start = cl->race_start;
+      cl->race_start = NULL;
+
+      if (G_Race_Inside(cl, start) && G_Race_Start(cl)) {
+        G_UseTargets((g_entity_t *) start, cl->entity);
+      }
+    }
+    return;
+  }
+
+  if (!g_level.race_course.start_count && cl->race_run.state == RACE_RUN_IDLE &&
+      (cmd->forward || cmd->right || cmd->up)) {
+    G_Race_Start(cl);
+  }
+}
+
+/**
+ * @brief Samples the speed for the finish report, and starts the run for a
+ * client who has just left an exit-mode start zone.
+ */
+static void G_ClientDidMove_Race(g_client_t *cl, const pm_cmd_t *cmd) {
+
+  previous.ClientDidMove(cl, cmd);
+
+  if (!G_Race_CanRun(cl)) {
+    return;
+  }
+
+  g_race_run_t *run = &cl->race_run;
+
+  if (run->state == RACE_RUN_ACTIVE) {
+    const float speed = Vec3_Length(cl->entity->velocity);
+
+    run->top_speed = Maxf(run->top_speed, speed);
+    run->speed_sum += speed;
+    run->speed_samples++;
+  }
+
+  if (cl->race_start && !G_Race_Inside(cl, cl->race_start)) {
+    const g_entity_t *start = cl->race_start;
+    cl->race_start = NULL;
+
+    if (start->count == RACE_START_EXIT && G_Race_Start(cl)) {
+      G_UseTargets((g_entity_t *) start, cl->entity);
+    }
+  }
+}
+
+static void G_WriteStats_Race(g_client_t *cl) {
+
+  previous.WriteStats(cl);
+
+  const g_race_run_t *run = &cl->race_run;
+
+  uint32_t time = 0;
+  if (run->state == RACE_RUN_ACTIVE) {
+    time = g_level.time - run->start_time;
+  } else if (run->state == RACE_RUN_FINISHED) {
+    time = run->elapsed;
+  }
+
+  cl->ps.stats[STAT_RACE_MODE] = G_Race_Mode(cl);
+  cl->ps.stats[STAT_RACE_RUN] = run->state;
+  cl->ps.stats[STAT_RACE_TIME_LOW] = (int16_t) (uint16_t) time;
+  cl->ps.stats[STAT_RACE_TIME_HIGH] = (int16_t) (uint16_t) (time >> 16);
+  cl->ps.stats[STAT_RACE_CHECKPOINTS] = run->checkpoint_count;
+  cl->ps.stats[STAT_RACE_FLAGS] = run->invalid;
+}
+
+void G_Race_Init(void) {
+
+  if (installed) {
+    return;
+  }
+
+  installed = true;
+
+  previous.ConfigureLevel = G_ConfigureLevel;
+  G_ConfigureLevel = G_ConfigureLevel_Race;
+
+  previous.SpawnEntity = G_SpawnEntity;
+  G_SpawnEntity = G_SpawnEntity_Race;
+
+  previous.PrepareSpawn = G_PrepareSpawn;
+  G_PrepareSpawn = G_PrepareSpawn_Race;
+
+  previous.TossInventory = G_TossInventory;
+  G_TossInventory = G_TossInventory_Race;
+
+  previous.ModifyDamage = G_ModifyDamage;
+  G_ModifyDamage = G_ModifyDamage_Race;
+
+  previous.AllowHook = G_AllowHook;
+  G_AllowHook = G_AllowHook_Race;
+
+  previous.HandleClientCommand = G_HandleClientCommand;
+  G_HandleClientCommand = G_HandleClientCommand_Race;
+
+  previous.ClientWillThink = G_ClientWillThink;
+  G_ClientWillThink = G_ClientWillThink_Race;
+
+  previous.ClientDidMove = G_ClientDidMove;
+  G_ClientDidMove = G_ClientDidMove_Race;
+
+  previous.WriteStats = G_WriteStats;
+  G_WriteStats = G_WriteStats_Race;
+}

--- a/src/game/race/g_race.h
+++ b/src/game/race/g_race.h
@@ -1,0 +1,79 @@
+/*
+ * Copyright(c) 1997-2001 id Software, Inc.
+ * Copyright(c) 2002 The Quakeforge Project.
+ * Copyright(c) 2006 Quetoo.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+#pragma once
+
+#include "g_local.h"
+
+/**
+ * @file
+ * @brief Racing: the course, the run, and the rules around them.
+ *
+ * `g_race.c` owns the run - starting, checkpoints, finishing, the modes and
+ * the commands - and installs the hooks that make the module a race rather
+ * than a deathmatch. `g_race_entity.c` owns the triggers that describe a
+ * course, and calls in here when a client touches one.
+ */
+
+/**
+ * @brief Installs racing over the hooks it needs, once per module image.
+ */
+void G_Race_Init(void);
+
+/**
+ * @brief How `cl` is taking part right now.
+ */
+g_race_mode_t G_Race_Mode(const g_client_t *cl);
+
+/**
+ * @brief The course, as the triggers spawn. Each records itself here, and
+ * `G_ConfigureLevel` validates the result once they all have.
+ */
+void G_Race_AddStart(void);
+bool G_Race_AddCheckpoint(int32_t checkpoint);
+void G_Race_AddFinish(void);
+
+/**
+ * @brief The run, as the client crosses the course. Each returns true if the
+ * touch counted, which is when a trigger fires its targets.
+ */
+bool G_Race_Start(g_client_t *cl);
+bool G_Race_Checkpoint(g_client_t *cl, uint16_t checkpoint);
+bool G_Race_Finish(g_client_t *cl);
+
+/**
+ * @brief Arms a start zone that begins the run on the way out, or on a jump
+ * from inside it, rather than on the way in.
+ */
+void G_Race_ArmStart(g_client_t *cl, const g_entity_t *start);
+
+/**
+ * @brief Whether `cl` touched `ent` within `wait` seconds of last touching it.
+ * A trigger stood in reports a touch every frame, and this is what stops each
+ * of them counting.
+ */
+bool G_Race_Debounced(g_client_t *cl, const g_entity_t *ent, float wait);
+
+/**
+ * @brief Spawns the race triggers by class name, or returns false for a class
+ * that is not one. Chained under `SpawnEntity` by `G_Race_Init`.
+ */
+bool G_Race_SpawnEntity(g_entity_t *ent);

--- a/src/game/race/g_race_entity.c
+++ b/src/game/race/g_race_entity.c
@@ -1,0 +1,188 @@
+/*
+ * Copyright(c) 1997-2001 id Software, Inc.
+ * Copyright(c) 2002 The Quakeforge Project.
+ * Copyright(c) 2006 Quetoo.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+#include "g_race.h"
+
+/**
+ * @file
+ * @brief The triggers that describe a course. Each records itself with the
+ * course as it spawns, and hands the client to g_race.c when touched.
+ *
+ * All of them are brush triggers, invisible, and fire their `target` and
+ * `message` like a `trigger_multiple` does when the touch counted. `wait`
+ * debounces a client standing in one, and defaults to half a second.
+ */
+
+// what a trigger stood in waits before counting the same client again
+#define RACE_TRIGGER_WAIT .5f
+
+/**
+ * @brief The common half of every race trigger's setup.
+ */
+static void G_trigger_race_Init(g_entity_t *ent, void (*Touch)(g_entity_t *, g_entity_t *, const cm_trace_t *)) {
+
+  if (ent->wait == 0.f) {
+    ent->wait = RACE_TRIGGER_WAIT;
+  }
+
+  ent->solid = SOLID_TRIGGER;
+  ent->move_type = MOVE_TYPE_NONE;
+  ent->sv_flags |= SVF_NO_CLIENT;
+  ent->Touch = Touch;
+
+  gi.SetModel(ent, ent->model);
+  gi.LinkEntity(ent);
+}
+
+/**
+ * @brief Whether `other` is a client this trigger should hear from right now.
+ */
+static bool G_trigger_race_Accepts(g_entity_t *ent, g_entity_t *other) {
+
+  if (!other->client) {
+    return false;
+  }
+
+  return !G_Race_Debounced(other->client, ent, ent->wait);
+}
+
+static void G_trigger_race_start_Touch(g_entity_t *ent, g_entity_t *other, const cm_trace_t *trace) {
+
+  if (!G_trigger_race_Accepts(ent, other)) {
+    return;
+  }
+
+  if (ent->count == RACE_START_TOUCH) {
+    if (G_Race_Start(other->client)) {
+      G_UseTargets(ent, other);
+    }
+  } else {
+    G_Race_ArmStart(other->client, ent); // and g_race.c fires it on the way out
+  }
+}
+
+/*QUAKED trigger_race_start (.5 .5 .5) ?
+ Where a run begins. A course may have several, or none: with none, the run
+ begins on the client's first movement.
+
+ -------- Keys --------
+ start_mode : When the run begins: touch (default) on entering, exit on leaving,
+ or jump on the first jump from inside.
+ wait : Seconds before the same client is heard from again (default 0.5).
+ message : An optional string to display when the run begins.
+ target : The name of the entity or team to use when the run begins.
+ */
+static void G_trigger_race_start(g_entity_t *ent) {
+
+  const char *mode = gi.EntityValue(ent->def, "start_mode")->nullable_string;
+
+  if (!mode || !*mode || !q_strcasecmp(mode, "touch")) {
+    ent->count = RACE_START_TOUCH;
+  } else if (!q_strcasecmp(mode, "exit")) {
+    ent->count = RACE_START_EXIT;
+  } else if (!q_strcasecmp(mode, "jump")) {
+    ent->count = RACE_START_JUMP;
+  } else {
+    G_Warn("%s has start_mode \"%s\"; it must be touch, exit or jump\n", etos(ent), mode);
+    G_FreeEntity(ent);
+    return;
+  }
+
+  G_trigger_race_Init(ent, G_trigger_race_start_Touch);
+  G_Race_AddStart();
+}
+
+static void G_trigger_race_checkpoint_Touch(g_entity_t *ent, g_entity_t *other, const cm_trace_t *trace) {
+
+  if (G_trigger_race_Accepts(ent, other) && G_Race_Checkpoint(other->client, ent->count)) {
+    G_UseTargets(ent, other);
+  }
+}
+
+/*QUAKED trigger_race_checkpoint (.5 .5 .5) ?
+ A checkpoint. A course's checkpoints must be numbered 1 through N with none
+ missing, and are passed in that order.
+
+ -------- Keys --------
+ cp : This checkpoint's number, from 1.
+ wait : Seconds before the same client is heard from again (default 0.5).
+ message : An optional string to display when the checkpoint is reached.
+ target : The name of the entity or team to use when the checkpoint is reached.
+ */
+static void G_trigger_race_checkpoint(g_entity_t *ent) {
+
+  const cm_entity_t *cp = gi.EntityValue(ent->def, "cp");
+
+  // an unreadable number is recorded as an impossible one, so that the course
+  // is spoiled rather than validated around the trigger this frees
+  if (!G_Race_AddCheckpoint(cp->parsed & ENTITY_INTEGER ? cp->integer : 0)) {
+    G_Warn("%s needs cp, an integer from 1 through %d\n", etos(ent), RACE_MAX_CHECKPOINTS);
+    G_FreeEntity(ent);
+    return;
+  }
+
+  ent->count = cp->integer;
+
+  G_trigger_race_Init(ent, G_trigger_race_checkpoint_Touch);
+}
+
+static void G_trigger_race_finish_Touch(g_entity_t *ent, g_entity_t *other, const cm_trace_t *trace) {
+
+  if (G_trigger_race_Accepts(ent, other) && G_Race_Finish(other->client)) {
+    G_UseTargets(ent, other);
+  }
+}
+
+/*QUAKED trigger_race_finish (.5 .5 .5) ?
+ Where a run ends, once every checkpoint has been passed. A course needs at
+ least one.
+
+ -------- Keys --------
+ wait : Seconds before the same client is heard from again (default 0.5).
+ message : An optional string to display when the run ends.
+ target : The name of the entity or team to use when the run ends.
+ */
+static void G_trigger_race_finish(g_entity_t *ent) {
+
+  G_trigger_race_Init(ent, G_trigger_race_finish_Touch);
+  G_Race_AddFinish();
+}
+
+static const struct {
+  const char *classname;
+  void (*Init)(g_entity_t *ent);
+} g_race_entity_classes[] = {
+  { "trigger_race_start", G_trigger_race_start },
+  { "trigger_race_checkpoint", G_trigger_race_checkpoint },
+  { "trigger_race_finish", G_trigger_race_finish },
+};
+
+bool G_Race_SpawnEntity(g_entity_t *ent) {
+
+  for (size_t i = 0; i < lengthof(g_race_entity_classes); i++) {
+    if (!q_strcmp(g_race_entity_classes[i].classname, ent->classname)) {
+      g_race_entity_classes[i].Init(ent);
+      return true;
+    }
+  }
+
+  return false;
+}

--- a/src/game/race/g_types.h
+++ b/src/game/race/g_types.h
@@ -82,6 +82,7 @@ typedef enum {
 #define CS_ITEM_SET        (CS_GAME + 7)  // active item set (g_items_t)
 #define CS_HOOK_PULL_SPEED (CS_GAME + 8)  // hook speed
 #define CS_VOTE            (CS_GAME + 9)  // the vote in progress (bg_vote.h)
+#define CS_RACE_COURSE     (CS_GAME + 10) // checkpoints\finishes\valid, for the HUD
 
 /**
  * @brief Player state statistics (inventory, score, etc).
@@ -103,13 +104,104 @@ typedef enum {
   STAT_SPECTATOR,
   STAT_TEAM,
   STAT_TIME,
-  STAT_WEAPON
+  STAT_WEAPON,
+
+  // racing, written by G_WriteStats_Race; the time is milliseconds split in two
+  STAT_RACE_MODE,        // g_race_mode_t
+  STAT_RACE_RUN,         // g_race_run_state_t
+  STAT_RACE_TIME_LOW,
+  STAT_RACE_TIME_HIGH,
+  STAT_RACE_CHECKPOINTS, // reached; the total is on CS_RACE_COURSE
+  STAT_RACE_FLAGS        // g_race_invalid_t
 } g_stat_t;
 
 /**
  * @brief Forces a statistic field to be re-sent, even if the value has not changed.
  */
 #define STAT_TOGGLE_BIT 0x4000
+
+_Static_assert(STAT_RACE_FLAGS < MAX_STATS, "the race stats must fit the stat array");
+
+/**
+ * @brief The most checkpoints a course may have. A course is contiguous
+ * checkpoints 1 through N and at least one finish; a start is optional.
+ */
+#define RACE_MAX_CHECKPOINTS 64
+
+/**
+ * @brief How a client is taking part. Spectating is derived from
+ * `g_client_persistent_t.spectator` rather than stored, so the two cannot
+ * disagree; the other two are the client's choice and persist across respawns.
+ */
+typedef enum {
+  RACE_MODE_RACE,      // finishes count, and the hook and noclip are refused
+  RACE_MODE_PRACTICE,  // nothing counts, and everything is allowed
+  RACE_MODE_SPECTATOR
+} g_race_mode_t;
+
+/**
+ * @brief Where a run is.
+ */
+typedef enum {
+  RACE_RUN_IDLE,
+  RACE_RUN_ACTIVE,
+  RACE_RUN_FINISHED
+} g_race_run_state_t;
+
+/**
+ * @brief Why a finished run in race mode cannot count.
+ */
+typedef enum {
+  RACE_INVALID_NOCLIP = 1 << 0
+} g_race_invalid_t;
+
+/**
+ * @brief When a `trigger_race_start` begins the run, kept in the trigger's `count`.
+ */
+typedef enum {
+  RACE_START_TOUCH, // on entering
+  RACE_START_EXIT,  // on leaving
+  RACE_START_JUMP   // on the first jump from inside
+} g_race_start_mode_t;
+
+/**
+ * @brief The course the level's triggers describe, gathered as they spawn and
+ * validated once they all have.
+ */
+typedef struct {
+  uint64_t checkpoints; // bit N - 1 is set once checkpoint N has spawned
+  uint16_t checkpoint_count;
+  uint16_t start_count;
+  uint16_t finish_count;
+  bool malformed; // a checkpoint number out of range was seen
+  bool valid;
+} g_race_course_t;
+
+/**
+ * @brief One attempt at the course. Lives on `g_client_t`, so a respawn clears
+ * it, which is what a death means to a run.
+ */
+typedef struct {
+  g_race_run_state_t state;
+  g_race_mode_t mode; // the mode the run was started in, which is what decides whether it counts
+  uint16_t checkpoint_count;
+  uint32_t start_time;
+  uint32_t elapsed; // set on finish
+  uint32_t checkpoint_times[RACE_MAX_CHECKPOINTS]; // from the start
+  float start_speed, end_speed, top_speed;
+  float speed_sum; // over speed_samples, for the average
+  uint32_t speed_samples;
+  uint8_t invalid; // g_race_invalid_t
+} g_race_run_t;
+
+/**
+ * @brief A position a practicing client asked to return to, in the spawn
+ * point's terms: the origin is the floor, as `g_client_spawn_t.origin` is.
+ */
+typedef struct {
+  vec3_t origin, angles;
+  bool set;
+} g_race_spawn_t;
 
 /**
  * @brief Muzzle flashes are bound to the entity that created them. This allows
@@ -867,6 +959,11 @@ typedef struct {
    */
   Vector *frags;
 
+  /**
+   * @brief The course the triggers describe, validated in `G_ConfigureLevel`.
+   */
+  g_race_course_t race_course;
+
   } g_level_t;
 
 /**
@@ -1242,6 +1339,16 @@ typedef struct {
    * @brief Per-install GUID sent via userinfo, used for stats reporting.
    */
   char guid[MAX_QPATH];
+
+  /**
+   * @brief Racing or practicing, chosen by the client and kept across respawns.
+   */
+  g_race_mode_t race_mode;
+
+  /**
+   * @brief Where `kill` returns a practicing client to, once they have `store`d.
+   */
+  g_race_spawn_t race_spawn;
 } g_client_persistent_t;
 
 /**
@@ -1274,6 +1381,24 @@ struct g_client_s {
    * @brief Most recently received movement command.
    */
   pm_cmd_t cmd;
+
+  /**
+   * @brief The run in progress, cleared with the rest of this structure on respawn.
+   */
+  g_race_run_t race_run;
+
+  /**
+   * @brief The race trigger last touched and when, so that standing in one does
+   * not fire it every frame.
+   */
+  const g_entity_t *race_trigger;
+  uint32_t race_trigger_time;
+
+  /**
+   * @brief A start zone entered but not yet left or jumped out of, for the
+   * start modes that begin the run on the way out rather than on the way in.
+   */
+  const g_entity_t *race_start;
 
   /**
    * @brief Item inventory counts indexed by item index.

--- a/src/shared/shared.h
+++ b/src/shared/shared.h
@@ -296,11 +296,11 @@ typedef enum {
  * both the game and the client game hold.
  */
 typedef enum {
-  PM_MOVEMENT_QUETOO, // Quetoo's own, in bg_pmove_quetoo.c
-  PM_MOVEMENT_QUAKE,  // QuakeWorld's, in bg_pmove_quake.c
-  PM_MOVEMENT_QUAKE2, // Quake II's, in bg_pmove_quake2.c
-  PM_MOVEMENT_RACE,   // the race mod's own, in bg_pmove_race.c
-  PM_MOVEMENT_QUAKE3, // Quake III Arena's, in bg_pmove_quake3.c
+  PM_MOVEMENT_QUETOO,
+  PM_MOVEMENT_RACE,
+  PM_MOVEMENT_QUAKE,
+  PM_MOVEMENT_QUAKE2,
+  PM_MOVEMENT_QUAKE3,
 } pm_movement_t;
 
 /**


### PR DESCRIPTION
The first slice of racing itself, on the seams Phase 1 and 2 built. Two commits:
the movement reorder and relabel, and the run.

**The run.** Start, checkpoints 1 through N in order, finish. Three brush
triggers describe a course - `trigger_race_start` (begins on entry, on exit, or
on the first jump from inside; a course with none begins on first movement),
`trigger_race_checkpoint` (`cp` 1..64) and `trigger_race_finish` - and each
fires its `target` when the touch counted. The course is validated once they
have all spawned and published on `CS_RACE_COURSE`.

**The modes.** Racing counts: grapple and noclip refused, a valid finish
announced to everyone. Practicing is for learning: everything allowed, `store`
remembers a spot that `kill` returns to, nothing counts. Nobody is hurt in
either - players pass through each other, another player's attack does nothing,
and everything else keeps its knockback and loses its damage, so rocket jumps
work and lava does not kill. `kill` respawns at once with no corpse.

**Stats.** Six `STAT_RACE_*` (17 → 23 of 32): mode, run state, time in two
halves, checkpoints reached, disqualification flags.

**Harvested from the fork, narrowed and corrected.** Its inside-a-trigger test
asked `gi.Clip`, but the server never traces against a `SOLID_TRIGGER`, so it
was never true: exit starts fired a frame late and jump starts never fired.
Inside is a bounds overlap here, which is what fired the touch. Its stored
practice spawn drifted up a step height per `kill`; this stores the floor. A
checkpoint with no readable number now spoils the course rather than being
validated around.

**Re-cut from the #963 plan.** Step 3 as written had no triggers, and a timer
with no way to start it cannot be exercised, so the three plain triggers come
forward from step 4. Splits, stages, gates and one-way walls stay there;
records, replays and the HUD follow. `race` stays out of `GAME_MODULES` until it
is playable end to end.

**Found on the way, not fixed here:** `quetoo-dedicated +set game X` segfaults
in `Init` on `main` - `+set` creates a cvar named `game`, `Cmd_Add("game")`
returns NULL, `Cmd_SetAutocomplete` dereferences it. `+game X` is the flag
since 1b5e29b81. One-line guard, its own commit.

Verified: autotools and Xcode build the race module; `verify_projects.py` agrees
across all three systems; 21 `check_pmove` + 3 `check_net_message` pass; a
headless `quetoo-dedicated -p <worktree> +game race +map aerowalk` loads the
module, installs the hooks and runs the level. No map has race triggers yet, so
the run itself is exercised only by reading; a test map is the next thing this
needs.

Refs #963.