### PR TITLE
Add race records: one personal best per player per movement

### DIFF
--- a/Quetoo.vs15/game-race.vcxproj
+++ b/Quetoo.vs15/game-race.vcxproj
@@ -32,6 +32,7 @@
     <ClCompile Include="..\src\game\race\g_module.c" />
     <ClCompile Include="..\src\game\race\g_race.c" />
     <ClCompile Include="..\src\game\race\g_race_entity.c" />
+    <ClCompile Include="..\src\game\race\g_race_records.c" />
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{3c9e5fb2-6d74-4a1b-9153-8e4f7cab9d23}</ProjectGuid>

--- a/Quetoo.vs15/game-race.vcxproj.filters
+++ b/Quetoo.vs15/game-race.vcxproj.filters
@@ -251,5 +251,8 @@
     <ClCompile Include="..\src\game\race\g_race_entity.c">
       <Filter>src\race</Filter>
     </ClCompile>
+    <ClCompile Include="..\src\game\race\g_race_records.c">
+      <Filter>src\race</Filter>
+    </ClCompile>
   </ItemGroup>
 </Project>

--- a/Quetoo.xcodeproj/project.pbxproj
+++ b/Quetoo.xcodeproj/project.pbxproj
@@ -258,6 +258,7 @@
 		D2A5C1000000000000000029 /* g_module.c in Sources */ = {isa = PBXBuildFile; fileRef = D2A5C1000000000000000003 /* g_module.c */; };
 		D8A5C100000000000000000B /* g_race.c in Sources */ = {isa = PBXBuildFile; fileRef = D8A5C10000000000000000A1 /* g_race.c */; };
 		D8A5C100000000000000000C /* g_race_entity.c in Sources */ = {isa = PBXBuildFile; fileRef = D8A5C10000000000000000A2 /* g_race_entity.c */; };
+		D8A5C100000000000000000D /* g_race_records.c in Sources */ = {isa = PBXBuildFile; fileRef = D8A5C10000000000000000A4 /* g_race_records.c */; };
 		CE05B2F0302248070012F003 /* bg_item.h in Headers */ = {isa = PBXBuildFile; fileRef = CE05B23D302248070012862B /* bg_item.h */; };
 		D2A5C1000000000000000033 /* bg_item.h in Headers */ = {isa = PBXBuildFile; fileRef = D2A5C1000000000000000001 /* bg_item.h */; };
 		CE05B2F0302248070012F004 /* g_types.h in Headers */ = {isa = PBXBuildFile; fileRef = CE05B27C302248070012862B /* g_types.h */; };
@@ -1782,6 +1783,7 @@
 		D8A5C10000000000000000A1 /* g_race.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = g_race.c; sourceTree = "<group>"; };
 		D8A5C10000000000000000A2 /* g_race_entity.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = g_race_entity.c; sourceTree = "<group>"; };
 		D8A5C10000000000000000A3 /* g_race.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = g_race.h; sourceTree = "<group>"; };
+		D8A5C10000000000000000A4 /* g_race_records.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = g_race_records.c; sourceTree = "<group>"; };
 		CE05B27C302248070012862B /* g_types.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = g_types.h; sourceTree = "<group>"; };
 		D2A5C1000000000000000004 /* g_types.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = g_types.h; sourceTree = "<group>"; };
 		CE05B283302248070012862B /* Makefile.am */ = {isa = PBXFileReference; lastKnownFileType = text; path = Makefile.am; sourceTree = "<group>"; };
@@ -3066,6 +3068,7 @@
 				D2A5C1000000000000000003 /* g_module.c */,
 				D8A5C10000000000000000A1 /* g_race.c */,
 				D8A5C10000000000000000A2 /* g_race_entity.c */,
+				D8A5C10000000000000000A4 /* g_race_records.c */,
 				D8A5C10000000000000000A3 /* g_race.h */,
 				D2A5C1000000000000000004 /* g_types.h */,
 				D2A5C1000000000000000005 /* Makefile.am */,
@@ -5922,6 +5925,7 @@
 				D2A5C1000000000000000029 /* g_module.c in Sources */,
 				D8A5C100000000000000000B /* g_race.c in Sources */,
 				D8A5C100000000000000000C /* g_race_entity.c in Sources */,
