### PR TITLE
Remove pm_params_t.gravity_water

### DIFF
--- a/src/game/common/bg_pmove.c
+++ b/src/game/common/bg_pmove.c
@@ -243,13 +243,7 @@ void Pm_Gravity(void) {
     return;
   }
 
-  float gravity = pm->s.params.gravity;
-
-  if (pm->water_level > WATER_WAIST) {
-    gravity *= pm->s.params.gravity_water;
-  }
-
-  pm->s.velocity.z -= gravity * pm_locals.time;
+  pm->s.velocity.z -= pm->s.params.gravity * pm_locals.time;
 }
 
 /**

--- a/src/game/common/bg_pmove_quake.c
+++ b/src/game/common/bg_pmove_quake.c
@@ -67,7 +67,6 @@
 
 const pm_params_t pm_quake_params = {
   .gravity = 800,               // sv_gravity
-  .gravity_water = 1.f,         // unused: this kernel applies no gravity in water
   .accel_ground = 10.f,         // sv_accelerate
   .accel_ground_slick = 10.f,   // unused: Quake has no slick surfaces
   .accel_air = 10.f,            // sv_accelerate again; PM_AirMove passes it to both

--- a/src/game/common/bg_pmove_quake2.c
+++ b/src/game/common/bg_pmove_quake2.c
@@ -70,7 +70,6 @@
 
 const pm_params_t pm_quake2_params = {
   .gravity = 800,
-  .gravity_water = 1.f,         // unused: this movement applies no gravity in water
   .accel_ground = 10.f,         // pm_accelerate
   .accel_ground_slick = 10.f,   // Quake II does not accelerate differently on slick
   .accel_air = 1.f,             // the literal 1 the airborne case passes

--- a/src/game/common/bg_pmove_quake3.c
+++ b/src/game/common/bg_pmove_quake3.c
@@ -113,7 +113,6 @@
 
 const pm_params_t pm_quake3_params = {
   .gravity = 800,
-  .gravity_water = 1.f,         // unused: this movement applies no gravity while swimming
   .accel_ground = 10.f,         // pm_accelerate
   .accel_ground_slick = 1.f,    // pm_airaccelerate, which is what slick ground gets
   .accel_air = 1.f,             // pm_airaccelerate

--- a/src/game/common/bg_pmove_race.c
+++ b/src/game/common/bg_pmove_race.c
@@ -69,7 +69,6 @@
 
 const pm_params_t pm_race_params = {
   .gravity = 800,
-  .gravity_water = 1.f,
   .accel_ground = 10.f,
   .accel_ground_slick = 10.f,
   .accel_air = 1.f,             // uncapped wish, so strafing gains over a wide arc

--- a/src/game/common/g_main.c
+++ b/src/game/common/g_main.c
@@ -165,7 +165,6 @@ cvar_t *g_spectator_speed;
 cvar_t *g_stop_speed;
 cvar_t *g_water_acceleration;
 cvar_t *g_water_friction;
-cvar_t *g_water_gravity;
 cvar_t *g_water_jump_speed;
 cvar_t *g_water_speed;
 cvar_t *g_death_cam;
@@ -576,7 +575,6 @@ pm_params_t G_MovementParams(void) {
 
   pm_params_t params = (pm_params_t) {
     .gravity = g_level.gravity,
-    .gravity_water = g_water_gravity->value,
 
     .accel_ground = g_ground_acceleration->value,
     .accel_ground_slick = g_ground_acceleration_slick->value,
@@ -1155,7 +1153,6 @@ void G_Init(void) {
   g_stop_speed = gi.AddCvar("g_stop_speed", "100.0", 0, "Speed below which friction is amplified to stop the player. Default 100.0.");
   g_water_acceleration = gi.AddCvar("g_water_acceleration", "3.0", 0, "Acceleration applied underwater. Default 3.0.");
   g_water_friction = gi.AddCvar("g_water_friction", "2.0", 0, "Friction applied underwater. Default 2.0.");
-  g_water_gravity = gi.AddCvar("g_water_gravity", "0.33", 0, "Fraction of gravity applied underwater. Default 0.33.");
   g_water_jump_speed = gi.AddCvar("g_water_jump_speed", "420.0", 0, "Upward velocity when jumping out of water. Default 420.0.");
   g_water_speed = gi.AddCvar("g_water_speed", "140.0", 0, "Maximum swimming speed. Default 140.0.");
 

--- a/src/game/common/g_main.h
+++ b/src/game/common/g_main.h
@@ -177,7 +177,6 @@ extern cvar_t *g_spectator_speed;
 extern cvar_t *g_stop_speed;
 extern cvar_t *g_water_acceleration;
 extern cvar_t *g_water_friction;
-extern cvar_t *g_water_gravity;
 extern cvar_t *g_water_jump_speed;
 extern cvar_t *g_water_speed;
 extern cvar_t *g_death_cam;

--- a/src/net/net_message.c
+++ b/src/net/net_message.c
@@ -307,8 +307,8 @@ void Net_WriteDeltaPlayerState(mem_buf_t *msg, const player_state_t *from, const
     bits |= PS_PM_STEP_OFFSET;
   }
 
-  if (memcmp(&to->pm_state.params.gravity_water, &from->pm_state.params.gravity_water,
-             sizeof(pm_params_t) - offsetof(pm_params_t, gravity_water)) != 0) {
+  if (memcmp(&to->pm_state.params.accel_ground, &from->pm_state.params.accel_ground,
+             sizeof(pm_params_t) - offsetof(pm_params_t, accel_ground)) != 0) {
     bits |= PS_PM_PARAMS;
   }
 
@@ -375,7 +375,6 @@ void Net_WriteDeltaPlayerState(mem_buf_t *msg, const player_state_t *from, const
   }
 
   if (bits & PS_PM_PARAMS) {
-    Net_WriteFloat(msg, to->pm_state.params.gravity_water);
     Net_WriteFloat(msg, to->pm_state.params.accel_ground);
     Net_WriteFloat(msg, to->pm_state.params.accel_ground_slick);
     Net_WriteFloat(msg, to->pm_state.params.accel_air);
@@ -906,7 +905,6 @@ void Net_ReadDeltaPlayerState(mem_buf_t *msg, const player_state_t *from, player
   }
 
   if (bits & PS_PM_PARAMS) {
-    to->pm_state.params.gravity_water = Net_ReadFloat(msg);
     to->pm_state.params.accel_ground = Net_ReadFloat(msg);
     to->pm_state.params.accel_ground_slick = Net_ReadFloat(msg);
     to->pm_state.params.accel_air = Net_ReadFloat(msg);

--- a/src/shared/shared.h
+++ b/src/shared/shared.h
@@ -324,11 +324,6 @@ typedef struct {
   float speed_ground, speed_air, speed_water, speed_ladder, speed_spectator,
         speed_stop, speed_jump, speed_ducked, speed_duck_stand, speed_water_jump;
 
-  // the whole player box, standing, ducked and dead, rather than only its top:
-  // a movement whose box is not its own is not really its own. `PM_BOUNDS`,
-  // `PM_CROUCHED_BOUNDS` and `PM_DEAD_BOUNDS` are what these default to. The
-  // giblet box stays in `bg_pmove.c`: a giblet is a form Quetoo's game gives a
-  // player rather than a box any movement stands in
   box3_t bounds, bounds_ducked, bounds_dead;
 } pm_params_t;
 

--- a/src/shared/shared.h
+++ b/src/shared/shared.h
@@ -314,7 +314,6 @@ typedef enum {
 typedef struct {
   int16_t gravity;     // world gravity; default from g_gravity / map (int16)
   uint8_t movement;      // pm_movement_t; which movement Pm_Move runs
-  float gravity_water; // PM_GRAVITY_WATER
 
   float accel_ground, accel_ground_slick, accel_air, accel_water,
         accel_spectator, accel_ladder;
@@ -336,17 +335,17 @@ typedef struct {
 /**
  * @brief This layout is the wire format. `Net_WriteDeltaPlayerState` sends
  * `gravity` and `movement` on their own bits and compares everything from
- * `gravity_water` on with one `memcmp`, so two things must stay true: `movement`
+ * `accel_ground` on with one `memcmp`, so two things must stay true: `movement`
  * must keep sitting in the padding `gravity` leaves, or the compared region
  * moves, and that region must hold nothing but the floats the encoder writes,
  * or the comparison reads padding and resends the block at random. A field
  * added anywhere but the end breaks the first; a field of another width breaks
  * the second. Both are asserted rather than commented so that the build says so.
  */
