### PR TITLE
Show the run on the HUD, and dress the ghost as the record holder

### DIFF
--- a/Quetoo.vs15/cgame-race.vcxproj
+++ b/Quetoo.vs15/cgame-race.vcxproj
@@ -19,6 +19,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="..\src\cgame\race\cg_race.h" />
     <ClInclude Include="..\src\cgame\cgame.h" />
     <ClInclude Include="..\src\game\race\bg_item.h" />
     <ClInclude Include="..\src\game\common\bg_pmove.h" />
@@ -32,6 +33,8 @@
     <ClCompile Include="..\src\game\common\bg_pmove_race.c" />
     <ClCompile Include="..\src\game\common\bg_pmove_quake3.c" />
     <ClCompile Include="..\src\cgame\race\cg_module.c" />
+    <ClCompile Include="..\src\cgame\race\cg_race.c" />
+    <ClCompile Include="..\src\cgame\race\cg_race_hud.c" />
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{4daf60c3-7e85-4b2c-a264-9f5a8dbcae34}</ProjectGuid>

--- a/Quetoo.vs15/cgame-race.vcxproj.filters
+++ b/Quetoo.vs15/cgame-race.vcxproj.filters
@@ -60,6 +60,9 @@
     </Filter>
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="..\src\cgame\race\cg_race.h">
+      <Filter>src\race</Filter>
+    </ClInclude>
     <ClInclude Include="..\src\cgame\cgame.h">
       <Filter>src</Filter>
     </ClInclude>
@@ -294,6 +297,12 @@
       <Filter>src\common</Filter>
     </ClCompile>
     <ClCompile Include="..\src\cgame\race\cg_module.c">
+      <Filter>src\race</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\cgame\race\cg_race.c">
+      <Filter>src\race</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\cgame\race\cg_race_hud.c">
       <Filter>src\race</Filter>
     </ClCompile>
     <ClCompile Include="..\src\cgame\common\cg_client.c">

--- a/Quetoo.xcodeproj/project.pbxproj
+++ b/Quetoo.xcodeproj/project.pbxproj
@@ -1143,6 +1143,8 @@
 		D2A5C100000000000000009C /* cg_sound.c in Sources */ = {isa = PBXBuildFile; fileRef = CEBDD1B525A0C2710055860E /* cg_sound.c */; };
 		D2A5C100000000000000009D /* cg_sprite.c in Sources */ = {isa = PBXBuildFile; fileRef = CEAC32B7242124BB007E1253 /* cg_sprite.c */; };
 		D2A5C100000000000000009E /* cg_module.c in Sources */ = {isa = PBXBuildFile; fileRef = D2A5C1000000000000000056 /* cg_module.c */; };
+		D9A5C100000000000000000B /* cg_race.c in Sources */ = {isa = PBXBuildFile; fileRef = D9A5C10000000000000000A1 /* cg_race.c */; };
+		D9A5C100000000000000000C /* cg_race_hud.c in Sources */ = {isa = PBXBuildFile; fileRef = D9A5C10000000000000000A2 /* cg_race_hud.c */; };
 		D2A5C100000000000000009F /* cg_temp_entity.c in Sources */ = {isa = PBXBuildFile; fileRef = CE12D57B1C5C58C300CD0B13 /* cg_temp_entity.c */; };
 		D2A5C10000000000000000A0 /* cg_ui.c in Sources */ = {isa = PBXBuildFile; fileRef = CE6EE40F1F72919800FBC830 /* cg_ui.c */; };
 		D2A5C10000000000000000A1 /* cg_view.c in Sources */ = {isa = PBXBuildFile; fileRef = CE12D57E1C5C58C300CD0B13 /* cg_view.c */; };