+				D8A5C100000000000000000D /* g_race_records.c in Sources */,
 				D2A5C100000000000000002A /* g_physics.c in Sources */,
 				D2A5C100000000000000002B /* g_rules.c in Sources */,
 				D2A5C100000000000000002C /* g_vote.c in Sources */,

--- a/Quetoo.xcodeproj/xcshareddata/xcschemes/quetoo-all.xcscheme
+++ b/Quetoo.xcodeproj/xcshareddata/xcschemes/quetoo-all.xcscheme
@@ -149,15 +149,15 @@
             isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
-            argument = "+game test"
-            isEnabled = "NO">
+            argument = "+game race"
+            isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument
             argument = "+map claustrophobopolis"
             isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
-            argument = "+map edge"
+            argument = "+map cc_neox"
             isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument

--- a/src/game/game.h
+++ b/src/game/game.h
@@ -25,7 +25,7 @@
 #include "collision/cm_types.h"
 #include <Objectively/Vector.h>
 
-#define GAME_API_VERSION 34
+#define GAME_API_VERSION 35
 
 /**
  * @brief Server flags for `g_entity_t`.
@@ -553,6 +553,18 @@ typedef struct g_import_s {
    * contents merged into `worldspawn` during the compilation step are fully supported.
    */
   Vector *(*EntityBrushes)(const cm_entity_t *entity);
+
+  /**
+   * @brief Parses a string of brace-delimited key-value entity definitions, the
+   * format of a map's entity string and of `maps.lst`.
+   * @return A list of `cm_entity_t *`, each to be freed with `FreeEntity`.
+   */
+  List *(*LoadEntities)(const char *entity_string);
+
+  /**
+   * @brief Frees an entity definition from `LoadEntities`.
+   */
+  void (*FreeEntity)(cm_entity_t *entity);
 
   /**
    * @return The contents mask at the specific point. The point is tested

--- a/src/game/race/Makefile.am
+++ b/src/game/race/Makefile.am
@@ -56,6 +56,7 @@ game_la_SOURCES = \
 	g_physics.c \
 	g_race.c \
 	g_race_entity.c \
+	g_race_records.c \
 	g_rules.c \
 	g_sound.c \
 	g_util.c \

--- a/src/game/race/g_race.c
+++ b/src/game/race/g_race.c
@@ -213,6 +213,7 @@ bool G_Race_Start(g_client_t *cl) {
 
   run->state = RACE_RUN_ACTIVE;
   run->mode = G_Race_Mode(cl);
+  run->movement = cl->ps.pm_state.params.movement;
   run->stage = 1;
   run->start_time = g_level.time;
   run->start_speed = run->top_speed = speed;
@@ -354,6 +355,10 @@ bool G_Race_Finish(g_client_t *cl) {
     run->invalid |= RACE_INVALID_NOCLIP;
   }
 
+  if (cl->ps.pm_state.params.movement != run->movement) {
+    run->invalid |= RACE_INVALID_MOVEMENT;
+  }
+
   run->state = RACE_RUN_FINISHED;
   run->elapsed = g_level.time - run->start_time;
   run->end_speed = Vec3_Length(cl->entity->velocity);
@@ -365,6 +370,7 @@ bool G_Race_Finish(g_client_t *cl) {
   // it counts only if it was raced from start to finish with nothing to disqualify it
   if (run->mode == RACE_MODE_RACE && G_Race_Mode(cl) == RACE_MODE_RACE && !run->invalid) {
     gi.BroadcastPrint(PRINT_HIGH, "%s finished in %s\n", cl->persistent.net_name, time);
+    G_Race_SubmitRecord(cl);
   } else if (run->mode == RACE_MODE_PRACTICE) {
     gi.ClientPrint(cl, PRINT_HIGH, "Finished in %s, practicing\n", time);
   } else {
@@ -519,6 +525,13 @@ static void G_Race_Status_f(g_client_t *cl) {
                  course->finish_count, course->finish_count == 1 ? "" : "es",
                  course->valid ? "" : " ^1(invalid)^7");
 
+  const g_race_record_t *record = G_Race_Record(cl->persistent.guid, g_level.movement);
+  if (record) {
+    size_t count;
+    const size_t rank = G_Race_Rank(record, &count);
+    gi.ClientPrint(cl, PRINT_HIGH, "Best: %s, #%zu of %zu\n", G_Race_FormatTime(record->time), rank, count);
+  }
+
   switch (run->state) {
     case RACE_RUN_ACTIVE:
       gi.ClientPrint(cl, PRINT_HIGH, "Running: %s, checkpoint %u of %u%s\n",
@@ -543,6 +556,7 @@ static void G_ConfigureLevel_Race(void) {
 
   G_Race_ValidateCourse();
   G_Race_ResolveStages();
+  G_Race_LoadRecords();
 
   const g_race_course_t *course = &g_level.race_course;
 

--- a/src/game/race/g_race.h
+++ b/src/game/race/g_race.h
@@ -83,6 +83,29 @@ bool G_Race_Debounced(g_client_t *cl, const g_entity_t *ent, float wait);
 bool G_Race_SpawnEntity(g_entity_t *ent);
 
 /**
+ * @brief The records for this map, read from `records/<map>.rec` when the
+ * level is configured and published as `CS_RACE_RECORDS`.
+ */
+void G_Race_LoadRecords(void);
+
+/**
+ * @brief Files the finished run on `cl` as a personal best if it is one, and
+ * says so; a course record is said to everyone.
+ */
+void G_Race_SubmitRecord(g_client_t *cl);
+
+/**
+ * @brief The record `guid` holds under `movement`, or NULL.
+ */
+const g_race_record_t *G_Race_Record(const char *guid, pm_movement_t movement);
+
+/**
+ * @brief Where `record` stands among the records under its movement, from 1,
+ * and how many there are.
+ */
+size_t G_Race_Rank(const g_race_record_t *record, size_t *count);
+
+/**
  * @brief Finds each stage's `restart_target` once every entity has spawned,
  * and spoils the stages if any is missing. Called from `ConfigureLevel`.
  */

