### PR TITLE
Let each game module choose the movement a level falls back to

### DIFF
--- a/src/game/common/g_main.c
+++ b/src/game/common/g_main.c
@@ -655,7 +655,7 @@ static pm_movement_t G_CoerceMovement(void) {
  */
 pm_movement_t G_ResolveMovement(const char *name) {
 
-  g_movement_level = PM_MOVEMENT_QUETOO;
+  g_movement_level = G_MOVEMENT_DEFAULT;
 
   if (name && *name) {
     if (!Pm_MovementByName(name, &g_movement_level)) {

--- a/src/game/ctf/g_types.h
+++ b/src/game/ctf/g_types.h
@@ -38,6 +38,11 @@
 #define GAME_NAME "ctf"
 
 /**
+ * @brief The movement a level runs when it names none and `g_movement` defers.
+ */
+#define G_MOVEMENT_DEFAULT PM_MOVEMENT_QUETOO
+
+/**
  * @brief Game protocol version (protocol minor version). To be incremented
  * whenever the game protocol changes.
  */

--- a/src/game/default/g_types.h
+++ b/src/game/default/g_types.h
@@ -36,6 +36,11 @@
 #define GAME_NAME "default"
 
 /**
+ * @brief The movement a level runs when it names none and `g_movement` defers.
+ */
+#define G_MOVEMENT_DEFAULT PM_MOVEMENT_QUETOO
+
+/**
  * @brief Game protocol version (protocol minor version). To be incremented
  * whenever the game protocol changes.
  */

--- a/src/game/lithium/g_types.h
+++ b/src/game/lithium/g_types.h
@@ -38,6 +38,11 @@
 #define GAME_NAME "lithium"
 
 /**
+ * @brief The movement a level runs when it names none and `g_movement` defers.
+ */
+#define G_MOVEMENT_DEFAULT PM_MOVEMENT_QUETOO
+
+/**
  * @brief Game protocol version (protocol minor version). To be incremented
  * whenever the game protocol changes.
  */

--- a/src/game/race/g_types.h
+++ b/src/game/race/g_types.h
@@ -37,6 +37,11 @@
 #define GAME_NAME "race"
 
 /**
+ * @brief The movement a level runs when it names none and `g_movement` defers.
+ */
+#define G_MOVEMENT_DEFAULT PM_MOVEMENT_RACE
+
+/**
  * @brief Game protocol version (protocol minor version). To be incremented
  * whenever the game protocol changes.
  */


### PR DESCRIPTION
A level that names no `movement`, under `g_movement "default"`, ran Quetoo's
movement whatever the module. The race module is about its own movement, so a
race map with no say should get `race` - while a mapper's worldspawn `movement`
and an admin's `g_movement` still win exactly as before.

`G_MOVEMENT_DEFAULT` in each module's `g_types.h` (`PM_MOVEMENT_QUETOO` for
default, ctf and lithium; `PM_MOVEMENT_RACE` for race), used by
`G_ResolveMovement` in place of the hard-coded fallback. Deliberately the
fallback rather than the cvar default: a `g_movement` of `race` would override a
race map that asked for `quake3`.

Refs #963.

🤖 Generated with [Claude Code](https://claude.com/claude-code)