### PR TITLE
Arrange the scoreboard for racing: the course records and the racers

### DIFF
--- a/Quetoo.vs15/cgame-race.vcxproj
+++ b/Quetoo.vs15/cgame-race.vcxproj
@@ -35,6 +35,7 @@
     <ClCompile Include="..\src\cgame\race\cg_module.c" />
     <ClCompile Include="..\src\cgame\race\cg_race.c" />
     <ClCompile Include="..\src\cgame\race\cg_race_hud.c" />
+    <ClCompile Include="..\src\cgame\race\cg_race_score.c" />
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{4daf60c3-7e85-4b2c-a264-9f5a8dbcae34}</ProjectGuid>

--- a/Quetoo.vs15/cgame-race.vcxproj.filters
+++ b/Quetoo.vs15/cgame-race.vcxproj.filters
@@ -305,6 +305,9 @@
     <ClCompile Include="..\src\cgame\race\cg_race_hud.c">
       <Filter>src\race</Filter>
     </ClCompile>
+    <ClCompile Include="..\src\cgame\race\cg_race_score.c">
+      <Filter>src\race</Filter>
+    </ClCompile>
     <ClCompile Include="..\src\cgame\common\cg_client.c">
       <Filter>src\common</Filter>
     </ClCompile>

--- a/Quetoo.xcodeproj/project.pbxproj
+++ b/Quetoo.xcodeproj/project.pbxproj
@@ -1145,6 +1145,7 @@
 		D2A5C100000000000000009E /* cg_module.c in Sources */ = {isa = PBXBuildFile; fileRef = D2A5C1000000000000000056 /* cg_module.c */; };
 		D9A5C100000000000000000B /* cg_race.c in Sources */ = {isa = PBXBuildFile; fileRef = D9A5C10000000000000000A1 /* cg_race.c */; };
 		D9A5C100000000000000000C /* cg_race_hud.c in Sources */ = {isa = PBXBuildFile; fileRef = D9A5C10000000000000000A2 /* cg_race_hud.c */; };
+		D9A5C100000000000000000D /* cg_race_score.c in Sources */ = {isa = PBXBuildFile; fileRef = D9A5C10000000000000000A4 /* cg_race_score.c */; };
 		D2A5C100000000000000009F /* cg_temp_entity.c in Sources */ = {isa = PBXBuildFile; fileRef = CE12D57B1C5C58C300CD0B13 /* cg_temp_entity.c */; };
 		D2A5C10000000000000000A0 /* cg_ui.c in Sources */ = {isa = PBXBuildFile; fileRef = CE6EE40F1F72919800FBC830 /* cg_ui.c */; };
 		D2A5C10000000000000000A1 /* cg_view.c in Sources */ = {isa = PBXBuildFile; fileRef = CE12D57E1C5C58C300CD0B13 /* cg_view.c */; };
@@ -2573,6 +2574,7 @@
 		D9A5C10000000000000000A1 /* cg_race.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = cg_race.c; sourceTree = "<group>"; };
 		D9A5C10000000000000000A2 /* cg_race_hud.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = cg_race_hud.c; sourceTree = "<group>"; };
 		D9A5C10000000000000000A3 /* cg_race.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = cg_race.h; sourceTree = "<group>"; };
+		D9A5C10000000000000000A4 /* cg_race_score.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = cg_race_score.c; sourceTree = "<group>"; };
 		D2A5C1000000000000000057 /* Makefile.am */ = {isa = PBXFileReference; lastKnownFileType = text; path = Makefile.am; sourceTree = "<group>"; };
 		D2A5C1000000000000000061 /* cgame.so */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; name = cgame.so; path = "cgame-race.so"; sourceTree = BUILT_PRODUCTS_DIR; };
 		D3A5C10000000000000000A1 /* bg_pmove_quetoo.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = bg_pmove_quetoo.c; sourceTree = "<group>"; };
@@ -4328,6 +4330,7 @@
 				D2A5C1000000000000000056 /* cg_module.c */,
 				D9A5C10000000000000000A1 /* cg_race.c */,
 				D9A5C10000000000000000A2 /* cg_race_hud.c */,
+				D9A5C10000000000000000A4 /* cg_race_score.c */,
 				D9A5C10000000000000000A3 /* cg_race.h */,
 				D2A5C1000000000000000057 /* Makefile.am */,
 			);
@@ -6715,6 +6718,7 @@
 				D2A5C100000000000000009E /* cg_module.c in Sources */,
 				D9A5C100000000000000000B /* cg_race.c in Sources */,
 				D9A5C100000000000000000C /* cg_race_hud.c in Sources */,