--- a/src/game/race/g_race_records.c
+++ b/src/game/race/g_race_records.c
@@ -1,0 +1,401 @@
+/*
+ * Copyright(c) 1997-2001 id Software, Inc.
+ * Copyright(c) 2002 The Quakeforge Project.
+ * Copyright(c) 2006 Quetoo.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+#include <time.h>
+
+#include <Objectively/List.h>
+
+#include "g_race.h"
+
+/**
+ * @file
+ * @brief The records: one personal best per client per movement, in a text
+ * file per map that reads like `maps.lst`:
+ *
+ *     {
+ *       "guid" "..."
+ *       "name" "..."
+ *       "movement" "race"
+ *       "time" "83412"
+ *       ...
+ *     }
+ *
+ * The file is read whole when the level is configured and rewritten whole when
+ * a best is beaten; it is never sent anywhere, so it is written to be read by a
+ * person. A block that cannot be a record is warned about and skipped, as a
+ * `maps.lst` entry without a name is.
+ */
+
+// how many of the best are published for the scoreboard
+#define RACE_RECORDS_SHOWN 15
+
+static const char *G_Race_RecordsPath(void) {
+  return va("records/%s.rec", g_level.name);
+}
+
+/**
+ * @brief Formats a time as the file and the messages show it.
+ */
+static const char *G_Race_RecordTime(uint32_t ms) {
+  return va("%u:%02u.%03u", ms / 60000, ms / 1000 % 60, ms % 1000);
+}
+
+/**
+ * @brief FNV-1a over the parameters a run was made under: not a key, just a way
+ * to tell two records under the same movement apart if its cvars were changed.
+ */
+static uint32_t G_Race_HashParams(const pm_params_t *params) {
+
+  const uint8_t *bytes = (const uint8_t *) params;
+  uint32_t hash = 2166136261u;
+
+  for (size_t i = 0; i < sizeof(*params); i++) {
+    hash = (hash ^ bytes[i]) * 16777619u;
+  }
+
+  return hash;
+}
+
+/**
+ * @brief Reads `key_N` for N from `first` up, as long as they are there: a
+ * value is at most `MAX_BSP_ENTITY_VALUE` long, so a list is one key per time.
+ */
+static uint16_t G_Race_ParseTimes(const cm_entity_t *def, const char *key, int32_t first, uint32_t *times) {
+  uint16_t count = 0;
+
+  for (int32_t n = first; n <= RACE_MAX_CHECKPOINTS; n++) {
+    const cm_entity_t *time = gi.EntityValue(def, va("%s_%d", key, n));
+
+    if (!(time->parsed & ENTITY_INTEGER)) {
+      break;
+    }
+
+    times[count++] = time->integer;
+  }
+
+  return count;
+}
+
+static int32_t G_Race_CompareRecords(const void *a, const void *b) {
+  const g_race_record_t *ra = a, *rb = b;
+
+  if (ra->movement != rb->movement) {
+    return (int32_t) ra->movement - (int32_t) rb->movement;
+  }
+
+  return ra->time < rb->time ? -1 : ra->time > rb->time ? 1 : 0;
+}
+
+static void G_Race_SortRecords(void) {
+  qsort(g_level.race_records, g_level.race_record_count, sizeof(g_race_record_t), G_Race_CompareRecords);
+}
+
+/**
+ * @brief Room for one more record, in level memory so that the level's end
+ * frees it along with everything else.
+ */
+static g_race_record_t *G_Race_AddRecord(void) {
+
+  if (g_level.race_record_count == g_level.race_record_capacity) {
+    const size_t capacity = g_level.race_record_capacity ? g_level.race_record_capacity * 2 : 32;
+    g_race_record_t *records = gi.Malloc(capacity * sizeof(g_race_record_t), MEM_TAG_GAME_LEVEL);
+
+    if (g_level.race_record_count) {
+      memcpy(records, g_level.race_records, g_level.race_record_count * sizeof(g_race_record_t));
+    }
+
+    g_level.race_records = records;
+    g_level.race_record_capacity = capacity;
+  }
+
+  g_race_record_t *record = &g_level.race_records[g_level.race_record_count++];
+  memset(record, 0, sizeof(*record));
+  return record;
+}
+
+static g_race_record_t *G_Race_FindRecord(const char *guid, pm_movement_t movement) {
+
+  for (size_t i = 0; i < g_level.race_record_count; i++) {
+    g_race_record_t *record = &g_level.race_records[i];
+
+    if (record->movement == movement && !q_strcmp(record->guid, guid)) {
+      return record;
+    }
+  }
+
+  return NULL;
+}
+
+const g_race_record_t *G_Race_Record(const char *guid, pm_movement_t movement) {
+  return G_Race_FindRecord(guid, movement);
+}
+
+size_t G_Race_Rank(const g_race_record_t *record, size_t *count) {
+  size_t rank = 0;
+
+  *count = 0;
+  for (size_t i = 0; i < g_level.race_record_count; i++) {
+    const g_race_record_t *r = &g_level.race_records[i];
+
+    if (r->movement != record->movement) {
+      continue;
+    }
+
+    (*count)++;
+    if (r == record) {
+      rank = *count;
+    }
+  }
+
+  return rank;
+}
+
+/**
+ * @brief The best under the level's movement, as `name\time` pairs, as many as
+ * are shown and fit.
+ */
+static void G_Race_PublishRecords(void) {
+  char string[MAX_STRING_CHARS] = "";
+  size_t shown = 0;
+
+  for (size_t i = 0; i < g_level.race_record_count && shown < RACE_RECORDS_SHOWN; i++) {
+    const g_race_record_t *record = &g_level.race_records[i];
+
+    if (record->movement != g_level.movement) {
+      continue;
+    }
+
+    const char *pair = va("%s%s\\%u", shown ? "\\" : "", record->name, record->time);
+
+    if (q_strlen(string) + q_strlen(pair) >= sizeof(string)) {
+      break;
+    }
+
+    q_strlcat(string, pair, sizeof(string));
+    shown++;
+  }
+
+  gi.SetConfigString(CS_RACE_RECORDS, string);
+}
+
+/**
+ * @brief Reads one block, or says why it is not a record.
+ */
+static bool G_Race_ParseRecord(const cm_entity_t *def, int32_t index) {
+
+  const char *guid = gi.EntityValue(def, "guid")->nullable_string;
+  const char *movement_name = gi.EntityValue(def, "movement")->nullable_string;
+  const cm_entity_t *time = gi.EntityValue(def, "time");
+
+  pm_movement_t movement;
+
+  if (!guid || !*guid) {
+    G_Warn("Record %d in %s has no guid\n", index, G_Race_RecordsPath());
+    return false;
+  }
+
+  if (!movement_name || !Pm_MovementByName(movement_name, &movement)) {
+    G_Warn("Record %d in %s has no movement, or one nothing answers to\n", index, G_Race_RecordsPath());
+    return false;
+  }
+
+  if (!(time->parsed & ENTITY_INTEGER) || time->integer <= 0) {
+    G_Warn("Record %d in %s has no time\n", index, G_Race_RecordsPath());
+    return false;
+  }
+
+  if (G_Race_FindRecord(guid, movement)) {
+    G_Warn("Record %d in %s repeats %s under %s\n", index, G_Race_RecordsPath(), guid, movement_name);
+    return false;
+  }
+
+  g_race_record_t *record = G_Race_AddRecord();
+
+  q_strlcpy(record->guid, guid, sizeof(record->guid));
+  q_strlcpy(record->name, gi.EntityValue(def, "name")->string, sizeof(record->name));
+  q_strlcpy(record->ip, gi.EntityValue(def, "ip")->string, sizeof(record->ip));
+  q_strlcpy(record->date, gi.EntityValue(def, "date")->string, sizeof(record->date));
+
+  record->movement = movement;
+  record->params = (uint32_t) strtoul(gi.EntityValue(def, "params")->string, NULL, 16);
+  record->time = time->integer;
+
+  record->checkpoint_count = G_Race_ParseTimes(def, "checkpoint", 1, record->checkpoint_times);
+  record->split_count = G_Race_ParseTimes(def, "split", 1, record->split_times);
+  record->stage_count = G_Race_ParseTimes(def, "stage", 2, record->stage_times);
+
+  sscanf(gi.EntityValue(def, "speed")->string, "%f %f %f",
+         &record->start_speed, &record->top_speed, &record->average_speed);
+
+  return true;
+}
+
+void G_Race_LoadRecords(void) {
+
+  // the level's end freed the last map's, and this may be the same map again
+  g_level.race_records = NULL;
+  g_level.race_record_count = g_level.race_record_capacity = 0;
+
+  void *buffer;
+  if (gi.LoadFile(G_Race_RecordsPath(), &buffer) <= 0) { // missing, or empty and so not even a buffer
+    G_Debug("No records at %s\n", G_Race_RecordsPath());
+    G_Race_PublishRecords();
+    return;
+  }
+
+  List *defs = gi.LoadEntities(buffer);
+
+  int32_t index = 0;
+  for (const ListNode *node = defs->head; node; node = node->next, index++) {
+    cm_entity_t *def = node->element;
+    G_Race_ParseRecord(def, index);
+    gi.FreeEntity(def);
+  }
+
+  release(defs);
+  gi.FreeFile(buffer);
+
+  G_Race_SortRecords();
+  G_Race_PublishRecords();
+
+  G_Debug("Loaded %zu records from %s\n", g_level.race_record_count, G_Race_RecordsPath());
+}
+
+static void G_Race_WriteLine(file_t *file, const char *fmt, ...) __attribute__((format(printf, 2, 3)));
+
+static void G_Race_WriteLine(file_t *file, const char *fmt, ...) {
+  char line[MAX_STRING_CHARS];
+
+  va_list args;
+  va_start(args, fmt);
+  const int32_t len = vsnprintf(line, sizeof(line), fmt, args);
+  va_end(args);
+
+  gi.WriteFile(file, line, 1, Mini(len, (int32_t) sizeof(line) - 1));
+}
+
+static void G_Race_WriteTimes(file_t *file, const char *key, int32_t first, const uint32_t *times, uint16_t count) {
+
+  for (uint16_t i = 0; i < count; i++) {
+    G_Race_WriteLine(file, "  \"%s_%d\" \"%u\"\n", key, first + i, times[i]);
+  }
+}
+
+static void G_Race_SaveRecords(void) {
+
+  file_t *file = gi.OpenFileWrite(G_Race_RecordsPath());
+  if (!file) {
+    G_Warn("Failed to open %s for writing\n", G_Race_RecordsPath());
+    return;
+  }
+
+  G_Race_WriteLine(file, "// Race records for %s: one personal best per player per movement\n", g_level.name);
+
+  for (size_t i = 0; i < g_level.race_record_count; i++) {
+    const g_race_record_t *r = &g_level.race_records[i];
+
+    G_Race_WriteLine(file, "{\n");
+    G_Race_WriteLine(file, "  \"guid\" \"%s\"\n", r->guid);
+    G_Race_WriteLine(file, "  \"name\" \"%s\"\n", r->name);
+    G_Race_WriteLine(file, "  \"ip\" \"%s\"\n", r->ip);
+    G_Race_WriteLine(file, "  \"date\" \"%s\"\n", r->date);
+    G_Race_WriteLine(file, "  \"movement\" \"%s\"\n", Pm_Movement(r->movement)->name);
+    G_Race_WriteLine(file, "  \"params\" \"%08x\"\n", r->params);
+    G_Race_WriteLine(file, "  \"time\" \"%u\"\n", r->time);
+    G_Race_WriteTimes(file, "checkpoint", 1, r->checkpoint_times, r->checkpoint_count);
+    G_Race_WriteTimes(file, "split", 1, r->split_times, r->split_count);
+    G_Race_WriteTimes(file, "stage", 2, r->stage_times, r->stage_count);
+    G_Race_WriteLine(file, "  \"speed\" \"%.0f %.0f %.0f\"\n", r->start_speed, r->top_speed, r->average_speed);
+    G_Race_WriteLine(file, "}\n");
+  }
+
+  gi.CloseFile(file);
+}
+
+void G_Race_SubmitRecord(g_client_t *cl) {
+  const g_race_run_t *run = &cl->race_run;
+
+  const g_race_record_t *best = NULL;
+  for (size_t i = 0; i < g_level.race_record_count; i++) {
+    if (g_level.race_records[i].movement == run->movement) {
+      best = &g_level.race_records[i];
+      break;
+    }
+  }
+
+  g_race_record_t *record = G_Race_FindRecord(cl->persistent.guid, run->movement);
+
+  if (record && record->time <= run->elapsed) {
+    gi.ClientPrint(cl, PRINT_HIGH, "Your best is %s (+%s)\n", G_Race_RecordTime(record->time),
+                   G_Race_RecordTime(run->elapsed - record->time));
+    return;
+  }
+
+  const uint32_t previous = record ? record->time : 0;
+  const uint32_t best_time = best ? best->time : 0;
+
+  if (!record) {
+    record = G_Race_AddRecord();
+  }
+
+  q_strlcpy(record->guid, cl->persistent.guid, sizeof(record->guid));
+  q_strlcpy(record->name, cl->persistent.net_name, sizeof(record->name));
+  q_strlcpy(record->ip, InfoString_Get(cl->persistent.user_info, "ip"), sizeof(record->ip));
+
+  const time_t now = time(NULL);
+  strftime(record->date, sizeof(record->date), "%Y-%m-%dT%H:%M:%SZ", gmtime(&now));
+
+  record->movement = run->movement;
+  record->params = G_Race_HashParams(&cl->ps.pm_state.params);
+  record->time = run->elapsed;
+
+  record->checkpoint_count = run->checkpoint_count;
+  memcpy(record->checkpoint_times, run->checkpoint_times, sizeof(record->checkpoint_times));
+  record->split_count = run->split_count;
+  memcpy(record->split_times, run->split_times, sizeof(record->split_times));
+  record->stage_count = run->stage > 1 ? run->stage - 1 : 0;
+  memcpy(record->stage_times, run->stage_times, sizeof(record->stage_times));
+
+  record->start_speed = run->start_speed;
+  record->top_speed = run->top_speed;
+  record->average_speed = run->speed_samples ? run->speed_sum / run->speed_samples : 0.f;
+
+  G_Race_SortRecords();
+  G_Race_SaveRecords();
+  G_Race_PublishRecords();
+
+  if (!best_time || run->elapsed < best_time) {
+    if (best_time) {
+      gi.BroadcastPrint(PRINT_HIGH, "^3%s set the course record, %s faster^7\n",
+                        cl->persistent.net_name, G_Race_RecordTime(best_time - run->elapsed));
+    } else {
+      gi.BroadcastPrint(PRINT_HIGH, "^3%s set the first course record^7\n", cl->persistent.net_name);
+    }
+  } else if (previous) {
+    gi.ClientPrint(cl, PRINT_HIGH, "^2Personal best^7, %s faster\n", G_Race_RecordTime(previous - run->elapsed));
+  } else {
+    gi.ClientPrint(cl, PRINT_HIGH, "^2Personal best^7\n");
+  }
+
+  size_t count;
+  const size_t rank = G_Race_Rank(G_Race_FindRecord(cl->persistent.guid, run->movement), &count);
+  gi.ClientPrint(cl, PRINT_HIGH, "You are #%zu of %zu\n", rank, count);
+}