@@ -2568,6 +2570,9 @@
 		D2A5C1000000000000000005 /* Makefile.am */ = {isa = PBXFileReference; lastKnownFileType = text; path = Makefile.am; sourceTree = "<group>"; };
 		D2A5C100000000000000000F /* game-race.so */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; path = "game-race.so"; sourceTree = BUILT_PRODUCTS_DIR; };
 		D2A5C1000000000000000056 /* cg_module.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = cg_module.c; sourceTree = "<group>"; };
+		D9A5C10000000000000000A1 /* cg_race.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = cg_race.c; sourceTree = "<group>"; };
+		D9A5C10000000000000000A2 /* cg_race_hud.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = cg_race_hud.c; sourceTree = "<group>"; };
+		D9A5C10000000000000000A3 /* cg_race.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = cg_race.h; sourceTree = "<group>"; };
 		D2A5C1000000000000000057 /* Makefile.am */ = {isa = PBXFileReference; lastKnownFileType = text; path = Makefile.am; sourceTree = "<group>"; };
 		D2A5C1000000000000000061 /* cgame.so */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; name = cgame.so; path = "cgame-race.so"; sourceTree = BUILT_PRODUCTS_DIR; };
 		D3A5C10000000000000000A1 /* bg_pmove_quetoo.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = bg_pmove_quetoo.c; sourceTree = "<group>"; };
@@ -4321,6 +4326,9 @@
 			isa = PBXGroup;
 			children = (
 				D2A5C1000000000000000056 /* cg_module.c */,
+				D9A5C10000000000000000A1 /* cg_race.c */,
+				D9A5C10000000000000000A2 /* cg_race_hud.c */,
+				D9A5C10000000000000000A3 /* cg_race.h */,
 				D2A5C1000000000000000057 /* Makefile.am */,
 			);
 			path = race;
@@ -6705,6 +6713,8 @@
 				D2A5C100000000000000009C /* cg_sound.c in Sources */,
 				D2A5C100000000000000009D /* cg_sprite.c in Sources */,
 				D2A5C100000000000000009E /* cg_module.c in Sources */,
+				D9A5C100000000000000000B /* cg_race.c in Sources */,
+				D9A5C100000000000000000C /* cg_race_hud.c in Sources */,
 				D2A5C100000000000000009F /* cg_temp_entity.c in Sources */,
 				D2A5C10000000000000000A0 /* cg_ui.c in Sources */,
 				D2A5C10000000000000000A1 /* cg_view.c in Sources */,