-_Static_assert(offsetof(pm_params_t, gravity_water) == sizeof(float),
+_Static_assert(offsetof(pm_params_t, accel_ground) == sizeof(float),
                "pm_params_t.movement must fit in the padding after gravity");
-_Static_assert(sizeof(pm_params_t) - offsetof(pm_params_t, gravity_water) ==
-               41 * sizeof(float),
+_Static_assert(sizeof(pm_params_t) - offsetof(pm_params_t, accel_ground) ==
+               40 * sizeof(float),
                "the delta-compared region of pm_params_t must be floats only");
 
 /**

--- a/src/tests/check_net_message.c
+++ b/src/tests/check_net_message.c
@@ -48,7 +48,6 @@ static void Fill_TestParams(pm_params_t *p) {
   // a byte no `pm_movement_t` owns: what is under test is that the field reaches
   // the other side intact, not what it selects once it arrives
   p->movement = 200;
-  p->gravity_water = 0.5f;
   p->accel_ground = 11.f;       p->accel_ground_slick = 4.5f;
   p->accel_air = 3.f;           p->accel_water = 3.5f;
   p->accel_spectator = 2.75f;   p->accel_ladder = 17.f;
@@ -97,8 +96,8 @@ START_TEST(check_PlayerState_Params_RoundTrip) {
   ck_assert_int_eq(result.pm_state.params.gravity, to.pm_state.params.gravity);
   ck_assert_int_eq(result.pm_state.params.movement, to.pm_state.params.movement);
 
-  ck_assert_msg(memcmp(&result.pm_state.params.gravity_water, &to.pm_state.params.gravity_water,
-                       sizeof(pm_params_t) - offsetof(pm_params_t, gravity_water)) == 0,
+  ck_assert_msg(memcmp(&result.pm_state.params.accel_ground, &to.pm_state.params.accel_ground,
+                       sizeof(pm_params_t) - offsetof(pm_params_t, accel_ground)) == 0,
                 "pm_params_t (non-gravity) did not survive the round-trip");
 } END_TEST
 

--- a/src/tests/check_pmove.c
+++ b/src/tests/check_pmove.c
@@ -112,7 +112,6 @@ static pm_move_t Test_Move(pm_movement_t movement) {
   } else { // Quetoo's follows the server's cvars, which a test has none of
     pm.s.params = (pm_params_t) {
       .gravity = 800,
-      .gravity_water = PM_GRAVITY_WATER,
       .accel_ground = PM_ACCEL_GROUND,
       .accel_air = PM_ACCEL_AIR,
       .friction_ground = PM_FRICT_GROUND,


### PR DESCRIPTION
`gravity_water` was read in exactly one place, `Pm_Gravity` in the quetoo
movement, and only while a player was fully submerged, giving no input, and
still sinking slower than `PM_SPEED_WATER_SINK` - so its whole effect was how
fast an idle swimmer ramped to a 16 ups drift (about 60 ms at the default 0.33).
The `quake`, `quake2`, `quake3` and `race` movements never applied gravity in
water and each carried a `1.f` marked "unused". It was on the wire because #826
promoted every `g_water_*` cvar into `pm_params_t` wholesale.

Removed: the field, its float on the wire, `g_water_gravity`, and the kernel
table entries. The delta-compared region now anchors on `accel_ground` (40
floats); the static asserts and the round-trip test follow. `PM_GRAVITY_WATER`
stays because `g_physics.c` still sinks non-client entities by it.

No protocol bump, per the rule that main takes one bump at v1.0.85.

Verified: full autotools build, Xcode `quetoo-all`, `check_pmove` and
`check_net_message` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)