### PR TITLE
Keep the player model preview out of the world's voxel lights

### DIFF
--- a/src/client/renderer/r_main.c
+++ b/src/client/renderer/r_main.c
@@ -132,7 +132,13 @@ void R_UpdateUniforms(const r_view_t *view) {
     out->editor = editor->integer;
     out->developer = developer->integer;
 
-    if (r_models.world) {
+    // a view that is not the main view - the player model preview - has no
+    // relation to the world's lighting, and its lookups must all land on the
+    // one voxel of the fallback buffers: clamping to a zero-sized grid would
+    // not, since clamp() with a low bound above its high bound is undefined
+    if (view->type != VIEW_MAIN || !r_models.world) {
+      out->voxels.size = Vec4(1.f, 1.f, 1.f, 0.f);
+    } else {
       const r_bsp_voxels_t *voxels = &r_models.world->bsp->voxels;
 
       out->voxels.mins = Vec3_ToVec4(voxels->bounds.mins, 0.f);

--- a/src/client/renderer/r_mesh_draw.c
+++ b/src/client/renderer/r_mesh_draw.c
@@ -87,6 +87,7 @@ static struct {
   Texture *voxel_caustics_fallback;
   Texture *voxel_occlusion_fallback;
   Texture *sky_fallback;
+  Buffer *voxel_lights_fallback;
 
   /**
    * @brief Cached stage pipelines keyed by blend function.
@@ -622,8 +623,8 @@ void R_DrawMeshEntities(const r_view_t *view, RenderPass *pass) {
   SDL_GPUBuffer *storage[] = {
     r_lights.bsp_buffer->buffer,
     r_lights.dynamic_buffer->buffer,
-    bsp && bsp->voxels.light_data_buffer ? bsp->voxels.light_data_buffer->buffer : r_lights.bsp_buffer->buffer,
-    bsp && bsp->voxels.light_indices_buffer ? bsp->voxels.light_indices_buffer->buffer : r_lights.bsp_buffer->buffer,
+    bsp && bsp->voxels.light_data_buffer ? bsp->voxels.light_data_buffer->buffer : r_mesh_draw.voxel_lights_fallback->buffer,
+    bsp && bsp->voxels.light_indices_buffer ? bsp->voxels.light_indices_buffer->buffer : r_mesh_draw.voxel_lights_fallback->buffer,
   };
   $(pass, bindFragmentStorageBuffers, R_STORAGE_BSP_LIGHTS, storage, R_STORAGE_MATERIAL_TOTAL);
   $(pass, bindVertexStorageBuffers, R_STORAGE_BSP_LIGHTS, storage, R_STORAGE_MATERIAL_TOTAL);
@@ -753,6 +754,11 @@ void R_InitMeshPipeline(void) {
   }, NULL);
 
   r_mesh_draw.sky_fallback = $(r_context.device, createSolidColorTexture, SDL_GPU_TEXTURETYPE_CUBE, 6, 0x00000000);
+
+  // one voxel with no lights, for a view whose voxel uniforms name a 1x1x1 grid
+  static const int32_t no_lights[2];
+  r_mesh_draw.voxel_lights_fallback = $(r_context.device, createBufferWithConstMem,
+      SDL_GPU_BUFFERUSAGE_GRAPHICS_STORAGE_READ, no_lights, sizeof(no_lights));
 }
 
 /**
@@ -767,6 +773,7 @@ void R_ShutdownMeshPipeline(void) {
   r_mesh_draw.voxel_caustics_fallback = release(r_mesh_draw.voxel_caustics_fallback);
   r_mesh_draw.voxel_occlusion_fallback = release(r_mesh_draw.voxel_occlusion_fallback);
   r_mesh_draw.sky_fallback = release(r_mesh_draw.sky_fallback);
+  r_mesh_draw.voxel_lights_fallback = release(r_mesh_draw.voxel_lights_fallback);
 
   for (int32_t i = 0; i < r_mesh_draw.num_stage_pipelines; i++) {
     release(r_mesh_draw.stage_pipelines[i].pipeline);


### PR DESCRIPTION
Opening the player model view in-game froze the screen: the model drew once and
the rest of the frame turned to noise, in `default` as well as `race`.

**Cause.** The mesh vertex shader's `vertex_lighting` (`light.glsl:247`) walks
the world's voxel light lists for every view, with no view-type gate (the
fragment shader has one). For the preview, `R_DrawMeshEntities` bound the BSP
lights block as a stand-in for the voxel light-data and light-index storage
buffers, and `R_UpdateUniforms` still described the loaded world's voxel grid,
so the shader computed a real voxel index into a small buffer holding something
else and read out of bounds. Metal faulted the command buffer, which then never
presented - hence the freeze - and API validation cannot see OOB storage reads,
so the log was clean. At the main menu there is no world, so nothing was walked.

**Fix.** A view that is not `VIEW_MAIN` gets a 1x1x1 voxel grid in its uniforms,
so every lookup lands on index 0 (a zero-sized grid would hit `clamp()` with an
inverted range, which is undefined), and the two voxel-light slots bind a new
zeroed `voxel_lights_fallback` buffer that reads as "no lights" - the same
pattern as the existing caustics, occlusion and sky fallbacks.

Found by bisecting `R_DrawPlayerModelView` with temporary switches: the pass
without meshes was clean; the pass with meshes but stale uniforms still faulted.
Verified in play: model renders, world stays intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)