--- a/src/cgame/common/cg_client.c
+++ b/src/cgame/common/cg_client.c
@@ -662,10 +662,6 @@ static void Cg_RotateClientLegs(cl_entity_t *ent, r_entity_t *legs) {
 }
 
 /**
- * @brief Adds the numerous render entities which comprise a given client (player)
- * entity: head, torso, legs, weapon, flags, etc.
- */
-/**
  * @brief The tail of the `Cg_ClientInfo` chain: the slot the entity names.
  */
 static cg_client_info_t *Cg_ClientInfo_Common(const cl_entity_t *ent) {
@@ -674,6 +670,10 @@ static cg_client_info_t *Cg_ClientInfo_Common(const cl_entity_t *ent) {
 
 ClientInfo Cg_ClientInfo = Cg_ClientInfo_Common;
 
+/**
+ * @brief Adds the numerous render entities which comprise a given client (player)
+ * entity: head, torso, legs, weapon, flags, etc.
+ */
 void Cg_AddClientEntity(cl_entity_t *ent, r_entity_t *e) {
 
   const entity_state_t *s = &ent->current;

--- a/src/cgame/common/cg_client.c
+++ b/src/cgame/common/cg_client.c
@@ -665,10 +665,19 @@ static void Cg_RotateClientLegs(cl_entity_t *ent, r_entity_t *legs) {
  * @brief Adds the numerous render entities which comprise a given client (player)
  * entity: head, torso, legs, weapon, flags, etc.
  */
+/**
+ * @brief The tail of the `Cg_ClientInfo` chain: the slot the entity names.
+ */
+static cg_client_info_t *Cg_ClientInfo_Common(const cl_entity_t *ent) {
+  return &cg_state.clients[ent->current.client];
+}
+
+ClientInfo Cg_ClientInfo = Cg_ClientInfo_Common;
+
 void Cg_AddClientEntity(cl_entity_t *ent, r_entity_t *e) {
 
   const entity_state_t *s = &ent->current;
-  cg_client_info_t *ci = &cg_state.clients[s->client];
+  cg_client_info_t *ci = Cg_ClientInfo(ent);
 
   if (!ci->head || !ci->torso || !ci->legs) {
     if (*cgi.ConfigString(CS_CLIENTS + s->client)) {

--- a/src/cgame/common/cg_entity_effect.c
+++ b/src/cgame/common/cg_entity_effect.c
@@ -79,10 +79,8 @@ static void Cg_InactiveEffect(cl_entity_t *ent, const vec3_t org) {
 }
 
 /**
- * @brief Processes the entity's effects mask, augmenting the renderer entity.
- */
-/**
- * @brief The tail of the `Cg_EntityEffects` chain: the effects common knows.
+ * @brief The tail of the `Cg_EntityEffects` chain: processes the entity's
+ * effects mask, augmenting the renderer entity with the effects common knows.
  */
 static void Cg_EntityEffects_Common(cl_entity_t *ent, r_entity_t *e) {
 

--- a/src/cgame/common/cg_entity_effect.c
+++ b/src/cgame/common/cg_entity_effect.c
@@ -81,7 +81,10 @@ static void Cg_InactiveEffect(cl_entity_t *ent, const vec3_t org) {
 /**
  * @brief Processes the entity's effects mask, augmenting the renderer entity.
  */
-void Cg_EntityEffects(cl_entity_t *ent, r_entity_t *e) {
+/**
+ * @brief The tail of the `Cg_EntityEffects` chain: the effects common knows.
+ */
+static void Cg_EntityEffects_Common(cl_entity_t *ent, r_entity_t *e) {
 
   e->effects = ent->current.effects;
 
@@ -225,3 +228,5 @@ void Cg_EntityEffects(cl_entity_t *ent, r_entity_t *e) {
     }
   }
 }
+
+EntityEffects Cg_EntityEffects = Cg_EntityEffects_Common;

--- a/src/cgame/common/cg_entity_effect.h
+++ b/src/cgame/common/cg_entity_effect.h
@@ -24,7 +24,6 @@
 #include "cg_types.h"
 
 #if defined(__CG_LOCAL_H__)
-void Cg_EntityEffects(cl_entity_t *ent, r_entity_t *e);
 vec3_t Cg_EffectColor(float *hue, const float default_hue);
 vec3_t Cg_ClientEffectColor(const int32_t client, float *hue, const float default_hue);
 #endif

--- a/src/cgame/common/cg_module.h
+++ b/src/cgame/common/cg_module.h
@@ -314,6 +314,30 @@ typedef bool (*FilterEntity)(const cl_entity_t *ent);
 extern FilterEntity Cg_FilterEntity;
 
 /**
+ * @brief Augments the renderer entity for an entity the server sent, from its
+ * effects: rotation, bobbing, lights, the shells. The default maps the effects
+ * common knows.
+ * @details Chainable. A feature that defines an effect of its own calls previous
+ * and then reads its flag, as `EF_GAME` leaves it room to.
+ */
+typedef void (*EntityEffects)(cl_entity_t *ent, r_entity_t *e);
+
+extern EntityEffects Cg_EntityEffects;
+
+/**
+ * @brief The client info that dresses an entity wearing a player model: its
+ * models, skins and colors. The default is the info of the client slot the
+ * entity names.
+ * @details Chainable. A feature whose entity is a player that is not a client -
+ * a ghost, a dummy - answers its own info for it and defers to previous for
+ * the rest.
+ */
+struct cg_client_info_s;
+typedef struct cg_client_info_s *(*ClientInfo)(const cl_entity_t *ent);
+
+extern ClientInfo Cg_ClientInfo;
+
+/**
  * @}
  * @defgroup cg-hooks-presentation Presentation
  * @brief What the client game says about the game. Tails in cg_discord.c and

--- a/src/cgame/common/cg_types.h
+++ b/src/cgame/common/cg_types.h
@@ -58,7 +58,7 @@ typedef struct {
 /**
  * @brief The client game representation of clients (players).
  */
-typedef struct {
+typedef struct cg_client_info_s {
 
   /**
    * @brief The client info string, e.g. "newbie\qforcer/default."

--- a/src/cgame/race/Makefile.am
+++ b/src/cgame/race/Makefile.am
@@ -65,6 +65,8 @@ cgame_la_SOURCES = \
 	cg_main.c \
 	cg_media.c \
 	cg_module.c \
+	cg_race.c \
+	cg_race_hud.c \
 	cg_muzzle_flash.c \
 	cg_predict.c \
 	cg_score.c \

--- a/src/cgame/race/cg_race.c
+++ b/src/cgame/race/cg_race.c
@@ -35,7 +35,6 @@
 #define RACE_GHOST_ALPHA .5f
 
 static struct {
-  DrawHudElements DrawHudElements;
   ParseConfigString ParseConfigString;
   MediaDidLoad MediaDidLoad;
   FilterEntity FilterEntity;
@@ -59,13 +58,6 @@ static void Cg_Race_LoadGhost(void) {
 
 static bool Cg_Race_IsGhost(const cl_entity_t *ent) {
   return ent->current.effects & EF_RACE_GHOST;
-}
-
-static void Cg_DrawHudElements_Race(const player_state_t *ps, cg_hud_layout_t *layout) {
-
-  previous.DrawHudElements(ps, layout);
-
-  Cg_Race_DrawHud(ps);
 }
 
 static bool Cg_ParseConfigString_Race(int32_t index) {
@@ -125,8 +117,7 @@ void Cg_Race_Init(void) {
 
   installed = true;
 
-  previous.DrawHudElements = Cg_DrawHudElements;
-  Cg_DrawHudElements = Cg_DrawHudElements_Race;
+  Cg_DrawHudElements = Cg_Race_DrawHud;
 
   previous.ParseConfigString = Cg_ParseConfigString;
   Cg_ParseConfigString = Cg_ParseConfigString_Race;

--- a/src/cgame/race/cg_race.c
+++ b/src/cgame/race/cg_race.c
@@ -1,0 +1,145 @@
+/*
+ * Copyright(c) 1997-2001 id Software, Inc.
+ * Copyright(c) 2002 The Quakeforge Project.
+ * Copyright(c) 2006 Quetoo.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+#include "cg_race.h"
+
+/**
+ * @file
+ * @brief The hooks, and the ghost. See cg_race.h.
+ *
+ * The ghost the server sends wears the viewer's client slot, because a player
+ * model needs one; here it is dressed instead as the course record's holder,
+ * whose client info arrives on `CS_RACE_GHOST`, and drawn translucent. Another
+ * player's ghost is theirs to see and not ours.
+ */
+
+// how much of the ghost is there
+#define RACE_GHOST_ALPHA .5f
+
+static struct {
+  DrawHudElements DrawHudElements;
+  ParseConfigString ParseConfigString;
+  MediaDidLoad MediaDidLoad;
+  FilterEntity FilterEntity;
+  ClientInfo ClientInfo;
+  EntityEffects EntityEffects;
+} previous;
+
+static cg_client_info_t cg_race_ghost;
+
+uint32_t Cg_Race_Time(const player_state_t *ps) {
+  return (uint16_t) ps->stats[STAT_RACE_TIME_LOW] | ((uint32_t) (uint16_t) ps->stats[STAT_RACE_TIME_HIGH] << 16);
+}
+
+/**
+ * @brief Dresses the ghost as the record holder, or as nobody when there is no
+ * record, which `Cg_LoadClient` reads as the default.
+ */
+static void Cg_Race_LoadGhost(void) {
+  Cg_LoadClient(&cg_race_ghost, cgi.ConfigString(CS_RACE_GHOST));
+}
+
+static bool Cg_Race_IsGhost(const cl_entity_t *ent) {
+  return ent->current.effects & EF_RACE_GHOST;
+}
+
+static void Cg_DrawHudElements_Race(const player_state_t *ps, cg_hud_layout_t *layout) {
+
+  previous.DrawHudElements(ps, layout);
+
+  Cg_Race_DrawHud(ps);
+}
+
+static bool Cg_ParseConfigString_Race(int32_t index) {
+
+  if (index == CS_RACE_GHOST) {
+    Cg_Race_LoadGhost();
+    return true;
+  }
+
+  return previous.ParseConfigString(index);
+}
+
+/**
+ * @brief The client infos are media, and are reloaded with it.
+ */
+static void Cg_MediaDidLoad_Race(void) {
+
+  previous.MediaDidLoad();
+
+  Cg_Race_LoadGhost();
+}
+
+static bool Cg_FilterEntity_Race(const cl_entity_t *ent) {
+
+  if (Cg_Race_IsGhost(ent) && ent->current.client != cgi.client->frame.ps.client) {
+    return false;
+  }
+
+  return previous.FilterEntity(ent);
+}
+
+static cg_client_info_t *Cg_ClientInfo_Race(const cl_entity_t *ent) {
+
+  if (Cg_Race_IsGhost(ent)) {
+    return &cg_race_ghost;
+  }
+
+  return previous.ClientInfo(ent);
+}
+
+static void Cg_EntityEffects_Race(cl_entity_t *ent, r_entity_t *e) {
+
+  previous.EntityEffects(ent, e);
+
+  if (Cg_Race_IsGhost(ent)) {
+    e->effects |= EF_BLEND | EF_NO_SHADOW;
+    e->color = Vec4_Scale(e->color, RACE_GHOST_ALPHA);
+  }
+}
+
+void Cg_Race_Init(void) {
+  static bool installed;
+
+  if (installed) {
+    return;
+  }
+
+  installed = true;
+
+  previous.DrawHudElements = Cg_DrawHudElements;
+  Cg_DrawHudElements = Cg_DrawHudElements_Race;
+
+  previous.ParseConfigString = Cg_ParseConfigString;
+  Cg_ParseConfigString = Cg_ParseConfigString_Race;
+
+  previous.MediaDidLoad = Cg_MediaDidLoad;
+  Cg_MediaDidLoad = Cg_MediaDidLoad_Race;
+
+  previous.FilterEntity = Cg_FilterEntity;
+  Cg_FilterEntity = Cg_FilterEntity_Race;
+
+  previous.ClientInfo = Cg_ClientInfo;
+  Cg_ClientInfo = Cg_ClientInfo_Race;
+
+  previous.EntityEffects = Cg_EntityEffects;
+  Cg_EntityEffects = Cg_EntityEffects_Race;
+}

--- a/src/cgame/race/cg_race.h
+++ b/src/cgame/race/cg_race.h
@@ -41,6 +41,8 @@ void Cg_Race_Init(void);
 uint32_t Cg_Race_Time(const player_state_t *ps);
 
 /**
- * @brief Draws the run: the time, the checkpoints and the speed.
+ * @brief The whole HUD, arranged for racing: what common draws that a racer
+ * needs, and the run in place of the frags and deaths. Installed over
+ * `DrawHudElements` by `Cg_Race_Init`, not chained.
  */
-void Cg_Race_DrawHud(const player_state_t *ps);
+void Cg_Race_DrawHud(const player_state_t *ps, cg_hud_layout_t *layout);

--- a/src/cgame/race/cg_race.h
+++ b/src/cgame/race/cg_race.h
@@ -19,19 +19,28 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
  */
 
+#pragma once
 
-#include "cg_race.h"
-
-/**
- * @brief Race draws the grappling hook, a feature of the common sources that
- * `Cg_Init` installs from the define in this module's Makefile.am, and the run.
- */
-void Cg_Module_Init(void) {
-  Cg_Race_Init();
-}
+#include "cg_local.h"
 
 /**
- * @brief Nothing of its own to release; the hook feature owns what it loads.
+ * @file
+ * @brief Racing, as the client shows it: the run on the HUD, and the course
+ * record's ghost dressed as its holder. `cg_race.c` installs the hooks;
+ * `cg_race_hud.c` draws.
  */
-void Cg_Module_Shutdown(void) {
-}
+
+/**
+ * @brief Installs racing over the hooks it needs, once per module image.
+ */
+void Cg_Race_Init(void);
+
+/**
+ * @brief The run's time from the two stats it is split across.
+ */
+uint32_t Cg_Race_Time(const player_state_t *ps);
+
+/**
+ * @brief Draws the run: the time, the checkpoints and the speed.
+ */
+void Cg_Race_DrawHud(const player_state_t *ps);

--- a/src/cgame/race/cg_race_hud.c
+++ b/src/cgame/race/cg_race_hud.c
@@ -35,7 +35,8 @@
 // where the speed sits, from the middle of the view
 #define RACE_HUD_SPEED_OFFSET 48
 
-// how much of a frame's speed the readout takes on: it flickers at raw
+// how much of each frame's speed the readout takes on; shown raw, it flickers
+// with every frame at a high frame rate
 #define RACE_HUD_SPEED_LERP .2f
 
 static float cg_race_speed;

--- a/src/cgame/race/cg_race_hud.c
+++ b/src/cgame/race/cg_race_hud.c
@@ -23,17 +23,18 @@
 
 /**
  * @file
- * @brief The run on the HUD: the time across the top with the checkpoints
- * beneath it, and the speed under the crosshair. Everything here is read from
- * the player state the server already sends, or measured on the client; the
- * speed in particular is the client's own, not the server's word for it.
+ * @brief The HUD, arranged for racing. Health, ammo, armor and the powerups stay
+ * as common draws them - a rocket jump wants both - and the frags and deaths
+ * go, since nobody is scoring any; in their column are the speed and the runs
+ * so far. The run's time sits across the top with the checkpoints beneath it.
+ *
+ * Everything here is read from the player state the server already sends, or
+ * measured on the client; the speed in particular is the client's own, not
+ * the server's word for it.
  */
 
 // where the run sits, from the top of the view
 #define RACE_HUD_TOP 32
-
-// where the speed sits, from the middle of the view
-#define RACE_HUD_SPEED_OFFSET 48
 
 // how much of each frame's speed the readout takes on; shown raw, it flickers
 // with every frame at a high frame rate
@@ -87,26 +88,54 @@ static void Cg_Race_DrawRun(const player_state_t *ps) {
 }
 
 /**
- * @brief The horizontal speed, smoothed over frames, beneath the crosshair.
+ * @brief A stat row in the right-hand column, in the shape of the frags and
+ * deaths it stands in for: the label small, the value large beneath it.
  */
-static void Cg_Race_DrawSpeed(const player_state_t *ps) {
+static int32_t Cg_Race_DrawStat(int32_t y, const char *label, int32_t value) {
+  int32_t cw, ch;
+
+  cgi.BindFont("small", NULL, &ch);
+  cgi.Draw2DString(cgi.context->w - cgi.StringWidth(label), y, label, color_green);
+
+  cgi.BindFont("large", &cw, NULL);
+  cgi.Draw2DString(cgi.context->w - 3 * cw, y + ch, va("%3d", value), HUD_COLOR_STAT);
+
+  cgi.BindFont(NULL, NULL, NULL);
+
+  return y + HUD_PIC_HEIGHT + ch;
+}
+
+/**
+ * @brief The horizontal speed, smoothed over frames.
+ */
+static int32_t Cg_Race_DrawSpeed(const player_state_t *ps, int32_t y) {
 
   vec3_t velocity = ps->pm_state.velocity;
   velocity.z = 0.f;
 
   cg_race_speed += (Vec3_Length(velocity) - cg_race_speed) * RACE_HUD_SPEED_LERP;
 
-  cgi.BindFont("medium", NULL, NULL);
-  Cg_Race_DrawCentered(cgi.context->h / 2 + RACE_HUD_SPEED_OFFSET, va("%.0f", cg_race_speed), color_white);
-  cgi.BindFont(NULL, NULL, NULL);
+  return Cg_Race_DrawStat(y, "Speed", (int32_t) cg_race_speed);
 }
 
-void Cg_Race_DrawHud(const player_state_t *ps) {
+void Cg_Race_DrawHud(const player_state_t *ps, cg_hud_layout_t *layout) {
+
+  Cg_DrawVitals(ps);
+
+  layout->powerup_y = Cg_DrawPowerups(ps, layout->powerup_y);
+
+  Cg_DrawPickup(ps);
+
+  Cg_DrawSpectator(ps);
+
+  Cg_DrawChase(ps);
 
   if (ps->stats[STAT_RACE_MODE] == RACE_MODE_SPECTATOR) {
     return;
   }
 
   Cg_Race_DrawRun(ps);
-  Cg_Race_DrawSpeed(ps);
+
+  layout->stat_y = Cg_Race_DrawSpeed(ps, layout->stat_y);
+  layout->stat_y = Cg_Race_DrawStat(layout->stat_y, "Runs", ps->stats[STAT_RACE_RUNS]);
 }

--- a/src/cgame/race/cg_race_hud.c
+++ b/src/cgame/race/cg_race_hud.c
@@ -1,0 +1,111 @@
+/*
+ * Copyright(c) 1997-2001 id Software, Inc.
+ * Copyright(c) 2002 The Quakeforge Project.
+ * Copyright(c) 2006 Quetoo.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+#include "cg_race.h"
+
+/**
+ * @file
+ * @brief The run on the HUD: the time across the top with the checkpoints
+ * beneath it, and the speed under the crosshair. Everything here is read from
+ * the player state the server already sends, or measured on the client; the
+ * speed in particular is the client's own, not the server's word for it.
+ */
+
+// where the run sits, from the top of the view
+#define RACE_HUD_TOP 32
+
+// where the speed sits, from the middle of the view
+#define RACE_HUD_SPEED_OFFSET 48
+
+// how much of a frame's speed the readout takes on: it flickers at raw
+#define RACE_HUD_SPEED_LERP .2f
+
+static float cg_race_speed;
+
+static const char *Cg_Race_FormatTime(uint32_t ms) {
+  return va("%u:%02u.%03u", ms / 60000, ms / 1000 % 60, ms % 1000);
+}
+
+static void Cg_Race_DrawCentered(int32_t y, const char *string, const color_t color) {
+  cgi.Draw2DString((cgi.context->w - cgi.StringWidth(string)) / 2, y, string, color);
+}
+
+/**
+ * @brief The time, colored by what will become of it, and the checkpoints
+ * reached out of the course's.
+ */
+static void Cg_Race_DrawRun(const player_state_t *ps) {
+
+  const g_race_run_state_t state = ps->stats[STAT_RACE_RUN];
+  if (state == RACE_RUN_IDLE) {
+    return;
+  }
+
+  color_t color = color_white;
+  if (ps->stats[STAT_RACE_FLAGS]) {
+    color = color_red;
+  } else if (ps->stats[STAT_RACE_MODE] == RACE_MODE_PRACTICE) {
+    color = color_yellow;
+  } else if (state == RACE_RUN_FINISHED) {
+    color = color_green;
+  }
+
+  int32_t ch, y = RACE_HUD_TOP;
+
+  cgi.BindFont("large", NULL, &ch);
+  Cg_Race_DrawCentered(y, Cg_Race_FormatTime(Cg_Race_Time(ps)), color);
+  y += ch;
+
+  uint32_t checkpoints = 0;
+  sscanf(cgi.ConfigString(CS_RACE_COURSE), "%u", &checkpoints);
+
+  if (checkpoints) {
+    cgi.BindFont("small", NULL, &ch);
+    Cg_Race_DrawCentered(y, va("%d / %u", ps->stats[STAT_RACE_CHECKPOINTS], checkpoints), color_white);
+  }
+
+  cgi.BindFont(NULL, NULL, NULL);
+}
+
+/**
+ * @brief The horizontal speed, smoothed over frames, beneath the crosshair.
+ */
+static void Cg_Race_DrawSpeed(const player_state_t *ps) {
+
+  vec3_t velocity = ps->pm_state.velocity;
+  velocity.z = 0.f;
+
+  cg_race_speed += (Vec3_Length(velocity) - cg_race_speed) * RACE_HUD_SPEED_LERP;
+
+  cgi.BindFont("medium", NULL, NULL);
+  Cg_Race_DrawCentered(cgi.context->h / 2 + RACE_HUD_SPEED_OFFSET, va("%.0f", cg_race_speed), color_white);
+  cgi.BindFont(NULL, NULL, NULL);
+}
+
+void Cg_Race_DrawHud(const player_state_t *ps) {
+
+  if (ps->stats[STAT_RACE_MODE] == RACE_MODE_SPECTATOR) {
+    return;
+  }
+
+  Cg_Race_DrawRun(ps);
+  Cg_Race_DrawSpeed(ps);
+}

--- a/src/game/race/g_race.c
+++ b/src/game/race/g_race.c
@@ -234,6 +234,8 @@ bool G_Race_Start(g_client_t *cl) {
   run->movement = cl->ps.pm_state.params.movement;
   run->stage = 1;
   run->start_time = g_level.time;
+
+  cl->persistent.race_runs++;
   run->start_speed = run->top_speed = speed;
 
   if (cl->entity->move_type == MOVE_TYPE_NO_CLIP) {
@@ -603,6 +605,7 @@ static void G_ConfigureLevel_Race(void) {
   G_ForEachClient(cl, {
     G_Race_Reset(cl);
     cl->persistent.race_spawn.set = false;
+    cl->persistent.race_runs = 0;
   });
 }
 
@@ -806,6 +809,7 @@ static void G_WriteStats_Race(g_client_t *cl) {
   cl->ps.stats[STAT_RACE_TIME_HIGH] = (int16_t) (uint16_t) (time >> 16);
   cl->ps.stats[STAT_RACE_CHECKPOINTS] = run->checkpoint_count;
   cl->ps.stats[STAT_RACE_FLAGS] = run->invalid;
+  cl->ps.stats[STAT_RACE_RUNS] = cl->persistent.race_runs;
 }
 
 void G_Race_Init(void) {

--- a/src/game/race/g_types.h
+++ b/src/game/race/g_types.h
@@ -119,7 +119,8 @@ typedef enum {
   STAT_RACE_TIME_LOW,
   STAT_RACE_TIME_HIGH,
   STAT_RACE_CHECKPOINTS, // reached; the total is on CS_RACE_COURSE
-  STAT_RACE_FLAGS        // g_race_invalid_t
+  STAT_RACE_FLAGS,       // g_race_invalid_t
+  STAT_RACE_RUNS         // started on this map
 } g_stat_t;
 
 /**
@@ -127,7 +128,7 @@ typedef enum {
  */
 #define STAT_TOGGLE_BIT 0x4000
 
-_Static_assert(STAT_RACE_FLAGS < MAX_STATS, "the race stats must fit the stat array");
+_Static_assert(STAT_RACE_RUNS < MAX_STATS, "the race stats must fit the stat array");
 
 /**
  * @brief The most checkpoints a course may have, and likewise splits and
@@ -1458,6 +1459,11 @@ typedef struct {
    * @brief Whether the course record's ghost runs alongside this client's runs.
    */
   bool race_ghost;
+
+  /**
+   * @brief The runs started on this map, for the HUD.
+   */
+  uint16_t race_runs;
 } g_client_persistent_t;
 
 /**


### PR DESCRIPTION
Step 7, first slice (#963): the client side of the run and the ghost.

**Two seams in the common client game**, both chainable with common's behaviour
as the tail:
- `EntityEffects` - a module maps an effect of its own (`EF_GAME` bits) to what
  the renderer understands. The former `Cg_EntityEffects` is the tail.
- `ClientInfo` - a module says which `cg_client_info_t` dresses an entity wearing
  a player model; the tail is the slot the entity names. `cg_client_info_t` gains
  the struct tag `cg_client_info_s` so `cg_module.h` can forward-declare it.

**The ghost.** Dressed as the course record's holder from `CS_RACE_GHOST` (loaded
with `Cg_LoadClient`, reloaded with media) rather than as the viewer whose client
slot it borrows; `EF_BLEND | EF_NO_SHADOW` at half colour; every ghost but the
viewer's own is filtered out - another racer's ghost is theirs to see.

**The HUD.** Run time across the top, coloured by what will become of it (white;
yellow practicing; green finished; red when it cannot count), `n / N` checkpoints
beneath, and the horizontal speed under the crosshair - measured on the client
from the predicted velocity and smoothed over frames. Nothing about speed is on
the wire. Drawn over common's HUD, so health and ammo stay for the rocket jumps.

Verified: autotools, Xcode `quetoo-all`, `verify_projects.py`. A read-only review
traced hook install order, `Cg_LoadClient` reuse, the chase-cam case and the
stat reconstruction and found no defects. Seeing it needs a client; a run on
`racetest` with `ghost` on is the test.

Refs #963.

🤖 Generated with [Claude Code](https://claude.com/claude-code)