--- a/src/game/race/g_race_records.c
+++ b/src/game/race/g_race_records.c
@@ -62,14 +62,25 @@ static const char *G_Race_RecordTime(uint32_t ms) {
  * @brief FNV-1a over the parameters a run was made under: not a key, just a way
  * to tell two records under the same movement apart if its cvars were changed.
  */
-static uint32_t G_Race_HashParams(const pm_params_t *params) {
+static uint32_t G_Race_HashBytes(uint32_t hash, const void *data, size_t length) {
 
-  const uint8_t *bytes = (const uint8_t *) params;
-  uint32_t hash = 2166136261u;
+  const uint8_t *bytes = data;
 
-  for (size_t i = 0; i < sizeof(*params); i++) {
+  for (size_t i = 0; i < length; i++) {
     hash = (hash ^ bytes[i]) * 16777619u;
   }
+
+  return hash;
+}
+
+static uint32_t G_Race_HashParams(const pm_params_t *params) {
+
+  uint32_t hash = 2166136261u;
+
+  // the fields, not the struct: there is padding after movement
+  hash = G_Race_HashBytes(hash, &params->gravity, sizeof(params->gravity));
+  hash = G_Race_HashBytes(hash, &params->movement, sizeof(params->movement));
+  hash = G_Race_HashBytes(hash, &params->accel_ground, sizeof(*params) - offsetof(pm_params_t, accel_ground));
 
   return hash;
 }
@@ -118,8 +129,9 @@ static g_race_record_t *G_Race_AddRecord(void) {
     const size_t capacity = g_level.race_record_capacity ? g_level.race_record_capacity * 2 : 32;
     g_race_record_t *records = gi.Malloc(capacity * sizeof(g_race_record_t), MEM_TAG_GAME_LEVEL);
 
-    if (g_level.race_record_count) {
+    if (g_level.race_records) {
       memcpy(records, g_level.race_records, g_level.race_record_count * sizeof(g_race_record_t));
+      gi.Free(g_level.race_records);
     }
 
     g_level.race_records = records;

--- a/src/game/race/g_types.h
+++ b/src/game/race/g_types.h
@@ -83,6 +83,7 @@ typedef enum {
 #define CS_HOOK_PULL_SPEED (CS_GAME + 8)  // hook speed
 #define CS_VOTE            (CS_GAME + 9)  // the vote in progress (bg_vote.h)
 #define CS_RACE_COURSE     (CS_GAME + 10) // checkpoints\finishes\valid, for the HUD
+#define CS_RACE_RECORDS    (CS_GAME + 11) // the top times under this movement, name\time pairs
 
 /**
  * @brief Player state statistics (inventory, score, etc).
@@ -153,7 +154,8 @@ typedef enum {
  * @brief Why a finished run in race mode cannot count.
  */
 typedef enum {
-  RACE_INVALID_NOCLIP = 1 << 0
+  RACE_INVALID_NOCLIP = 1 << 0,
+  RACE_INVALID_MOVEMENT = 1 << 1 // the movement changed under the run
 } g_race_invalid_t;
 
 /**
@@ -213,6 +215,7 @@ typedef struct {
 typedef struct {
   g_race_run_state_t state;
   g_race_mode_t mode; // the mode the run was started in, which is what decides whether it counts
+  pm_movement_t movement; // the movement it was started under, which is what a record is comparable within
   uint16_t checkpoint_count;
   uint16_t split_count;
   uint16_t stage; // the one under way, from 1
@@ -226,6 +229,27 @@ typedef struct {
   uint32_t speed_samples;
   uint8_t invalid; // g_race_invalid_t
 } g_race_run_t;
+
+/**
+ * @brief A personal best on this map: one per client per movement, kept in
+ * `records/<map>.rec` as brace-delimited key-value blocks, the format of
+ * `maps.lst`. Keyed by the client's GUID and shown by name, so that a rename
+ * keeps the record.
+ */
+typedef struct {
+  char guid[MAX_QPATH];
+  char name[MAX_QPATH];
+  char ip[64];
+  char date[32]; // ISO 8601, UTC
+  pm_movement_t movement;
+  uint32_t params; // a hash of the pm_params_t the run was made under, for information
+  uint32_t time;
+  uint16_t checkpoint_count, split_count, stage_count;
+  uint32_t checkpoint_times[RACE_MAX_CHECKPOINTS];
+  uint32_t split_times[RACE_MAX_CHECKPOINTS];
+  uint32_t stage_times[RACE_MAX_CHECKPOINTS];
+  float start_speed, top_speed, average_speed;
+} g_race_record_t;
 
 /**
  * @brief A position a practicing client asked to return to, in the spawn
@@ -996,6 +1020,13 @@ typedef struct {
    * @brief The course the triggers describe, validated in `G_ConfigureLevel`.
    */
   g_race_course_t race_course;
+
+  /**
+   * @brief Every personal best on record for this map, all movements, sorted
+   * by movement and then time. Level memory, so the change of level frees it.
+   */
+  g_race_record_t *race_records;
+  size_t race_record_count, race_record_capacity;
 
   } g_level_t;
 

--- a/src/server/sv_game.c
+++ b/src/server/sv_game.c
@@ -367,6 +367,8 @@ void Sv_InitGame(void) {
   import.Worldspawn = Cm_Worldspawn;
   import.EntityValue = Cm_EntityValue;
   import.EntityBrushes = Cm_EntityBrushes;
+  import.LoadEntities = Cm_LoadEntities;
+  import.FreeEntity = Cm_FreeEntity;
   import.PointContents = Sv_PointContents;
   import.BoxContents = Sv_BoxContents;
   import.PointInsideBrush = Cm_PointInsideBrush;


### PR DESCRIPTION
Step 5 of the race module (#963), per D17.

**What a record is.** A client's best time on a map under a movement, keyed by
GUID and shown by name so a rename keeps it. Practice never records. A run whose
movement changed under it (`g_movement` flipped mid-run) is marked
`RACE_INVALID_MOVEMENT` and does not count. Every best is kept; nothing is
capped but the published top 15.

**The file.** `records/<map>.rec` in the write dir: brace-delimited key/value
blocks, the `maps.lst` format, read with the new `gi.LoadEntities` and written
via `gi.OpenFileWrite`. Text on purpose - it never crosses the wire, so it is
written for a person to read, grep and hand-edit. A block that cannot be a
record (no guid, no movement, no time, or a GUID repeated under one movement)
is warned about and skipped, as `sv_map_list.c` does; an empty file is no
records. Entity values cap at 128 characters, so times are one key each
(`checkpoint_1`, `split_1`, `stage_2`).

Each entry: guid, name, ip, date (ISO 8601 UTC), movement, params hash (FNV-1a
of `pm_params_t`, for information), time, checkpoint/split/stage times, start/
top/average speed.

**Runtime.** Loaded in `ConfigureLevel`, sorted by movement then time, top 15
under the level's movement published on `CS_RACE_RECORDS` as `name\time` pairs.
On a counting finish: new course record broadcast with the margin, personal
best to its owner with the margin, then rank. `race` status shows the caller's
best and rank.

**Engine.** `g_import_t` gains `LoadEntities` and `FreeEntity` (both existing
`Cm_*` functions); `GAME_API_VERSION` 35.

Verified: autotools, Xcode `quetoo-all`, `verify_projects.py` agree; headless
`quetoo-dedicated +game race +map racetest` against a hand-written `.rec` loads
the good blocks, warns on a block without a movement and on a duplicate GUID,
and loads an empty file without incident. Writing a record needs a finished run,
which a headless server cannot produce; the writer mirrors the reader's keys
and was reviewed rather than exercised.

Refs #963.

🤖 Generated with [Claude Code](https://claude.com/claude-code)