### PR TITLE
Predict the race barriers on the client

### DIFF
--- a/src/cgame/race/cg_race.c
+++ b/src/cgame/race/cg_race.c
@@ -103,7 +103,9 @@ static void Cg_Race_ParseBarrier(int32_t slot) {
 
   switch (barrier) {
     case RACE_BARRIER_GATE:
-      if (sscanf(s + n, "%hu\\%d\\%d", &b->gate.checkpoint, &mode, &invert) != 3) {
+      if (sscanf(s + n, "%hu\\%d\\%d", &b->gate.checkpoint, &mode, &invert) != 3 ||
+          b->gate.checkpoint < 1 || b->gate.checkpoint > RACE_MAX_CHECKPOINTS ||
+          (mode != RACE_GATE_AT_LEAST && mode != RACE_GATE_EXACT)) {
         Cg_Warn("Invalid gate \"%s\"\n", s);
         return;
       }

--- a/src/cgame/race/cg_race.c
+++ b/src/cgame/race/cg_race.c
@@ -23,12 +23,19 @@
 
 /**
  * @file
- * @brief The hooks, and the ghost. See cg_race.h.
+ * @brief The hooks, the ghost, and the barriers. See cg_race.h.
  *
  * The ghost the server sends wears the viewer's client slot, because a player
  * model needs one; here it is dressed instead as the course record's holder,
  * whose client info arrives on `CS_RACE_GHOST`, and drawn translucent. Another
  * player's ghost is theirs to see and not ours.
+ *
+ * The barriers are the `func_race_*` brushes, whose conditions arrive on
+ * `CS_RACE_BARRIERS` so that prediction clips them as the server will, from
+ * the run the stats describe. The client predicts only itself, and with no
+ * mover, so `G_Race_ClipEntity`'s "no mover, so solid" rule has no mirror;
+ * and it has no clip to one entity, so the one-way wall's "already inside"
+ * probe is a trace during which only that wall clips.
  */
 
 // how much of the ghost is there
@@ -40,9 +47,22 @@ static struct {
   FilterEntity FilterEntity;
   ClientInfo ClientInfo;
   EntityEffects EntityEffects;
+  ClipEntity ClipEntity;
 } previous;
 
 static cg_client_info_t cg_race_ghost;
+
+typedef struct {
+  int32_t entity; // the barrier's entity number
+  g_race_barrier_t barrier; // RACE_BARRIER_NONE for an empty slot
+  g_race_gate_t gate;
+  vec3_t move_dir;
+} cg_race_barrier_t;
+
+static cg_race_barrier_t cg_race_barriers[RACE_MAX_BARRIERS];
+
+// the one barrier a probe for "already inside" may clip, while it runs
+static const cl_entity_t *cg_race_probing;
 
 uint32_t Cg_Race_Time(const player_state_t *ps) {
   return (uint16_t) ps->stats[STAT_RACE_TIME_LOW] | ((uint32_t) (uint16_t) ps->stats[STAT_RACE_TIME_HIGH] << 16);
@@ -60,6 +80,69 @@ static bool Cg_Race_IsGhost(const cl_entity_t *ent) {
   return ent->current.effects & EF_RACE_GHOST;
 }
 
+/**
+ * @brief Reads one barrier's slot, as `G_func_race_Init` wrote it; an empty
+ * or malformed slot is no barrier, and the brush is then plainly solid.
+ */
+static void Cg_Race_ParseBarrier(int32_t slot) {
+  cg_race_barrier_t *b = &cg_race_barriers[slot];
+  const char *s = cgi.ConfigString(CS_RACE_BARRIERS + slot);
+
+  *b = (cg_race_barrier_t) { .barrier = RACE_BARRIER_NONE };
+
+  if (!*s) {
+    return;
+  }
+
+  int32_t entity, barrier, mode, invert, n = 0;
+
+  if (sscanf(s, "%d\\%d\\%n", &entity, &barrier, &n) != 2 || !n || entity < 0 || entity >= MAX_ENTITIES) {
+    Cg_Warn("Invalid barrier \"%s\"\n", s);
+    return;
+  }
+
+  switch (barrier) {
+    case RACE_BARRIER_GATE:
+      if (sscanf(s + n, "%hu\\%d\\%d", &b->gate.checkpoint, &mode, &invert) != 3) {
+        Cg_Warn("Invalid gate \"%s\"\n", s);
+        return;
+      }
+      b->gate.mode = mode;
+      b->gate.invert = invert != 0;
+      break;
+    case RACE_BARRIER_WALL:
+      if (sscanf(s + n, "%f\\%f", &b->move_dir.x, &b->move_dir.y) != 2) {
+        Cg_Warn("Invalid one-way wall \"%s\"\n", s);
+        return;
+      }
+      break;
+    default:
+      Cg_Warn("Invalid barrier \"%s\"\n", s);
+      return;
+  }
+
+  b->entity = entity;
+  b->barrier = barrier;
+}
+
+static void Cg_Race_ParseBarriers(void) {
+
+  for (int32_t i = 0; i < RACE_MAX_BARRIERS; i++) {
+    Cg_Race_ParseBarrier(i);
+  }
+}
+
+static const cg_race_barrier_t *Cg_Race_BarrierFor(const cl_entity_t *ent) {
+
+  for (int32_t i = 0; i < RACE_MAX_BARRIERS; i++) {
+    if (cg_race_barriers[i].barrier != RACE_BARRIER_NONE && cg_race_barriers[i].entity == ent->current.number) {
+      return &cg_race_barriers[i];
+    }
+  }
+
+  return NULL;
+}
+
 static bool Cg_ParseConfigString_Race(int32_t index) {
 
   if (index == CS_RACE_GHOST) {
@@ -67,17 +150,75 @@ static bool Cg_ParseConfigString_Race(int32_t index) {
     return true;
   }
 
+  if (index >= CS_RACE_BARRIERS && index < CS_RACE_BARRIERS + RACE_MAX_BARRIERS) {
+    Cg_Race_ParseBarrier(index - CS_RACE_BARRIERS);
+    return true;
+  }
+
   return previous.ParseConfigString(index);
 }
 
 /**
- * @brief The client infos are media, and are reloaded with it.
+ * @brief The client infos are media, and are reloaded with it; the barriers
+ * are re-read so that a new level's slots replace the last one's.
  */
 static void Cg_MediaDidLoad_Race(void) {
 
   previous.MediaDidLoad();
 
   Cg_Race_LoadGhost();
+  Cg_Race_ParseBarriers();
+}
+
+/**
+ * @brief `G_Race_ClipEntity`, as the client can apply it to itself.
+ */
+static bool Cg_ClipEntity_Race(const cl_entity_t *mover, const cl_entity_t *ent, const vec3_t start, const vec3_t end, const box3_t bounds) {
+
+  if (cg_race_probing) {
+    return ent == cg_race_probing;
+  }
+
+  const cg_race_barrier_t *b = Cg_Race_BarrierFor(ent);
+
+  if (!b) {
+    return previous.ClipEntity(mover, ent, start, end, bounds);
+  }
+
+  const player_state_t *ps = &cgi.client->frame.ps;
+
+  if (b->barrier == RACE_BARRIER_GATE) {
+
+    if (ps->stats[STAT_RACE_RUN] != RACE_RUN_ACTIVE) {
+      return false;
+    }
+
+    const bool open = b->gate.mode == RACE_GATE_EXACT
+                      ? ps->stats[STAT_RACE_CHECKPOINTS] == b->gate.checkpoint
+                      : ps->stats[STAT_RACE_CHECKPOINTS] >= b->gate.checkpoint;
+
+    if (open != b->gate.invert) {
+      return false;
+    }
+
+    return previous.ClipEntity(mover, ent, start, end, bounds);
+  }
+
+  cg_race_probing = ent;
+  const cm_trace_t tr = cgi.Trace(start, start, bounds, NULL, CONTENTS_MASK_CLIP_PLAYER);
+  cg_race_probing = NULL;
+
+  if (tr.start_solid && tr.ent == ent) {
+    return false;
+  }
+
+  const vec3_t travel = Vec3_Subtract(end, start);
+
+  if (travel.x * b->move_dir.x + travel.y * b->move_dir.y > 0.f) {
+    return false;
+  }
+
+  return previous.ClipEntity(mover, ent, start, end, bounds);
 }
 
 static bool Cg_FilterEntity_Race(const cl_entity_t *ent) {
@@ -134,4 +275,7 @@ void Cg_Race_Init(void) {
 
   previous.EntityEffects = Cg_EntityEffects;
   Cg_EntityEffects = Cg_EntityEffects_Race;
+
+  previous.ClipEntity = Cg_ClipEntity;
+  Cg_ClipEntity = Cg_ClipEntity_Race;
 }

--- a/src/game/race/g_race_entity.c
+++ b/src/game/race/g_race_entity.c
@@ -266,7 +266,8 @@ static void G_trigger_race_finish(g_entity_t *ent) {
 
 /**
  * @brief The common half of every barrier's setup: an inline brush, solid,
- * whose conditions `G_Race_ClipEntity` applies.
+ * whose conditions `G_Race_ClipEntity` applies, published on the barrier's
+ * `CS_RACE_BARRIERS` slot so that the client applies them too.
  */
 static void G_func_race_Init(g_entity_t *ent, g_race_barrier_t barrier) {
 
@@ -276,13 +277,25 @@ static void G_func_race_Init(g_entity_t *ent, g_race_barrier_t barrier) {
     return;
   }
 
+  if (g_level.race_course.barrier_count == RACE_MAX_BARRIERS) {
+    G_Warn("%s is one func_race_* too many; the level may have %d\n", etos(ent), RACE_MAX_BARRIERS);
+    G_FreeEntity(ent);
+    return;
+  }
+
   ent->race_barrier = barrier;
   ent->solid = SOLID_BSP;
   ent->move_type = MOVE_TYPE_NONE;
-  ent->sv_flags |= SVF_NO_CLIENT;
 
   gi.SetModel(ent, ent->model);
   gi.LinkEntity(ent);
+
+  const char *params = barrier == RACE_BARRIER_GATE
+                       ? va("%u\\%d\\%d", ent->race_gate.checkpoint, ent->race_gate.mode, ent->race_gate.invert)
+                       : va("%g\\%g", ent->move_dir.x, ent->move_dir.y);
+
+  gi.SetConfigString(CS_RACE_BARRIERS + g_level.race_course.barrier_count++,
+                     va("%u\\%d\\%s", ent->s.number, barrier, params));
 }
 
 /*QUAKED func_race_checkpoint_gate (0 .5 .8) ?

--- a/src/game/race/g_types.h
+++ b/src/game/race/g_types.h
@@ -90,6 +90,7 @@ typedef enum {
 #define CS_RACE_COURSE     (CS_GAME + 10) // checkpoints\finishes\valid, for the HUD
 #define CS_RACE_RECORDS    (CS_GAME + 11) // the top times under this movement, name\time pairs
 #define CS_RACE_GHOST      (CS_GAME + 12) // the course record holder as a CS_CLIENTS string, for the ghost's skin
+#define CS_RACE_BARRIERS   (CS_GAME + 13) // RACE_MAX_BARRIERS of entity\\barrier\\params, so the client predicts them
 
 /**
  * @brief Player state statistics (inventory, score, etc).
@@ -136,6 +137,9 @@ _Static_assert(STAT_RACE_RUNS < MAX_STATS, "the race stats must fit the stat arr
  * finish; a start is optional, and so are splits and stages.
  */
 #define RACE_MAX_CHECKPOINTS 64
+
+// how many func_race_* brushes a level may have, one config string each
+#define RACE_MAX_BARRIERS 32
 
 /**
  * @brief How a client is taking part. Spectating is derived from
@@ -209,6 +213,7 @@ typedef struct {
   uint16_t checkpoint_count, split_count, stage_count;
   uint16_t start_count;
   uint16_t finish_count;
+  uint16_t barrier_count; // func_race_* brushes published so far
   bool malformed, splits_malformed, stages_malformed; // a number out of range was seen
   bool valid;        // checkpoints 1 through N and a finish; nothing else bears on it
   bool splits_valid; // splits 1 through N, so they time


### PR DESCRIPTION
Step 7c of #963.

`func_race_checkpoint_gate` and `func_race_oneway_wall` were `SVF_NO_CLIENT`, so a closed gate was a server correction. Each barrier now publishes its parameters on `CS_RACE_BARRIERS + slot` (`RACE_MAX_BARRIERS` = 32 per level; `entity\kind\cp\mode\invert` for a gate, `entity\kind\dx\dy` for a wall) and is sent to clients. The race cgame parses the slots (per index, and all of them on `MediaDidLoad` so a new map clears the old set) and chains `Cg_ClipEntity` with a mirror of `G_Race_ClipEntity` driven by `STAT_RACE_RUN` / `STAT_RACE_CHECKPOINTS`.

Two differences from the server, by necessity: prediction passes no mover, so the "no mover, so solid" rule has no client mirror (only the local player is predicted); and there is no single-entity clip, so the one-way wall's "already inside" probe is a trace during which only that wall clips.

Verified: both modules build clean; `racetest` loads headlessly with no warnings ("Loaded map racetest, 10 entities" - the two barriers are now counted); the wire format round-trips through the client's exact `sscanf` calls. Not yet lap-tested with a client. `race` goes into `GAME_MODULES` in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)