### PR TITLE
Keep the client's ip in user_info across updates

### DIFF
--- a/src/server/sv_main.c
+++ b/src/server/sv_main.c
@@ -721,6 +721,10 @@ void Sv_UserInfoChanged(sv_client_t *cl) {
     return;
   }
 
+  // force the ip so the game can filter on it, as the connect did: a client's
+  // update replaces the whole string, and the client never sends one
+  InfoString_Set(cl->user_info, "ip", Sv_NetaddrToString(cl));
+
   // call game code to allow overrides
   svs.game->ClientUserInfoChanged(cl->gclient, cl->user_info);
 

--- a/src/server/sv_main.c
+++ b/src/server/sv_main.c
@@ -723,7 +723,11 @@ void Sv_UserInfoChanged(sv_client_t *cl) {
 
   // force the ip so the game can filter on it, as the connect did: a client's
   // update replaces the whole string, and the client never sends one
-  InfoString_Set(cl->user_info, "ip", Sv_NetaddrToString(cl));
+  if (!InfoString_Set(cl->user_info, "ip", Sv_NetaddrToString(cl))) {
+    Com_Print("No room for ip in user_info from %s\n", Sv_NetaddrToString(cl));
+    Sv_KickClient(cl, "Bad user info");
+    return;
+  }
 
   // call game code to allow overrides
   svs.game->ClientUserInfoChanged(cl->gclient, cl->user_info);


### PR DESCRIPTION
`Sv_ConnectionlessPacket` stuffs `ip` into the user_info at connect "so the game
can filter on it", but `CL_CMD_USER_INFO` (`sv_client.c:314`) replaces the whole
string with what the client sent, which never carries one. The game therefore
saw the ip only until the client's first update, which follows the connect
almost at once. Found when the first race record (#998) came out with `"ip" ""`.

Fix: `Sv_UserInfoChanged` stuffs it again on every update, after validation.
`InfoString_Set` overwrites, so a client-supplied `ip` is moot here as well.

🤖 Generated with [Claude Code](https://claude.com/claude-code)