### PR TITLE
Add the rest of the course: splits, stages, gates and one-way walls

### DIFF
--- a/src/game/race/g_race.c
+++ b/src/game/race/g_race.c
@@ -46,6 +46,7 @@
 static struct {
   ConfigureLevel ConfigureLevel;
   SpawnEntity SpawnEntity;
+  ClipEntity ClipEntity;
   PrepareSpawn PrepareSpawn;
   TossInventory TossInventory;
   ModifyDamage ModifyDamage;
@@ -109,15 +110,31 @@ void G_Race_AddStart(void) {
   g_level.race_course.start_count++;
 }
 
-bool G_Race_AddCheckpoint(int32_t checkpoint) {
+/**
+ * @brief Records number `n` of a sequence that runs from `first`, or marks the
+ * sequence malformed for an `n` that cannot be one of it.
+ */
+static bool G_Race_AddToSequence(uint64_t *sequence, bool *malformed, int32_t n, int32_t first) {
 
-  if (checkpoint < 1 || checkpoint > RACE_MAX_CHECKPOINTS) {
-    g_level.race_course.malformed = true;
+  if (n < first || n > RACE_MAX_CHECKPOINTS) {
+    *malformed = true;
     return false;
   }
 
-  g_level.race_course.checkpoints |= UINT64_C(1) << (checkpoint - 1);
+  *sequence |= UINT64_C(1) << (n - 1);
   return true;
+}
+
+bool G_Race_AddCheckpoint(int32_t checkpoint) {
+  return G_Race_AddToSequence(&g_level.race_course.checkpoints, &g_level.race_course.malformed, checkpoint, 1);
+}
+
+bool G_Race_AddSplit(int32_t split) {
+  return G_Race_AddToSequence(&g_level.race_course.splits, &g_level.race_course.splits_malformed, split, 1);
+}
+
+bool G_Race_AddStage(int32_t stage) {
+  return G_Race_AddToSequence(&g_level.race_course.stages, &g_level.race_course.stages_malformed, stage, 2);
 }
 
 void G_Race_AddFinish(void) {
@@ -125,25 +142,44 @@ void G_Race_AddFinish(void) {
 }
 
 /**
- * @brief A course is valid when its checkpoints are exactly 1 through N with
- * none missing, and it has somewhere to finish.
+ * @brief The lowest `n` bits.
  */
-static void G_Race_ValidateCourse(void) {
-  g_race_course_t *course = &g_level.race_course;
+static uint64_t G_Race_Bits(int32_t n) {
+  return n >= 64 ? UINT64_MAX : (UINT64_C(1) << n) - 1;
+}
 
-  course->checkpoint_count = 0;
+/**
+ * @brief Whether `sequence` is exactly `first` through N with none missing,
+ * for an N it reports. An empty sequence is a valid one with N of zero.
+ */
+static bool G_Race_ValidateSequence(uint64_t sequence, bool malformed, int32_t first, uint16_t *count) {
+
+  *count = 0;
   for (int32_t i = RACE_MAX_CHECKPOINTS; i > 0; i--) {
-    if (course->checkpoints & (UINT64_C(1) << (i - 1))) {
-      course->checkpoint_count = i;
+    if (sequence & (UINT64_C(1) << (i - 1))) {
+      *count = i;
       break;
     }
   }
 
-  const uint64_t expected = course->checkpoint_count == RACE_MAX_CHECKPOINTS
-                            ? UINT64_MAX
-                            : (UINT64_C(1) << course->checkpoint_count) - 1;
+  const uint64_t expected = *count ? G_Race_Bits(*count) & ~G_Race_Bits(first - 1) : 0;
 
-  course->valid = !course->malformed && course->checkpoints == expected && course->finish_count > 0;
+  return !malformed && sequence == expected;
+}
+
+/**
+ * @brief A course is valid when its checkpoints are exactly 1 through N with
+ * none missing, and it has somewhere to finish. Splits and stages are valid
+ * on their own terms and spoil only themselves.
+ */
+static void G_Race_ValidateCourse(void) {
+  g_race_course_t *course = &g_level.race_course;
+
+  course->valid = G_Race_ValidateSequence(course->checkpoints, course->malformed, 1, &course->checkpoint_count) &&
+                  course->finish_count > 0;
+
+  course->splits_valid = G_Race_ValidateSequence(course->splits, course->splits_malformed, 1, &course->split_count);
+  course->stages_valid = G_Race_ValidateSequence(course->stages, course->stages_malformed, 2, &course->stage_count);
 }
 
 // ---------------------------------------------------------------- the run
@@ -177,6 +213,7 @@ bool G_Race_Start(g_client_t *cl) {
 
   run->state = RACE_RUN_ACTIVE;
   run->mode = G_Race_Mode(cl);
+  run->stage = 1;
   run->start_time = g_level.time;
   run->start_speed = run->top_speed = speed;
 
@@ -231,6 +268,73 @@ bool G_Race_Checkpoint(g_client_t *cl, uint16_t checkpoint) {
   }, MULTICAST_PHS);
 
   return true;
+}
+
+/**
+ * @brief A split times the run without judging it: one reached out of order
+ * is simply not a split of this run.
+ */
+bool G_Race_Split(g_client_t *cl, uint16_t split, const char *label) {
+  g_race_run_t *run = &cl->race_run;
+
+  if (!G_Race_CanRun(cl) || run->state != RACE_RUN_ACTIVE || !g_level.race_course.splits_valid) {
+    return false;
+  }
+
+  if (split != run->split_count + 1) {
+    return false;
+  }
+
+  const uint32_t time = g_level.time - run->start_time;
+  const uint32_t previous = run->split_count ? run->split_times[run->split_count - 1] : 0;
+
+  run->split_times[run->split_count++] = time;
+
+  gi.ClientPrint(cl, PRINT_HIGH, "%s  %s  (+%s)\n", label && *label ? label : va("Split %u", split),
+                 G_Race_FormatTime(time), G_Race_FormatTime(time - previous));
+  return true;
+}
+
+/**
+ * @brief A stage is timed as a split is, and is also where a practicing client
+ * returns to: reaching one stores its anchor, as `store` would.
+ */
+bool G_Race_Stage(g_client_t *cl, uint16_t stage, const char *label, const g_entity_t *anchor) {
+  g_race_run_t *run = &cl->race_run;
+
+  if (!G_Race_CanRun(cl) || !g_level.race_course.stages_valid) {
+    return false;
+  }
+
+  const char *name = label && *label ? label : va("Stage %u", stage);
+  bool counted = false;
+
+  if (run->state == RACE_RUN_ACTIVE && stage == run->stage + 1) {
+    run->stage_times[stage - 2] = g_level.time - run->start_time;
+    run->stage = stage;
+
+    gi.ClientPrint(cl, PRINT_HIGH, "%s  %s\n", name, G_Race_FormatTime(run->stage_times[stage - 2]));
+    counted = true;
+  }
+
+  if (G_Race_Mode(cl) == RACE_MODE_PRACTICE) {
+    g_race_spawn_t *spawn = &cl->persistent.race_spawn;
+
+    if (!spawn->set || !Vec3_Equal(spawn->origin, anchor->s.origin)) {
+      *spawn = (g_race_spawn_t) {
+        .origin = anchor->s.origin,
+        .angles = anchor->s.angles,
+        .set = true,
+      };
+
+      if (!counted) {
+        gi.ClientPrint(cl, PRINT_HIGH, "%s. ^2kill^7 returns here\n", name);
+      }
+      counted = true;
+    }
+  }
+
+  return counted;
 }
 
 bool G_Race_Finish(g_client_t *cl) {
@@ -417,9 +521,10 @@ static void G_Race_Status_f(g_client_t *cl) {
 
   switch (run->state) {
     case RACE_RUN_ACTIVE:
-      gi.ClientPrint(cl, PRINT_HIGH, "Running: %s, checkpoint %u of %u\n",
+      gi.ClientPrint(cl, PRINT_HIGH, "Running: %s, checkpoint %u of %u%s\n",
                      G_Race_FormatTime(g_level.time - run->start_time),
-                     run->checkpoint_count, course->checkpoint_count);
+                     run->checkpoint_count, course->checkpoint_count,
+                     course->stages_valid && course->stage_count ? va(", stage %u of %u", run->stage, course->stage_count) : "");
       break;
     case RACE_RUN_FINISHED:
       gi.ClientPrint(cl, PRINT_HIGH, "Finished: %s\n", G_Race_FormatTime(run->elapsed));
@@ -437,6 +542,7 @@ static void G_ConfigureLevel_Race(void) {
   previous.ConfigureLevel();
 
   G_Race_ValidateCourse();
+  G_Race_ResolveStages();
 
   const g_race_course_t *course = &g_level.race_course;
 
@@ -461,6 +567,15 @@ static bool G_SpawnEntity_Race(g_entity_t *ent) {
   }
 
   return previous.SpawnEntity(ent);
+}
+
+static bool G_ClipEntity_Race(const g_entity_t *mover, const g_entity_t *ent, const vec3_t start, const vec3_t end, const box3_t bounds) {
+
+  if (!G_Race_ClipEntity(mover, ent, start, end, bounds)) {
+    return false;
+  }
+
+  return previous.ClipEntity(mover, ent, start, end, bounds);
 }
 
 /**
@@ -649,6 +764,9 @@ void G_Race_Init(void) {
 
   previous.SpawnEntity = G_SpawnEntity;
   G_SpawnEntity = G_SpawnEntity_Race;
+
+  previous.ClipEntity = G_ClipEntity;
+  G_ClipEntity = G_ClipEntity_Race;
 
   previous.PrepareSpawn = G_PrepareSpawn;
   G_PrepareSpawn = G_PrepareSpawn_Race;

--- a/src/game/race/g_race.h
+++ b/src/game/race/g_race.h
@@ -49,6 +49,8 @@ g_race_mode_t G_Race_Mode(const g_client_t *cl);
  */
 void G_Race_AddStart(void);
 bool G_Race_AddCheckpoint(int32_t checkpoint);
+bool G_Race_AddSplit(int32_t split);
+bool G_Race_AddStage(int32_t stage);
 void G_Race_AddFinish(void);
 
 /**
@@ -57,6 +59,8 @@ void G_Race_AddFinish(void);
  */
 bool G_Race_Start(g_client_t *cl);
 bool G_Race_Checkpoint(g_client_t *cl, uint16_t checkpoint);
+bool G_Race_Split(g_client_t *cl, uint16_t split, const char *label);
+bool G_Race_Stage(g_client_t *cl, uint16_t stage, const char *label, const g_entity_t *anchor);
 bool G_Race_Finish(g_client_t *cl);
 
 /**
@@ -77,3 +81,15 @@ bool G_Race_Debounced(g_client_t *cl, const g_entity_t *ent, float wait);
  * that is not one. Chained under `SpawnEntity` by `G_Race_Init`.
  */
 bool G_Race_SpawnEntity(g_entity_t *ent);
+
+/**
+ * @brief Finds each stage's `restart_target` once every entity has spawned,
+ * and spoils the stages if any is missing. Called from `ConfigureLevel`.
+ */
+void G_Race_ResolveStages(void);
+
+/**
+ * @brief Whether `ent` clips `mover`, which is where a gate or one-way wall
+ * decides. Pure, and chained under `ClipEntity` by `G_Race_Init`.
+ */
+bool G_Race_ClipEntity(const g_entity_t *mover, const g_entity_t *ent, const vec3_t start, const vec3_t end, const box3_t bounds);

--- a/src/game/race/g_race_entity.c
+++ b/src/game/race/g_race_entity.c
@@ -23,12 +23,13 @@
 
 /**
  * @file
- * @brief The triggers that describe a course. Each records itself with the
- * course as it spawns, and hands the client to g_race.c when touched.
+ * @brief The entities that describe a course: the triggers, which record
+ * themselves with the course as they spawn and hand the client to g_race.c when
+ * touched, and the barriers, brushes that are solid to a racer on a condition.
  *
- * All of them are brush triggers, invisible, and fire their `target` and
- * `message` like a `trigger_multiple` does when the touch counted. `wait`
- * debounces a client standing in one, and defaults to half a second.
+ * The triggers are invisible, and fire their `target` and `message` like a
+ * `trigger_multiple` does when the touch counted. `wait` debounces a client
+ * standing in one, and defaults to half a second.
  */
 
 // what a trigger stood in waits before counting the same client again
@@ -144,6 +145,103 @@ static void G_trigger_race_checkpoint(g_entity_t *ent) {
   G_trigger_race_Init(ent, G_trigger_race_checkpoint_Touch);
 }
 
+static const char *G_trigger_race_Label(const g_entity_t *ent) {
+  return gi.EntityValue(ent->def, "label")->nullable_string;
+}
+
+static void G_trigger_race_split_Touch(g_entity_t *ent, g_entity_t *other, const cm_trace_t *trace) {
+
+  if (G_trigger_race_Accepts(ent, other) && G_Race_Split(other->client, ent->count, G_trigger_race_Label(ent))) {
+    G_UseTargets(ent, other);
+  }
+}
+
+/*QUAKED trigger_race_split (.5 .5 .5) ?
+ A timing point. A course's splits are numbered 1 through N with none missing
+ and are passed in that order, but they only time the run: one missed does not
+ spoil it.
+
+ -------- Keys --------
+ split : This split's number, from 1.
+ label : An optional name, printed with the time (default "Split N").
+ wait : Seconds before the same client is heard from again (default 0.5).
+ message : An optional string to display when the split is reached.
+ target : The name of the entity or team to use when the split is reached.
+ */
+static void G_trigger_race_split(g_entity_t *ent) {
+
+  const cm_entity_t *split = gi.EntityValue(ent->def, "split");
+
+  if (!G_Race_AddSplit(split->parsed & ENTITY_INTEGER ? split->integer : 0)) {
+    G_Warn("%s needs split, an integer from 1 through %d\n", etos(ent), RACE_MAX_CHECKPOINTS);
+    G_FreeEntity(ent);
+    return;
+  }
+
+  ent->count = split->integer;
+
+  G_trigger_race_Init(ent, G_trigger_race_split_Touch);
+}
+
+static void G_trigger_race_stage_Touch(g_entity_t *ent, g_entity_t *other, const cm_trace_t *trace) {
+
+  if (G_trigger_race_Accepts(ent, other) &&
+      G_Race_Stage(other->client, ent->count, G_trigger_race_Label(ent), ent->target_ent)) {
+    G_UseTargets(ent, other);
+  }
+}
+
+/*QUAKED trigger_race_stage (.5 .5 .5) ?
+ Where a stage of the course begins. A run begins in stage 1, so stages are
+ numbered 2 through N with none missing and entered in that order, and each is
+ timed as a split is. A practicing client who reaches one has its restart_target
+ stored, as store would, so that kill returns to the stage rather than the spawn.
+
+ -------- Keys --------
+ stage : This stage's number, from 2.
+ restart_target : The targetname of the info_notnull to return to, placed as a spawn point would be.
+ label : An optional name, printed with the time (default "Stage N").
+ wait : Seconds before the same client is heard from again (default 0.5).
+ message : An optional string to display when the stage is reached.
+ target : The name of the entity or team to use when the stage is reached.
+ */
+static void G_trigger_race_stage(g_entity_t *ent) {
+
+  const cm_entity_t *stage = gi.EntityValue(ent->def, "stage");
+  const char *restart = gi.EntityValue(ent->def, "restart_target")->nullable_string;
+
+  const bool complete = (stage->parsed & ENTITY_INTEGER) && restart && *restart;
+
+  if (!G_Race_AddStage(complete ? stage->integer : 0)) {
+    G_Warn("%s needs stage, an integer from 2 through %d, and restart_target\n", etos(ent), RACE_MAX_CHECKPOINTS);
+    G_FreeEntity(ent);
+    return;
+  }
+
+  ent->count = stage->integer;
+
+  G_trigger_race_Init(ent, G_trigger_race_stage_Touch);
+}
+
+void G_Race_ResolveStages(void) {
+
+  g_entity_t *stage = NULL;
+  while ((stage = G_Find(stage, EOFS(classname), "trigger_race_stage"))) {
+
+    const char *name = gi.EntityValue(stage->def, "restart_target")->nullable_string;
+
+    g_entity_t *anchor = G_Find(NULL, EOFS(target_name), name);
+
+    if (!anchor || q_strcmp(anchor->classname, "info_notnull") || G_Find(anchor, EOFS(target_name), name)) {
+      G_Warn("%s needs restart_target to name one info_notnull, and \"%s\" does not\n", etos(stage), name);
+      g_level.race_course.stages_valid = false;
+      continue;
+    }
+
+    stage->target_ent = anchor;
+  }
+}
+
 static void G_trigger_race_finish_Touch(g_entity_t *ent, g_entity_t *other, const cm_trace_t *trace) {
 
   if (G_trigger_race_Accepts(ent, other) && G_Race_Finish(other->client)) {
@@ -166,13 +264,138 @@ static void G_trigger_race_finish(g_entity_t *ent) {
   G_Race_AddFinish();
 }
 
+/**
+ * @brief The common half of every barrier's setup: an inline brush, solid,
+ * whose conditions `G_Race_ClipEntity` applies.
+ */
+static void G_func_race_Init(g_entity_t *ent, g_race_barrier_t barrier) {
+
+  if (!ent->model || ent->model[0] != '*') {
+    G_Warn("%s needs a brush\n", etos(ent));
+    G_FreeEntity(ent);
+    return;
+  }
+
+  ent->race_barrier = barrier;
+  ent->solid = SOLID_BSP;
+  ent->move_type = MOVE_TYPE_NONE;
+
+  gi.SetModel(ent, ent->model);
+  gi.LinkEntity(ent);
+}
+
+/*QUAKED func_race_checkpoint_gate (0 .5 .8) ?
+ A brush that is solid to a racer until the run satisfies its checkpoint
+ condition, and solid to everything else always. A client with no run under way
+ passes freely. Texture it with clip so that it is never seen.
+
+ -------- Keys --------
+ cp : The checkpoint the gate is about, from 1.
+ mode : atleast (default) opens the gate once checkpoint cp has been reached; exact opens it only while cp is the last one reached.
+ invert : 1 to close the gate under the condition instead of opening it.
+ */
+static void G_func_race_checkpoint_gate(g_entity_t *ent) {
+
+  const cm_entity_t *cp = gi.EntityValue(ent->def, "cp");
+  const char *mode = gi.EntityValue(ent->def, "mode")->nullable_string;
+
+  if (!(cp->parsed & ENTITY_INTEGER) || cp->integer < 1 || cp->integer > RACE_MAX_CHECKPOINTS) {
+    G_Warn("%s needs cp, an integer from 1 through %d\n", etos(ent), RACE_MAX_CHECKPOINTS);
+    G_FreeEntity(ent);
+    return;
+  }
+
+  g_race_gate_t gate = {
+    .checkpoint = cp->integer,
+    .invert = gi.EntityValue(ent->def, "invert")->integer != 0,
+  };
+
+  if (!mode || !*mode || !q_strcasecmp(mode, "atleast")) {
+    gate.mode = RACE_GATE_AT_LEAST;
+  } else if (!q_strcasecmp(mode, "exact")) {
+    gate.mode = RACE_GATE_EXACT;
+  } else {
+    G_Warn("%s has mode \"%s\"; it must be atleast or exact\n", etos(ent), mode);
+    G_FreeEntity(ent);
+    return;
+  }
+
+  ent->race_gate = gate;
+
+  G_func_race_Init(ent, RACE_BARRIER_GATE);
+}
+
+/*QUAKED func_race_oneway_wall (0 .5 .8) ?
+ A brush that a racer passes through in one direction and not the other, and
+ that is solid to everything else. Texture it with clip so that it is never seen.
+
+ -------- Keys --------
+ angle : The direction of travel that passes, in the horizontal plane.
+ */
+static void G_func_race_oneway_wall(g_entity_t *ent) {
+
+  G_SetMoveDir(ent);
+  ent->move_dir.z = 0.f;
+
+  if (Vec3_Equal(ent->move_dir, Vec3_Zero())) {
+    G_Warn("%s needs angle, a direction of travel in the horizontal plane\n", etos(ent));
+    G_FreeEntity(ent);
+    return;
+  }
+
+  G_func_race_Init(ent, RACE_BARRIER_WALL);
+}
+
+/**
+ * @brief Called for every entity a trace considers, so the ones that are not
+ * barriers, and everything that is not a client, are turned away first.
+ *
+ * A wall the client is already inside never clips: the only way in was the way
+ * it allows, and clipping it from within would wedge the client. The test asks
+ * the server for this one brush, which asks back here with no mover and is told
+ * the wall is a wall, so the recursion ends there.
+ */
+bool G_Race_ClipEntity(const g_entity_t *mover, const g_entity_t *ent, const vec3_t start, const vec3_t end, const box3_t bounds) {
+
+  if (ent->race_barrier == RACE_BARRIER_NONE || !mover || !mover->client) {
+    return true;
+  }
+
+  if (ent->race_barrier == RACE_BARRIER_GATE) {
+    const g_race_run_t *run = &mover->client->race_run;
+
+    if (run->state != RACE_RUN_ACTIVE) {
+      return false;
+    }
+
+    const g_race_gate_t *gate = &ent->race_gate;
+    const bool open = gate->mode == RACE_GATE_EXACT
+                      ? run->checkpoint_count == gate->checkpoint
+                      : run->checkpoint_count >= gate->checkpoint;
+
+    return open == gate->invert;
+  }
+
+  if (gi.Clip(start, start, bounds, ent, CONTENTS_MASK_CLIP_PLAYER).start_solid) {
+    return false;
+  }
+
+  const vec3_t travel = Vec3_Subtract(end, start);
+
+  return travel.x * ent->move_dir.x + travel.y * ent->move_dir.y <= 0.f;
+}
+
 static const struct {
   const char *classname;
   void (*Init)(g_entity_t *ent);
 } g_race_entity_classes[] = {
   { "trigger_race_start", G_trigger_race_start },
   { "trigger_race_checkpoint", G_trigger_race_checkpoint },
+  { "trigger_race_split", G_trigger_race_split },
+  { "trigger_race_stage", G_trigger_race_stage },
   { "trigger_race_finish", G_trigger_race_finish },
+  { "func_race_checkpoint_gate", G_func_race_checkpoint_gate },
+  { "func_race_oneway_wall", G_func_race_oneway_wall },
 };
 
 bool G_Race_SpawnEntity(g_entity_t *ent) {

--- a/src/game/race/g_race_entity.c
+++ b/src/game/race/g_race_entity.c
@@ -279,6 +279,7 @@ static void G_func_race_Init(g_entity_t *ent, g_race_barrier_t barrier) {
   ent->race_barrier = barrier;
   ent->solid = SOLID_BSP;
   ent->move_type = MOVE_TYPE_NONE;
+  ent->sv_flags |= SVF_NO_CLIENT;
 
   gi.SetModel(ent, ent->model);
   gi.LinkEntity(ent);

--- a/src/game/race/g_types.h
+++ b/src/game/race/g_types.h
@@ -123,8 +123,9 @@ typedef enum {
 _Static_assert(STAT_RACE_FLAGS < MAX_STATS, "the race stats must fit the stat array");
 
 /**
- * @brief The most checkpoints a course may have. A course is contiguous
- * checkpoints 1 through N and at least one finish; a start is optional.
+ * @brief The most checkpoints a course may have, and likewise splits and
+ * stages. A course is contiguous checkpoints 1 through N and at least one
+ * finish; a start is optional, and so are splits and stages.
  */
 #define RACE_MAX_CHECKPOINTS 64
 
@@ -165,16 +166,44 @@ typedef enum {
 } g_race_start_mode_t;
 
 /**
+ * @brief What a `func_race_*` brush is to a racer's movement, kept on the
+ * entity so that `G_Race_ClipEntity` can tell one at a glance.
+ */
+typedef enum {
+  RACE_BARRIER_NONE,
+  RACE_BARRIER_GATE, // solid until the run's checkpoints satisfy it
+  RACE_BARRIER_WALL  // solid from one side only
+} g_race_barrier_t;
+
+/**
+ * @brief When a `func_race_checkpoint_gate` opens.
+ */
+typedef enum {
+  RACE_GATE_AT_LEAST, // once the checkpoint has been reached
+  RACE_GATE_EXACT     // only while it is the last one reached
+} g_race_gate_mode_t;
+
+typedef struct {
+  uint16_t checkpoint;
+  g_race_gate_mode_t mode;
+  bool invert; // closed under the condition rather than open
+} g_race_gate_t;
+
+/**
  * @brief The course the level's triggers describe, gathered as they spawn and
  * validated once they all have.
  */
 typedef struct {
   uint64_t checkpoints; // bit N - 1 is set once checkpoint N has spawned
-  uint16_t checkpoint_count;
+  uint64_t splits;      // likewise for splits 1 through N
+  uint64_t stages;      // likewise for stages 2 through N; a run begins in stage 1
+  uint16_t checkpoint_count, split_count, stage_count;
   uint16_t start_count;
   uint16_t finish_count;
-  bool malformed; // a checkpoint number out of range was seen
-  bool valid;
+  bool malformed, splits_malformed, stages_malformed; // a number out of range was seen
+  bool valid;        // checkpoints 1 through N and a finish; nothing else bears on it
+  bool splits_valid; // splits 1 through N, so they time
+  bool stages_valid; // stages 2 through N, each with somewhere to return to
 } g_race_course_t;
 
 /**
@@ -185,9 +214,13 @@ typedef struct {
   g_race_run_state_t state;
   g_race_mode_t mode; // the mode the run was started in, which is what decides whether it counts
   uint16_t checkpoint_count;
+  uint16_t split_count;
+  uint16_t stage; // the one under way, from 1
   uint32_t start_time;
   uint32_t elapsed; // set on finish
   uint32_t checkpoint_times[RACE_MAX_CHECKPOINTS]; // from the start
+  uint32_t split_times[RACE_MAX_CHECKPOINTS];
+  uint32_t stage_times[RACE_MAX_CHECKPOINTS]; // stage_times[N - 2] is when stage N began
   float start_speed, end_speed, top_speed;
   float speed_sum; // over speed_samples, for the average
   uint32_t speed_samples;
@@ -1981,6 +2014,12 @@ struct g_entity_s {
    * @brief True if the entity should advance along the item path.
    */
   bool move_node;
+
+  /**
+   * @brief What this brush is to a racer's movement, for the `func_race_*` classes.
+   */
+  g_race_barrier_t race_barrier;
+  g_race_gate_t race_gate;
 };
 
 typedef struct g_entity_s g_entity_t;


### PR DESCRIPTION
Step 4 of the race module (#963): two more triggers and the first two barriers.

**Splits and stages.** `trigger_race_split` (`split` 1..N, `label`) times the run
without judging it: one reached out of order is simply not a split of this run.
`trigger_race_stage` (`stage` 2..N, `restart_target`, `label`) is timed the same
way, and is also where a practicing client returns to: reaching one stores its
`info_notnull` anchor as `store` would, so `kill` goes back to the stage rather
than the spawn. Both sequences validate on their own terms and spoil only
themselves; the course stays valid. Anchors are resolved in `ConfigureLevel`,
once every entity has spawned.

**Gates.** `func_race_checkpoint_gate` (`cp`, `mode` atleast|exact, `invert`) is
a brush that is solid to a racer until the run's checkpoints satisfy it, and
solid to everything else always. It binds only an *active* run, so a practicing
client with no run under way passes freely rather than being locked out of the
later sections.

**One-way walls.** `func_race_oneway_wall` (`angle`) passes a racer one way and
not the other, and needs no per-client latch: `G_Race_ClipEntity` stays pure by
asking `gi.Clip` whether the mover is already inside this one brush. That nested
call comes back through the hook with no mover, where a wall is a wall, so the
recursion ends there.

**Not carried from the fork:** the 1024-unit gate clearance rule, the 64-barrier
cap and the model-index uniqueness check all existed only for its client-side
latch bitmask; the FNV split-layout hash belongs with records (step 5).

Verified: autotools and Xcode build the race module, `verify_projects.py` agrees
across all three systems (no new files), and a headless
`quetoo-dedicated +game race +map racetest` on a test map extended with a gate,
split, stage + anchor and one-way wall spawns all seven classes with no
warnings (10 baseline entities, up from 6). Prediction of barriers on the client
is step 7; until then a client walking into a closed gate will be corrected by
the server.

Refs #963.

🤖 Generated with [Claude Code](https://claude.com/claude-code)