+				D9A5C100000000000000000D /* cg_race_score.c in Sources */,
 				D2A5C100000000000000009F /* cg_temp_entity.c in Sources */,
 				D2A5C10000000000000000A0 /* cg_ui.c in Sources */,
 				D2A5C10000000000000000A1 /* cg_view.c in Sources */,

--- a/src/cgame/common/cg_score.c
+++ b/src/cgame/common/cg_score.c
@@ -90,15 +90,15 @@ void Cg_ParseScores(void) {
   }
 }
 
-/**
- * @brief Discards the scores, so that a board from the previous server is not
- * drawn on the next.
- */
 const g_score_t *Cg_Scores(size_t *count) {
   *count = cg_score_state.num_scores;
   return cg_score_state.scores;
 }
 
+/**
+ * @brief Discards the scores, so that a board from the previous server is not
+ * drawn on the next.
+ */
 void Cg_ClearScores(void) {
 
   memset(&cg_score_state, 0, sizeof(cg_score_state));

--- a/src/cgame/common/cg_score.c
+++ b/src/cgame/common/cg_score.c
@@ -94,6 +94,11 @@ void Cg_ParseScores(void) {
  * @brief Discards the scores, so that a board from the previous server is not
  * drawn on the next.
  */
+const g_score_t *Cg_Scores(size_t *count) {
+  *count = cg_score_state.num_scores;
+  return cg_score_state.scores;
+}
+
 void Cg_ClearScores(void) {
 
   memset(&cg_score_state, 0, sizeof(cg_score_state));

--- a/src/cgame/common/cg_score.h
+++ b/src/cgame/common/cg_score.h
@@ -26,4 +26,9 @@
 #if defined(__CG_LOCAL_H__)
 void Cg_ParseScores(void);
 void Cg_ClearScores(void);
+
+/**
+ * @brief The scores as last parsed, sorted, for a module drawing its own board.
+ */
+const g_score_t *Cg_Scores(size_t *count);
 #endif

--- a/src/cgame/race/Makefile.am
+++ b/src/cgame/race/Makefile.am
@@ -67,6 +67,7 @@ cgame_la_SOURCES = \
 	cg_module.c \
 	cg_race.c \
 	cg_race_hud.c \
+	cg_race_score.c \
 	cg_muzzle_flash.c \
 	cg_predict.c \
 	cg_score.c \

--- a/src/cgame/race/cg_race.c
+++ b/src/cgame/race/cg_race.c
@@ -118,6 +118,7 @@ void Cg_Race_Init(void) {
   installed = true;
 
   Cg_DrawHudElements = Cg_Race_DrawHud;
+  Cg_DrawScores = Cg_Race_DrawScores;
 
   previous.ParseConfigString = Cg_ParseConfigString;
   Cg_ParseConfigString = Cg_ParseConfigString_Race;

--- a/src/cgame/race/cg_race.h
+++ b/src/cgame/race/cg_race.h
@@ -41,6 +41,17 @@ void Cg_Race_Init(void);
 uint32_t Cg_Race_Time(const player_state_t *ps);
 
 /**
+ * @brief Formats a run time as the HUD and the board show it.
+ */
+const char *Cg_Race_FormatTime(uint32_t ms);
+
+/**
+ * @brief The scoreboard, arranged for racing. Installed over `DrawScores` by
+ * `Cg_Race_Init`, not chained.
+ */
+void Cg_Race_DrawScores(const player_state_t *ps);
+
+/**
  * @brief The whole HUD, arranged for racing: what common draws that a racer
  * needs, and the run in place of the frags and deaths. Installed over
  * `DrawHudElements` by `Cg_Race_Init`, not chained.

--- a/src/cgame/race/cg_race_hud.c
+++ b/src/cgame/race/cg_race_hud.c
@@ -42,7 +42,7 @@
 
 static float cg_race_speed;
 
-static const char *Cg_Race_FormatTime(uint32_t ms) {
+const char *Cg_Race_FormatTime(uint32_t ms) {
   return va("%u:%02u.%03u", ms / 60000, ms / 1000 % 60, ms % 1000);
 }
 

--- a/src/cgame/race/cg_race_score.c
+++ b/src/cgame/race/cg_race_score.c
@@ -1,0 +1,182 @@
+/*
+ * Copyright(c) 1997-2001 id Software, Inc.
+ * Copyright(c) 2002 The Quakeforge Project.
+ * Copyright(c) 2006 Quetoo.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+#include "cg_race.h"
+
+/**
+ * @file
+ * @brief The scoreboard, arranged for racing: the course records down the left,
+ * from `CS_RACE_RECORDS`, and the racers down the right, each with their mode,
+ * their best on this map and their runs, in the order the server ranked them.
+ */
+
+#define RACE_SCORES_COL_WIDTH 280
+#define RACE_SCORES_ROW_HEIGHT 48
+#define RACE_SCORES_ICON_WIDTH 48
+
+// the most records the config string carries, as the server publishes it
+#define RACE_SCORES_RECORDS 15
+
+static const char *Cg_Race_ModeName(g_race_mode_t mode) {
+
+  switch (mode) {
+    case RACE_MODE_RACE:
+      return "racing";
+    case RACE_MODE_PRACTICE:
+      return "practicing";
+    default:
+      return "spectating";
+  }
+}
+
+/**
+ * @brief The map's title across the top, as the common board has it.
+ * @return The y beneath it.
+ */
+static int32_t Cg_Race_DrawScoresHeader(void) {
+  int32_t ch;
+
+  cgi.BindFont("medium", NULL, &ch);
+
+  const int32_t y = 64 - ch - 4;
+  const char *title = cgi.ConfigString(CS_MESSAGE);
+
+  cgi.Draw2DString((cgi.context->w - cgi.StringWidth(title)) / 2, y, title, color_white);
+
+  cgi.BindFont(NULL, NULL, NULL);
+
+  return y + ch;
+}
+
+/**
+ * @brief The course records, one a row: rank, name and time.
+ */
+static void Cg_Race_DrawRecords(int32_t x, int32_t y) {
+  char string[MAX_STRING_CHARS];
+  int32_t ch;
+
+  q_strlcpy(string, cgi.ConfigString(CS_RACE_RECORDS), sizeof(string));
+
+  cgi.BindFont("small", NULL, &ch);
+
+  cgi.Draw2DString(x, y, "Course records", color_green);
+  y += ch;
+
+  if (!*string) {
+    cgi.Draw2DString(x, y, "none yet", color_grey);
+    cgi.BindFont(NULL, NULL, NULL);
+    return;
+  }
+
+  char *s = string;
+  for (int32_t rank = 1; rank <= RACE_SCORES_RECORDS && *s; rank++) {
+
+    char *name = s;
+    char *time = strchr(name, '\\');
+    if (!time) {
+      break;
+    }
+    *time++ = '\0';
+
+    s = strchr(time, '\\');
+    if (s) {
+      *s++ = '\0';
+    } else {
+      s = time + q_strlen(time);
+    }
+
+    const char *formatted = Cg_Race_FormatTime((uint32_t) strtoul(time, NULL, 10));
+
+    cgi.Draw2DString(x, y, va("%2d  %s", rank, name), color_white);
+    cgi.Draw2DString(x + RACE_SCORES_COL_WIDTH - cgi.StringWidth(formatted), y, formatted, color_white);
+    y += ch;
+  }
+
+  cgi.BindFont(NULL, NULL, NULL);
+}
+
+/**
+ * @brief One racer: their icon and name with their ping, then what they are
+ * doing, their best and their runs.
+ */
+static void Cg_Race_DrawScore(int32_t x, int32_t y, const g_score_t *s) {
+  int32_t cw, ch;
+
+  const cg_client_info_t *info = &cg_state.clients[s->client];
+
+  cgi.Draw2DImage(x + 1, y + 1, RACE_SCORES_ICON_WIDTH - 2, RACE_SCORES_ICON_WIDTH - 2, info->icon, color_white);
+
+  x += RACE_SCORES_ICON_WIDTH;
+
+  const int32_t fw = RACE_SCORES_COL_WIDTH - RACE_SCORES_ICON_WIDTH - 1;
+
+  if (s->color >= 0) {
+    color_t c = ColorHSV(s->color, 1.f, 1.f);
+    c.a = s->client == cgi.client->frame.ps.client ? .3f : .15f;
+
+    cgi.Draw2DFill(x, y, fw, RACE_SCORES_ROW_HEIGHT - 1, c);
+  }
+
+  cgi.BindFont("small", &cw, &ch);
+
+  cgi.Draw2DString(x, y, info->name, color_white);
+  cgi.Draw2DString(x + fw - 5 * cw, y, va("%3dms", s->ping), color_white);
+  y += ch;
+
+  cgi.Draw2DString(x, y, Cg_Race_ModeName(s->race_mode), color_white);
+
+  if (s->race_mode != RACE_MODE_SPECTATOR) {
+    const char *best = s->race_best ? Cg_Race_FormatTime(s->race_best) : "no time";
+    const char *right = va("%s  %u run%s", best, s->race_runs, s->race_runs == 1 ? "" : "s");
+
+    cgi.Draw2DString(x + fw - cgi.StringWidth(right), y, right, color_white);
+  }
+
+  cgi.BindFont(NULL, NULL, NULL);
+}
+
+void Cg_Race_DrawScores(const player_state_t *ps) {
+
+  if (!ps->stats[STAT_SCORES]) {
+    return;
+  }
+
+  const int32_t start_y = Cg_Race_DrawScoresHeader();
+  const int32_t gap = RACE_SCORES_ICON_WIDTH / 2;
+
+  const int32_t left = cgi.context->w / 2 - RACE_SCORES_COL_WIDTH - gap / 2;
+  const int32_t right = cgi.context->w / 2 + gap / 2;
+
+  Cg_Race_DrawRecords(left, start_y);
+
+  size_t count;
+  const g_score_t *scores = Cg_Scores(&count);
+
+  // a second column of racers opens to the right once the first is full
+  const size_t rows = Maxz(3, (cgi.context->h - 2 * start_y) / RACE_SCORES_ROW_HEIGHT);
+
+  for (size_t i = 0; i < count && i < 2 * rows; i++) {
+    const int32_t x = right + (int32_t) (i / rows) * (RACE_SCORES_COL_WIDTH + gap);
+    const int32_t y = start_y + (int32_t) (i % rows) * RACE_SCORES_ROW_HEIGHT;
+
+    Cg_Race_DrawScore(x, y, &scores[i]);
+  }
+}

--- a/src/game/race/g_race.c
+++ b/src/game/race/g_race.c
@@ -57,6 +57,7 @@ static struct {
   ClientDidMove ClientDidMove;
   ClientWillDisconnect ClientWillDisconnect;
   WriteStats WriteStats;
+  WriteScore WriteScore;
 } previous;
 
 static bool installed;
@@ -812,6 +813,29 @@ static void G_WriteStats_Race(g_client_t *cl) {
   cl->ps.stats[STAT_RACE_RUNS] = cl->persistent.race_runs;
 }
 
+/**
+ * @brief The racer's standing on the board: their best, their mode and their
+ * runs, and a score that sorts them by rank, since the common board sorts by
+ * score before the race board ever sees the rows.
+ */
+static void G_WriteScore_Race(const g_client_t *cl, g_score_t *s) {
+
+  previous.WriteScore(cl, s);
+
+  s->race_mode = G_Race_Mode(cl);
+  s->race_runs = cl->persistent.race_runs;
+
+  const g_race_record_t *record = G_Race_Record(cl->persistent.guid, g_level.movement);
+  if (record) {
+    size_t count;
+    s->race_best = record->time;
+    s->score = -(int16_t) G_Race_Rank(record, &count);
+  } else {
+    s->race_best = 0;
+    s->score = -9998; // beneath any rank, above the -9999 the board sorts spectators to
+  }
+}
+
 void G_Race_Init(void) {
 
   if (installed) {
@@ -858,4 +882,7 @@ void G_Race_Init(void) {
 
   previous.WriteStats = G_WriteStats;
   G_WriteStats = G_WriteStats_Race;
+
+  previous.WriteScore = G_WriteScore;
+  G_WriteScore = G_WriteScore_Race;
 }

--- a/src/game/race/g_types.h
+++ b/src/game/race/g_types.h
@@ -438,6 +438,14 @@ typedef struct {
    * @brief Team index.
    */
   uint8_t team;
+
+  /**
+   * @brief How the client is taking part, their best on this map under the
+   * level's movement in milliseconds or 0 for none, and their runs so far.
+   */
+  uint8_t race_mode; // g_race_mode_t
+  uint32_t race_best;
+  uint16_t race_runs;
 } g_score_t;
 
 /**


### PR DESCRIPTION
Step 7, second slice (#963): the scoreboard.

**The board.** Map title across the top as before; the course records down the
left, parsed from `CS_RACE_RECORDS` (rank, name, time; "none yet" when empty);
the racers down the right, each row with icon, name, ping, what they are doing
(racing / practicing / spectating), their best on this map and their runs so
far, in the order the server ranked them, spectators last. A second column of
racers opens to the right once the first is full, as the common board does.

**The wire.** The race module owns `g_score_t`, so the row gains `race_mode`,
`race_best` and `race_runs` outright (20 bytes a row; the existing chunking at
512 bytes per message still holds). `G_WriteScore_Race` fills them and sets
`score` to minus the rank - `-9998` with no time - so the common client's sort
(descending by score, spectators forced to -9999) orders the rows for us.

**Common.** `Cg_Scores()` exposes the parsed, sorted rows so a module drawing
its own board can reach them; nothing else in common changes.

Verified: autotools, Xcode `quetoo-all`, `verify_projects.py`. A read-only review
caught the no-time sentinel sorting racers beneath spectators and the missing
second column; both fixed. Seeing it needs a client and a few players.

Refs #963.

🤖 Generated with [Claude Code](https://claude.com/claude-code)