### PR TITLE
Tighten the hook APIs from the #963 sweep, part 1

### DIFF
--- a/src/cgame/cgame.h
+++ b/src/cgame/cgame.h
@@ -36,7 +36,7 @@
 #include <Objectively/RESTClient.h>
 #include <Objectively/Vector.h>
 
-#define CGAME_API_VERSION 36
+#define CGAME_API_VERSION 37
 
 /**
  * @brief The client game import struct imports engine functionailty to the client game.
@@ -628,6 +628,19 @@ typedef struct cg_import_s {
    * @return A trace result.
    */
   cm_trace_t (*Trace)(const vec3_t start, const vec3_t end, const box3_t bounds, const cl_entity_t *skip, int32_t contents);
+
+  /**
+   * @brief Clips a box trace against a single entity, the reciprocal of the
+   * game's `Clip`. The client's skip rules and `ClipEntity` still apply, the
+   * latter with no mover.
+   * @param start The trace start point.
+   * @param end The trace end point.
+   * @param bounds The trace bounds, or `Box3_Zero()` for point/line trace.
+   * @param test The entity to clip against.
+   * @param contents Solids matching this mask will clip the returned trace.
+   * @return A trace result.
+   */
+  cm_trace_t (*Clip)(const vec3_t start, const vec3_t end, const box3_t bounds, const cl_entity_t *test, int32_t contents);
 
   /**
    * @brief Traces a point ray from `start` to `end` against a single brush.

--- a/src/cgame/common/cg_main.c
+++ b/src/cgame/common/cg_main.c
@@ -84,6 +84,7 @@ cvar_t *cg_skin;
 cvar_t *editor;
 
 cg_import_t cgi;
+static cg_export_t cge;
 
 /**
  * @brief Called when the client first comes up or switches game directories. Client
@@ -198,6 +199,8 @@ static void Cg_Init(void) {
   Cg_Vote_Init();
 
   Cg_Module_Init();
+
+  cge.ClipEntity = Cg_ClipEntity;
 
   cgi.Print("Client game module initialized\n");
 }
@@ -554,7 +557,6 @@ ScreenDidUpdate Cg_ScreenDidUpdate = Cg_ScreenDidUpdate_Common;
  * @brief Entry point that populates and returns the cgame export table with all function pointers.
  */
 cg_export_t *Cg_LoadCgame(cg_import_t *import) {
-  static cg_export_t cge;
 
   cgi = *import;
 
@@ -583,7 +585,6 @@ cg_export_t *Cg_LoadCgame(cg_import_t *import) {
   cge.UpdateScreen = Cg_UpdateScreen;
   cge.UpdateInstaller = Cg_UpdateInstaller;
   cge.UpdateDiscord = Cg_UpdateDiscord;
-  cge.ClipEntity = Cg_ExportClipEntity;
 
   return &cge;
 }

--- a/src/cgame/common/cg_module.h
+++ b/src/cgame/common/cg_module.h
@@ -188,9 +188,8 @@ extern Move Cg_Move;
 /**
  * @brief A pending command with time is about to be run through `Pm_Move` for
  * prediction. The move is set up once from the last server frame and carried
- * through every pending command, so whatever a feature sets on it here - a
- * training aid installing `pm->Accelerate`, say - stays set for the commands
- * that follow.
+ * through every pending command, so whatever a feature sets on it here stays
+ * set for the commands that follow.
  * @details Notification; the tail does nothing.
  */
 typedef void (*MoveCommandWillRun)(pm_move_t *pm, const cl_cmd_t *cmd);

--- a/src/cgame/common/cg_module.h
+++ b/src/cgame/common/cg_module.h
@@ -153,7 +153,8 @@ extern ListGameplayModes Cg_ListGameplayModes;
 
 /**
  * @brief Decides whether `ent` clips a trace made on behalf of `mover`, after the
- * client has applied its own skip rules. The default clips everything.
+ * client has applied its own skip rules. There is no tail: the chain is `NULL`
+ * until a feature installs a link, and the client does not call an empty one.
  * @details Chainable, and the reciprocal of the game's `ClipEntity`: a feature
  * installs the same rule on both sides, or prediction disagrees with the server.
  * An implementation MUST be pure.

--- a/src/cgame/common/cg_module.h
+++ b/src/cgame/common/cg_module.h
@@ -157,7 +157,9 @@ extern ListGameplayModes Cg_ListGameplayModes;
  * until a feature installs a link, and the client does not call an empty one.
  * @details Chainable, and the reciprocal of the game's `ClipEntity`: a feature
  * installs the same rule on both sides, or prediction disagrees with the server.
- * An implementation MUST be pure.
+ * Prediction traces on behalf of `cgi.client->entity`; `mover` is `NULL` for a
+ * trace with no entity behind it, as it is for `cgi.Clip`. An implementation
+ * MUST be pure.
  */
 typedef bool (*ClipEntity)(const cl_entity_t *mover, const cl_entity_t *ent, const vec3_t start, const vec3_t end, const box3_t bounds);
 

--- a/src/cgame/common/cg_predict.c
+++ b/src/cgame/common/cg_predict.c
@@ -84,7 +84,7 @@ PredictionDidComplete Cg_PredictionDidComplete = Cg_PredictionDidComplete_Common
  * @brief Trace wrapper for `Pm_Move`.
  */
 static cm_trace_t Cg_PredictMovement_Trace(const vec3_t start, const vec3_t end, const box3_t bounds) {
-  return cgi.Trace(start, end, bounds, NULL, CONTENTS_MASK_CLIP_PLAYER);
+  return cgi.Trace(start, end, bounds, cgi.client->entity, CONTENTS_MASK_CLIP_PLAYER);
 }
 
 /**

--- a/src/cgame/common/cg_predict.c
+++ b/src/cgame/common/cg_predict.c
@@ -88,22 +88,11 @@ static cm_trace_t Cg_PredictMovement_Trace(const vec3_t start, const vec3_t end,
 }
 
 /**
- * @brief The tail of the `Cg_ClipEntity` chain: every entity clips.
+ * @brief The `Cg_ClipEntity` chain has no tail: it is `NULL` until a module
+ * installs a link, and `Cg_Init` exports whatever is installed, so that a
+ * client game with nothing to say is never asked.
  */
-static bool Cg_ClipEntity_Common(const cl_entity_t *mover, const cl_entity_t *ent, const vec3_t start, const vec3_t end, const box3_t bounds) {
-  return true;
-}
-
-ClipEntity Cg_ClipEntity = Cg_ClipEntity_Common;
-
-/**
- * @brief The `ClipEntity` export. The client holds this rather than the chain
- * head, so that the chain a module installs from `Cg_Module_Init` is the one
- * that gets called.
- */
-bool Cg_ExportClipEntity(const cl_entity_t *mover, const cl_entity_t *ent, const vec3_t start, const vec3_t end, const box3_t bounds) {
-  return Cg_ClipEntity(mover, ent, start, end, bounds);
-}
+ClipEntity Cg_ClipEntity = NULL;
 
 /**
  * @brief Run recent movement commands through the player movement code locally, storing the

--- a/src/cgame/common/cg_predict.h
+++ b/src/cgame/common/cg_predict.h
@@ -26,5 +26,4 @@
 #if defined(__CG_LOCAL_H__)
 bool Cg_ExportUsePrediction(void);
 void Cg_PredictMovement(const Vector *cmds);
-bool Cg_ExportClipEntity(const cl_entity_t *mover, const cl_entity_t *ent, const vec3_t start, const vec3_t end, const box3_t bounds);
 #endif

--- a/src/cgame/race/cg_race.c
+++ b/src/cgame/race/cg_race.c
@@ -32,10 +32,9 @@
  *
  * The barriers are the `func_race_*` brushes, whose conditions arrive on
  * `CS_RACE_BARRIERS` so that prediction clips them as the server will, from
- * the run the stats describe. The client predicts only itself, and with no
- * mover, so `G_Race_ClipEntity`'s "no mover, so solid" rule has no mirror;
- * and it has no clip to one entity, so the one-way wall's "already inside"
- * probe is a trace during which only that wall clips.
+ * the run the stats describe. The client predicts only itself, so the racer
+ * `G_Race_ClipEntity` asks after is this client's entity, and anything else
+ * that traces meets a wall.
  */
 
 // how much of the ghost is there
@@ -60,9 +59,6 @@ typedef struct {
 } cg_race_barrier_t;
 
 static cg_race_barrier_t cg_race_barriers[RACE_MAX_BARRIERS];
-
-// the one barrier a probe for "already inside" may clip, while it runs
-static const cl_entity_t *cg_race_probing;
 
 uint32_t Cg_Race_Time(const player_state_t *ps) {
   return (uint16_t) ps->stats[STAT_RACE_TIME_LOW] | ((uint32_t) (uint16_t) ps->stats[STAT_RACE_TIME_HIGH] << 16);
@@ -180,15 +176,10 @@ static bool Cg_Race_ClipPrevious(const cl_entity_t *mover, const cl_entity_t *en
  * @brief `G_Race_ClipEntity`, as the client can apply it to itself.
  */
 static bool Cg_ClipEntity_Race(const cl_entity_t *mover, const cl_entity_t *ent, const vec3_t start, const vec3_t end, const box3_t bounds) {
-
-  if (cg_race_probing) {
-    return ent == cg_race_probing;
-  }
-
   const cg_race_barrier_t *b = Cg_Race_BarrierFor(ent);
 
-  if (!b) {
-    return previous.ClipEntity(mover, ent, start, end, bounds);
+  if (!b || !mover || mover != cgi.client->entity) {
+    return Cg_Race_ClipPrevious(mover, ent, start, end, bounds);
   }
 
   const player_state_t *ps = &cgi.client->frame.ps;
@@ -210,11 +201,7 @@ static bool Cg_ClipEntity_Race(const cl_entity_t *mover, const cl_entity_t *ent,
     return Cg_Race_ClipPrevious(mover, ent, start, end, bounds);
   }
 
-  cg_race_probing = ent;
-  const cm_trace_t tr = cgi.Trace(start, start, bounds, NULL, CONTENTS_MASK_CLIP_PLAYER);
-  cg_race_probing = NULL;
-
-  if (tr.start_solid && tr.ent == ent) {
+  if (cgi.Clip(start, start, bounds, ent, CONTENTS_MASK_CLIP_PLAYER).start_solid) {
     return false;
   }
 

--- a/src/cgame/race/cg_race.c
+++ b/src/cgame/race/cg_race.c
@@ -172,6 +172,10 @@ static void Cg_MediaDidLoad_Race(void) {
   Cg_Race_ParseBarriers();
 }
 
+static bool Cg_Race_ClipPrevious(const cl_entity_t *mover, const cl_entity_t *ent, const vec3_t start, const vec3_t end, const box3_t bounds) {
+  return previous.ClipEntity ? previous.ClipEntity(mover, ent, start, end, bounds) : true;
+}
+
 /**
  * @brief `G_Race_ClipEntity`, as the client can apply it to itself.
  */
@@ -203,7 +207,7 @@ static bool Cg_ClipEntity_Race(const cl_entity_t *mover, const cl_entity_t *ent,
       return false;
     }
 
-    return previous.ClipEntity(mover, ent, start, end, bounds);
+    return Cg_Race_ClipPrevious(mover, ent, start, end, bounds);
   }
 
   cg_race_probing = ent;
@@ -220,7 +224,7 @@ static bool Cg_ClipEntity_Race(const cl_entity_t *mover, const cl_entity_t *ent,
     return false;
   }
 
-  return previous.ClipEntity(mover, ent, start, end, bounds);
+  return Cg_Race_ClipPrevious(mover, ent, start, end, bounds);
 }
 
 static bool Cg_FilterEntity_Race(const cl_entity_t *ent) {

--- a/src/client/cl_cgame.c
+++ b/src/client/cl_cgame.c
@@ -269,6 +269,7 @@ void Cl_InitCgame(void) {
   import.BoxLeafnums = Cm_BoxLeafnums;
   import.PointInsideBrush = Cm_PointInsideBrush;
   import.Trace = Cl_Trace;
+  import.Clip = Cl_Clip;
   import.PointLeafnum = Cm_PointLeafnum;
   import.TraceToBrush = Cm_TraceToBrush;
 

--- a/src/client/cl_predict.c
+++ b/src/client/cl_predict.c
@@ -138,7 +138,8 @@ typedef struct {
 } cl_trace_t;
 
 /**
- * @brief Clips the specified trace to other solid entities in the frame.
+ * @brief Clips the specified trace to the specified entity.
+ * @return True if the trace began in solid, so that the caller may stop.
  */
 static void Cl_ClipTraceToEntities(cl_trace_t *trace) {
 

--- a/src/client/cl_predict.c
+++ b/src/client/cl_predict.c
@@ -141,6 +141,50 @@ typedef struct {
  * @brief Clips the specified trace to the specified entity.
  * @return True if the trace began in solid, so that the caller may stop.
  */
+static bool Cl_ClipTraceToEntity(cl_trace_t *trace, cl_entity_t *ent) {
+  const entity_state_t *s = &ent->current;
+
+  if (s->solid < SOLID_BOX) {
+    return false;
+  }
+
+  if (ent == trace->skip) {
+    return false;
+  }
+
+  if (ent == cl.entity) {
+    return false;
+  }
+
+  if (!Box3_Intersects(ent->abs_bounds, trace->abs_bounds)) {
+    return false;
+  }
+
+  if (cls.cgame->ClipEntity && !cls.cgame->ClipEntity(trace->skip, ent, trace->start, trace->end, trace->bounds)) {
+    return false;
+  }
+
+  const int32_t head_node = Cl_HullForEntity(s);
+
+  cm_trace_t tr;
+
+  if (Mat4_Equal(ent->matrix, Mat4_Identity())) {
+    tr = Cm_BoxTrace(trace->start, trace->end, trace->bounds, head_node, trace->contents);
+  } else {
+    tr = Cm_TransformedBoxTrace(trace->start, trace->end, trace->bounds, head_node, trace->contents, ent->matrix, ent->inverse_matrix);
+  }
+
+  if (tr.start_solid || tr.fraction < trace->trace.fraction) {
+    trace->trace = tr;
+    trace->trace.ent = ent;
+  }
+
+  return tr.start_solid;
+}
+
+/**
+ * @brief Clips the specified trace to other solid entities in the frame.
+ */
 static void Cl_ClipTraceToEntities(cl_trace_t *trace) {
 
   for (int32_t i = 0; i < cl.frame.num_entities; i++) {
@@ -148,47 +192,33 @@ static void Cl_ClipTraceToEntities(cl_trace_t *trace) {
     const uint32_t snum = (cl.frame.entity_state + i) & ENTITY_STATE_MASK;
     const entity_state_t *s = &cl.entity_states[snum];
 
-    if (s->solid < SOLID_BOX) {
-      continue;
-    }
-
-    cl_entity_t *ent = &cl.entities[s->number];
-
-    if (ent == trace->skip) {
-      continue;
-    }
-
-    if (ent == cl.entity) {
-      continue;
-    }
-
-    if (!Box3_Intersects(ent->abs_bounds, trace->abs_bounds)) {
-      continue;
-    }
-
-    if (cls.cgame && !cls.cgame->ClipEntity(trace->skip, ent, trace->start, trace->end, trace->bounds)) {
-      continue;
-    }
-
-    const int32_t head_node = Cl_HullForEntity(s);
-
-    cm_trace_t tr;
-    
-    if (Mat4_Equal(ent->matrix, Mat4_Identity())) {
-      tr = Cm_BoxTrace(trace->start, trace->end, trace->bounds, head_node, trace->contents);
-    } else {
-      tr = Cm_TransformedBoxTrace(trace->start, trace->end, trace->bounds, head_node, trace->contents, ent->matrix, ent->inverse_matrix);
-    }
-
-    if (tr.start_solid || tr.fraction < trace->trace.fraction) {
-      trace->trace = tr;
-      trace->trace.ent = ent;
-
-      if (tr.start_solid) {
-        return;
-      }
+    if (Cl_ClipTraceToEntity(trace, &cl.entities[s->number])) {
+      return;
     }
   }
+}
+
+/**
+ * @brief Tests a clip of the specified translation against the specified
+ * entity. This is the reciprocal of `Sv_Clip`.
+ */
+cm_trace_t Cl_Clip(const vec3_t start, const vec3_t end, const box3_t bounds, const cl_entity_t *test, int32_t contents) {
+
+  cl_trace_t trace = {
+    .start = start,
+    .end = end,
+    .bounds = bounds,
+    .abs_bounds = Cm_TraceBounds(start, end, bounds),
+    .contents = contents,
+    .trace = {
+      .fraction = 1.f,
+      .end = end,
+    }
+  };
+
+  Cl_ClipTraceToEntity(&trace, (cl_entity_t *) test);
+
+  return trace.trace;
 }
 
 /**

--- a/src/client/cl_predict.h
+++ b/src/client/cl_predict.h
@@ -25,6 +25,7 @@
 
 int32_t Cl_PointContents(const vec3_t point);
 int32_t Cl_BoxContents(const box3_t bounds);
+cm_trace_t Cl_Clip(const vec3_t start, const vec3_t end, const box3_t bounds, const cl_entity_t *test, int32_t contents);
 cm_trace_t Cl_Trace(const vec3_t start, const vec3_t end, const box3_t bounds, const cl_entity_t *skip, int32_t contents);
 
 #if defined(__CL_LOCAL_H__)

--- a/src/game/common/bg_pmove.c
+++ b/src/game/common/bg_pmove.c
@@ -228,10 +228,6 @@ void Pm_Accelerate(const vec3_t dir, float speed, float accel) {
 
     pm->s.velocity = Vec3_Fmaf(pm->s.velocity, accel_speed, dir);
   }
-
-  if (pm->Accelerate) {
-    pm->Accelerate(pm, dir, speed, accel);
-  }
 }
 
 /**

--- a/src/game/common/bg_pmove.h
+++ b/src/game/common/bg_pmove.h
@@ -211,13 +211,6 @@ typedef struct pm_move_s {
   debug_t (*DebugMask)(void);
   void (*Debug)(const debug_t debug, const char *func, const char *fmt, ...);
   debug_t debug_mask;
-
-  /**
-   * @brief Called on each user-intended acceleration, or `NULL`, whether or not
-   * the move was already at the wished speed. For training aids that sample the
-   * move as it happens; it MUST NOT change it.
-   */
-  void (*Accelerate)(const struct pm_move_s *pm, const vec3_t dir, float speed, float accel);
 } pm_move_t;
 
 /**

--- a/src/game/common/bg_pmove_quake.c
+++ b/src/game/common/bg_pmove_quake.c
@@ -353,10 +353,6 @@ static void Pm_QuakeAccelerate(const vec3_t dir, float speed, float accel) {
   const float accel_speed = Minf(accel * pm_locals.time * speed, add_speed);
 
   pm->s.velocity = Vec3_Fmaf(pm->s.velocity, accel_speed, dir);
-
-  if (pm->Accelerate) {
-    pm->Accelerate(pm, dir, speed, accel);
-  }
 }
 
 /**
@@ -384,10 +380,6 @@ static void Pm_QuakeAirAccelerate(const vec3_t dir, float speed, float accel) {
   const float accel_speed = Minf(accel * speed * pm_locals.time, add_speed);
 
   pm->s.velocity = Vec3_Fmaf(pm->s.velocity, accel_speed, dir);
-
-  if (pm->Accelerate) {
-    pm->Accelerate(pm, dir, speed, accel);
-  }
 }
 
 /**

--- a/src/game/common/bg_pmove_quake2.c
+++ b/src/game/common/bg_pmove_quake2.c
@@ -326,10 +326,6 @@ static void Pm_Quake2Accelerate(const vec3_t dir, float speed, float accel) {
   const float accel_speed = Minf(accel * pm_locals.time * speed, add_speed);
 
   pm->s.velocity = Vec3_Fmaf(pm->s.velocity, accel_speed, dir);
-
-  if (pm->Accelerate) {
-    pm->Accelerate(pm, dir, speed, accel);
-  }
 }
 
 /**

--- a/src/game/common/bg_pmove_quake3.c
+++ b/src/game/common/bg_pmove_quake3.c
@@ -460,10 +460,6 @@ static void Pm_Quake3Accelerate(const vec3_t dir, float speed, float accel) {
   const float accel_speed = Minf(accel * pm_locals.time * speed, add_speed);
 
   pm->s.velocity = Vec3_Fmaf(pm->s.velocity, accel_speed, dir);
-
-  if (pm->Accelerate) {
-    pm->Accelerate(pm, dir, speed, accel);
-  }
 }
 
 /**

--- a/src/game/common/bg_pmove_race.c
+++ b/src/game/common/bg_pmove_race.c
@@ -346,10 +346,6 @@ static void Pm_RaceAccelerate(const vec3_t dir, float speed, float accel) {
   const float accel_speed = Minf(accel * pm_locals.time * speed, add_speed);
 
   pm->s.velocity = Vec3_Fmaf(pm->s.velocity, accel_speed, dir);
-
-  if (pm->Accelerate) {
-    pm->Accelerate(pm, dir, speed, accel);
-  }
 }
 
 /**

--- a/src/game/common/g_ai_node.c
+++ b/src/game/common/g_ai_node.c
@@ -1606,7 +1606,7 @@ Vector *G_Ai_Node_FindPath(const g_client_t *cl, const ai_node_id_t start, const
 
       if (cl && cl->entity) {
         const int32_t water_level = (link_contents & CONTENTS_WATER) ? 1 : 0;
-        const float estimated_damage = G_Ai_EstimatedFallDamage(drop, g_level.gravity, water_level);
+        const float estimated_damage = G_Ai_EstimatedFallDamage(drop, G_LevelGravity(), water_level);
 
         if (estimated_damage + AI_DROP_HEALTH_MARGIN >= cl->entity->health) {
           continue;

--- a/src/game/common/g_client.c
+++ b/src/game/common/g_client.c
@@ -1876,22 +1876,11 @@ static void G_PrepareMove_Common(g_client_t *cl, pm_move_t *pm) {
 PrepareMove G_PrepareMove = G_PrepareMove_Common;
 
 /**
- * @brief The tail of the `G_ClipEntity` chain: every entity clips.
+ * @brief The `G_ClipEntity` chain has no tail: it is `NULL` until a module
+ * installs a link, and `G_Init` exports whatever is installed, so that a game
+ * with nothing to say is never asked.
  */
-static bool G_ClipEntity_Common(const g_entity_t *mover, const g_entity_t *ent, const vec3_t start, const vec3_t end, const box3_t bounds) {
-  return true;
-}
-
-ClipEntity G_ClipEntity = G_ClipEntity_Common;
-
-/**
- * @brief The `ClipEntity` export. The server holds this rather than the chain
- * head, so that the chain a module installs from `G_Module_Init` is the one
- * that gets called.
- */
-bool G_ExportClipEntity(const g_entity_t *mover, const g_entity_t *ent, const vec3_t start, const vec3_t end, const box3_t bounds) {
-  return G_ClipEntity(mover, ent, start, end, bounds);
-}
+ClipEntity G_ClipEntity = NULL;
 
 /**
  * @brief Process the movement command, call `Pm_Move` and act on the result.

--- a/src/game/common/g_client.c
+++ b/src/game/common/g_client.c
@@ -1929,10 +1929,6 @@ static void G_ClientMove(g_client_t *cl, pm_cmd_t *cmd) {
     } else {
       gi.Print("PMove frame %8" PRIu64 " / %8" PRIu64, pmove_frame, pmove_frames);
       pmove_frame++;
-
-      // the recording holds the pointers of whatever module made it; the
-      // movement kernel travels as an id in the parameters, so it survives
-      pm.Accelerate = NULL;
     }
   }
 

--- a/src/game/common/g_client.h
+++ b/src/game/common/g_client.h
@@ -31,6 +31,5 @@ void G_ClientDisconnect(g_client_t *cl);
 void G_ClientRespawn(g_client_t *cl, bool voluntary);
 void G_ClientThink(g_client_t *cl, pm_cmd_t *cmd);
 void G_ClientUserInfoChanged(g_client_t *cl, const char *user_info);
-bool G_ExportClipEntity(const g_entity_t *mover, const g_entity_t *ent, const vec3_t start, const vec3_t end, const box3_t bounds);
 void G_Giblets(const g_giblets_t *giblets);
 #endif

--- a/src/game/common/g_combat.c
+++ b/src/game/common/g_combat.c
@@ -301,10 +301,10 @@ static int32_t G_CheckArmor(g_entity_t *ent, const vec3_t pos, const vec3_t norm
  * @brief The tail of the `G_ModifyDamage` chain, applying the quad damage
  * powerup. Never vetoes. Features holding their own modifiers install over the top.
  */
-static bool G_ModifyDamage_Common(const g_damage_t *dmg, int32_t *damage, int32_t *knockback) {
+static bool G_ModifyDamage_Common(g_entity_t *target, g_entity_t *attacker, int32_t *damage, int32_t *knockback) {
 
-  if (dmg->attacker->client) {
-    if (dmg->attacker->client->inventory[POWERUP_QUAD]) {
+  if (attacker->client) {
+    if (attacker->client->inventory[POWERUP_QUAD]) {
       *damage *= QUAD_DAMAGE_FACTOR;
       *knockback *= QUAD_KNOCKBACK_FACTOR;
     }
@@ -341,7 +341,6 @@ ModifyDamage G_ModifyDamage = G_ModifyDamage_Common;
 void G_Damage(const g_damage_t *dmg) {
 
   g_entity_t *target = dmg->target;
-  g_entity_t *inflictor = dmg->inflictor ?: ge.entities[0];
   g_entity_t *attacker = dmg->attacker ?: ge.entities[0];
 	const vec3_t dir = dmg->dir;
 	const vec3_t pos = dmg->point;
@@ -352,7 +351,6 @@ void G_Damage(const g_damage_t *dmg) {
 	g_means_of_death mod = dmg->mod;
 
   assert(target);
-  assert(inflictor);
   assert(attacker);
   assert(damage >= 0);
   assert(damage <= INT16_MAX);
@@ -369,11 +367,7 @@ void G_Damage(const g_damage_t *dmg) {
     }
   }
 
-  g_damage_t resolved = *dmg;
-  resolved.inflictor = inflictor;
-  resolved.attacker = attacker;
-
-  if (!G_ModifyDamage(&resolved, &damage, &knockback)) {
+  if (!G_ModifyDamage(target, attacker, &damage, &knockback)) {
     return;
   }
 

--- a/src/game/common/g_entity.c
+++ b/src/game/common/g_entity.c
@@ -734,7 +734,7 @@ static void G_worldspawn_Music(void) {
  message : The map title.
  sky : The sky environment map (default unit1_).
  ambient : The ambient light level (e.g. 0.14 0.11 0.12).
- gravity : Gravity for the level (default 800).
+ gravity : Gravity for the level; unset, the movement's applies, 800 for most.
  gameplay : The gameplay mode, one of "deathmatch, instagib, arena."
  hook : Enables the grappling hook (unset for gameplay default, 0 = disabled, 1 = enabled)."
  teams : Enables and enforces teams play (enabled = 1, auto-balance = 2).
@@ -776,12 +776,14 @@ static void G_worldspawn(g_entity_t *ent) {
     g_level.gravity = g_gravity->integer;
   } else if (gravity_map && (gravity_map->parsed & ENTITY_INTEGER) && gravity_map->integer > 0) { // then map metadata gravity
     g_level.gravity = gravity_map->integer;
-  } else { // or fall back on worldspawn
+  } else { // or worldspawn; unset, it stays zero, and the movement's gravity applies
     const cm_entity_t *gravity = gi.EntityValue(ent->def, "gravity");
     if (gravity->parsed & ENTITY_INTEGER) {
-      g_level.gravity = gravity->integer;
-    } else {
-      g_level.gravity = DEFAULT_GRAVITY;
+      if (gravity->integer) {
+        g_level.gravity = gravity->integer;
+      } else {
+        G_Warn("%s has gravity 0, which is unset: the movement's applies\n", g_level.name);
+      }
     }
   }
 

--- a/src/game/common/g_main.c
+++ b/src/game/common/g_main.c
@@ -567,60 +567,78 @@ static char *G_FormatTime(uint32_t time) {
 
 /**
  * @brief Factory for `pm_params_t`, hydrated fresh from the g_* movement cvars at
- * each `Pm_Move` call site. Gravity carries map/worldspawn precedence, so it is
- * taken from `g_level`. Values are passed through verbatim; `Pm_Move` performs all
- * sanitization (clamping, divide-by-zero guards).
+ * each `Pm_Move` call site. Values are passed through verbatim; `Pm_Move`
+ * performs all sanitization (clamping, divide-by-zero guards).
+ *
+ * Every movement but Quetoo's is defined by its own parameters rather than by
+ * this server's cvars: one that drifted with a cvar would not be a movement
+ * anyone could set a comparable record under. Gravity is the exception, as the
+ * level's when the level sets one; see `G_LevelGravity`.
  */
 pm_params_t G_MovementParams(void) {
 
-  pm_params_t params = (pm_params_t) {
-    .gravity = g_level.gravity,
-
-    .accel_ground = g_ground_acceleration->value,
-    .accel_ground_slick = g_ground_acceleration_slick->value,
-    .accel_air = g_air_acceleration->value,
-    .accel_water = g_water_acceleration->value,
-    .accel_spectator = g_spectator_acceleration->value,
-    .accel_ladder = g_ladder_acceleration->value,
-
-    .friction_ground = g_ground_friction->value,
-    .friction_ground_slick = g_ground_friction_slick->value,
-    .friction_air = g_air_friction->value,
-    .friction_water = g_water_friction->value,
-    .friction_spectator = g_spectator_friction->value,
-    .friction_ladder = g_ladder_friction->value,
-
-    .speed_ground = g_ground_speed->value,
-    .speed_air = g_air_speed->value,
-    .speed_water = g_water_speed->value,
-    .speed_ladder = g_ladder_speed->value,
-    .speed_spectator = g_spectator_speed->value,
-    .speed_stop = g_stop_speed->value,
-    .speed_jump = g_jump_speed->value,
-    .speed_ducked = g_duck_speed->value,
-    .speed_duck_stand = g_duck_stand_speed->value,
-    .speed_water_jump = g_water_jump_speed->value,
-
-    // no cvars for these, unlike every other parameter here: a box is a shape
-    // rather than a scalar, and one a server could only move by its top would
-    // leave the rendered model, sized from PM_BOUNDS, disagreeing with the hull.
-    // A mod that wants another shape writes these three
-    .bounds = PM_BOUNDS,
-    .bounds_ducked = PM_CROUCHED_BOUNDS,
-    .bounds_dead = PM_DEAD_BOUNDS,
-    .movement = g_level.movement,
-  };
-
-  // every movement but Quetoo's is defined by its own parameters rather than by
-  // this server's cvars: one that drifted with a cvar would not be a movement
-  // anyone could set a comparable record under
   const pm_movement_info_t *movement = Pm_Movement(g_level.movement);
-  if (movement && movement->params) {
+  pm_params_t params;
+
+  if (movement->params) {
     params = *movement->params;
-    params.movement = g_level.movement;
+  } else {
+    params = (pm_params_t) {
+      .gravity = DEFAULT_GRAVITY,
+
+      .accel_ground = g_ground_acceleration->value,
+      .accel_ground_slick = g_ground_acceleration_slick->value,
+      .accel_air = g_air_acceleration->value,
+      .accel_water = g_water_acceleration->value,
+      .accel_spectator = g_spectator_acceleration->value,
+      .accel_ladder = g_ladder_acceleration->value,
+
+      .friction_ground = g_ground_friction->value,
+      .friction_ground_slick = g_ground_friction_slick->value,
+      .friction_air = g_air_friction->value,
+      .friction_water = g_water_friction->value,
+      .friction_spectator = g_spectator_friction->value,
+      .friction_ladder = g_ladder_friction->value,
+
+      .speed_ground = g_ground_speed->value,
+      .speed_air = g_air_speed->value,
+      .speed_water = g_water_speed->value,
+      .speed_ladder = g_ladder_speed->value,
+      .speed_spectator = g_spectator_speed->value,
+      .speed_stop = g_stop_speed->value,
+      .speed_jump = g_jump_speed->value,
+      .speed_ducked = g_duck_speed->value,
+      .speed_duck_stand = g_duck_stand_speed->value,
+      .speed_water_jump = g_water_jump_speed->value,
+
+      .bounds = PM_BOUNDS,
+      .bounds_ducked = PM_CROUCHED_BOUNDS,
+      .bounds_dead = PM_DEAD_BOUNDS,
+    };
+  }
+
+  params.movement = g_level.movement;
+
+  if (g_level.gravity) {
+    params.gravity = g_level.gravity;
   }
 
   return params;
+}
+
+/**
+ * @brief The gravity in effect: the level's, if `g_gravity`, the map's metadata
+ * or its worldspawn set one, and otherwise the movement's own.
+ */
+float G_LevelGravity(void) {
+
+  if (g_level.gravity) {
+    return g_level.gravity;
+  }
+
+  const pm_movement_info_t *movement = Pm_Movement(g_level.movement);
+
+  return movement->params ? movement->params->gravity : DEFAULT_GRAVITY;
 }
 
 /**

--- a/src/game/common/g_main.c
+++ b/src/game/common/g_main.c
@@ -987,6 +987,8 @@ void G_Init(void) {
 
   G_Module_Init();
 
+  ge.ClipEntity = G_ClipEntity;
+
   for (int32_t i = 0; i < sv_max_clients->integer; i++) {
     ge.clients[i] = gi.Malloc(sizeof(g_client_t), MEM_TAG_GAME);
     ge.clients[i]->ps.client = i;
@@ -1286,7 +1288,6 @@ g_export_t *G_LoadGame(g_import_t *import) {
   ge.Frame = G_Frame;
 
   ge.GameName = G_GameName;
-  ge.ClipEntity = G_ExportClipEntity;
 
   return &ge;
 }

--- a/src/game/common/g_main.h
+++ b/src/game/common/g_main.h
@@ -29,6 +29,7 @@ extern g_level_t g_level;
 extern g_media_t g_media;
 
 pm_params_t G_MovementParams(void);
+float G_LevelGravity(void);
 pm_movement_t G_ResolveMovement(const char *name);
 
 extern g_import_t gi;

--- a/src/game/common/g_module.h
+++ b/src/game/common/g_module.h
@@ -279,13 +279,15 @@ extern PrepareMove G_PrepareMove;
 
 /**
  * @brief Decides whether `ent` clips a trace made on behalf of `mover`, after the
- * server has applied its own skip rules. The default clips everything.
- * @details Chainable. A feature that makes an entity solid to some movers and not
- * others, such as a one-way wall, returns false for the movers it lets through
- * and defers to previous otherwise. `mover` is `NULL` for a trace with no
- * entity behind it. An implementation MUST be pure: the server and the client
- * both call it, from `Sv_Trace` and `Cl_Trace`, and speculative traces such as
- * the bots' lookahead run it many times for a move that never happens.
+ * server has applied its own skip rules. There is no tail: the chain is `NULL`
+ * until a feature installs a link, and the server does not call an empty one.
+ * @details Chainable; a link whose previous is `NULL` treats it as true. A
+ * feature that makes an entity solid to some movers and not others, such as a
+ * one-way wall, returns false for the movers it lets through and defers to
+ * previous otherwise. `mover` is `NULL` for a trace with no entity behind it.
+ * An implementation MUST be pure: the server and the client both call it, from
+ * `Sv_Trace` and `Cl_Trace`, and speculative traces such as the bots' lookahead
+ * run it many times for a move that never happens.
  */
 typedef bool (*ClipEntity)(const g_entity_t *mover, const g_entity_t *ent, const vec3_t start, const vec3_t end, const box3_t bounds);
 

--- a/src/game/common/g_module.h
+++ b/src/game/common/g_module.h
@@ -250,12 +250,11 @@ extern TossInventory G_TossInventory;
  * further down the chain. A feature that forbids an attack entirely, one in
  * which players never hurt each other, say, returns false without calling
  * previous, and `G_Damage` does nothing at all: no pain, no blood, no knockback.
- * A link that calls previous MUST return false when previous does.
- * `dmg->inflictor` and `dmg->attacker` are resolved to the world entity when the
- * attack had none.
+ * A link that calls previous MUST return false when previous does. `attacker`
+ * is the world entity when the attack had none.
  * @return False to abort the attack.
  */
-typedef bool (*ModifyDamage)(const g_damage_t *dmg, int32_t *damage, int32_t *knockback);
+typedef bool (*ModifyDamage)(g_entity_t *target, g_entity_t *attacker, int32_t *damage, int32_t *knockback);
 
 extern ModifyDamage G_ModifyDamage;
 

--- a/src/game/common/g_physics.c
+++ b/src/game/common/g_physics.c
@@ -308,7 +308,7 @@ static void G_Accelerate(g_entity_t *ent, const vec3_t dir, float speed, float a
 static void G_Gravity(g_entity_t *ent) {
 
   if (ent->ground.ent == NULL) {
-    float gravity = g_level.gravity;
+    float gravity = G_LevelGravity();
 
     if (ent->water_level) {
       gravity *= PM_GRAVITY_WATER;

--- a/src/game/common/g_tech.c
+++ b/src/game/common/g_tech.c
@@ -99,10 +99,7 @@ static const g_item_t *G_ResolveInventoryItem_Tech(g_client_t *cl, const char *n
  * previous so that the three keep the order they had before resist and strength
  * were a hook.
  */
-static bool G_ModifyDamage_Tech(const g_damage_t *dmg, int32_t *damage, int32_t *knockback) {
-
-  g_entity_t *const target = dmg->target;
-  g_entity_t *const attacker = dmg->attacker;
+static bool G_ModifyDamage_Tech(g_entity_t *target, g_entity_t *attacker, int32_t *damage, int32_t *knockback) {
 
   if (target->client && G_HasTech(target->client, TECH_RESIST)) {
     *damage *= TECH_RESIST_DAMAGE_FACTOR;
@@ -111,7 +108,7 @@ static bool G_ModifyDamage_Tech(const g_damage_t *dmg, int32_t *damage, int32_t 
     G_PlayTechSound(target->client);
   }
 
-  if (!previous.ModifyDamage(dmg, damage, knockback)) {
+  if (!previous.ModifyDamage(target, attacker, damage, knockback)) {
     return false;
   }
 

--- a/src/game/race/g_race.c
+++ b/src/game/race/g_race.c
@@ -657,17 +657,17 @@ static void G_TossInventory_Race(g_client_t *cl) {
  * anything else keeps its knockback and loses its damage, which is what a
  * rocket jump needs and a lava pit does not get.
  */
-static bool G_ModifyDamage_Race(const g_damage_t *dmg, int32_t *damage, int32_t *knockback) {
+static bool G_ModifyDamage_Race(g_entity_t *target, g_entity_t *attacker, int32_t *damage, int32_t *knockback) {
 
-  if (!dmg->target->client) {
-    return previous.ModifyDamage(dmg, damage, knockback);
+  if (!target->client) {
+    return previous.ModifyDamage(target, attacker, damage, knockback);
   }
 
-  if (dmg->attacker->client && dmg->attacker != dmg->target) {
+  if (attacker->client && attacker != target) {
     return false;
   }
 
-  if (!previous.ModifyDamage(dmg, damage, knockback)) {
+  if (!previous.ModifyDamage(target, attacker, damage, knockback)) {
     return false;
   }
 

--- a/src/game/race/g_race.c
+++ b/src/game/race/g_race.c
@@ -625,7 +625,7 @@ static bool G_ClipEntity_Race(const g_entity_t *mover, const g_entity_t *ent, co
     return false;
   }
 
-  return previous.ClipEntity(mover, ent, start, end, bounds);
+  return previous.ClipEntity ? previous.ClipEntity(mover, ent, start, end, bounds) : true;
 }
 
 /**

--- a/src/server/sv_world.c
+++ b/src/server/sv_world.c
@@ -471,12 +471,12 @@ static void Sv_ClipTraceToEntity(sv_trace_t *trace, const g_entity_t *ent) {
     }
   }
 
-  if (!svs.game->ClipEntity(trace->skip, ent, trace->start, trace->end, trace->bounds)) {
+  const int32_t head_node = Sv_HullForEntity(ent);
+  if (head_node == -1) {
     return;
   }
 
-  const int32_t head_node = Sv_HullForEntity(ent);
-  if (head_node == -1) {
+  if (svs.game->ClipEntity && !svs.game->ClipEntity(trace->skip, ent, trace->start, trace->end, trace->bounds)) {
     return;
   }
 


### PR DESCRIPTION
Items 1-5 of the review of everything that changed in pre-existing `.c`/`.h` files since #975 (#963). One commit per item.

1. **`pm_move_t.Accelerate` removed.** A sampling callback threaded through all five kernels for a training aid that does not exist; nothing assigned it.
2. **`ClipEntity` is opt-in.** The chain has no tail: `G_ClipEntity`/`Cg_ClipEntity` are NULL until a module installs a link, `G_Init`/`Cg_Init` export whatever is installed after module init, and the engine guards the pointer - so Default/CTF/Lithium no longer pay a cross-module call per entity per trace. The export trampolines go away; the server asks after the hull check.
3. **`cgi.Clip`** (`Cl_Clip`, reciprocal of `Sv_Clip`), and prediction traces on behalf of `cgi.client->entity`. The race client's one-way-wall probe becomes the one-liner the server has, the re-entrancy sentinel from #1006 is gone, and the client can mirror the server's "no mover, so solid" rule. `CGAME_API_VERSION` 37.
4. **`ModifyDamage`** is back to `(target, attacker, damage*, knockback*)` returning `bool`. Call ordering in `G_Damage` unchanged.
5. **Level gravity reaches every movement.** `G_MovementParams` branches first (Quetoo from cvars, the rest from their params) and applies the level's gravity over the movement's. `g_level.gravity == 0` now means unset (it was forced to 800), so the movement's own applies unless `g_gravity`, map metadata or worldspawn set one; `G_LevelGravity()` for readers outside pmove. A worldspawn `gravity 0` is warned about, since zero is now "unset".

`ClientDidChat` stays, per discussion - note it is a *Did* hook, so muzzling would need a `ClientWillChat` returning `bool`.

Verified: full build clean; `make check` 20/20 (`--with-tests`); `racetest` under race and `edge` under default load headlessly with the established entity counts (10 / 80). Read-only review pass applied (zero-gravity sentinel guard, NULL-mover recursion guard, orphaned comment). Not lap-tested with a client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)