### PR TITLE
Tighten the hook APIs from the #963 sweep, part 2

### DIFF
--- a/src/cgame/common/cg_hud.c
+++ b/src/cgame/common/cg_hud.c
@@ -123,61 +123,40 @@ void Cg_DrawPickup(const player_state_t *ps) {
 }
 
 /**
- * @brief Draws the player's frag count in the top-right corner of the HUD.
+ * @brief Reserves a stat row without drawing it, so that a spectator sees the
+ * rows below it where a player would.
  */
-int32_t Cg_DrawFrags(const player_state_t *ps, int32_t y) {
-  const int16_t frags = ps->stats[STAT_FRAGS];
-  int32_t x, cw, ch;
+static int32_t Cg_ReserveStat(int32_t y) {
+  int32_t ch;
 
   cgi.BindFont("small", NULL, &ch);
-
-  if (ps->stats[STAT_SPECTATOR] && !ps->stats[STAT_CHASE]) {
-    cgi.BindFont(NULL, NULL, NULL);
-    return y + HUD_PIC_HEIGHT + ch;
-  }
-
-  x = cgi.context->w - cgi.StringWidth("Frags");
-
-  cgi.Draw2DString(x, y, "Frags", color_green);
-
-  cgi.BindFont("large", &cw, NULL);
-
-  x = cgi.context->w - 3 * cw;
-
-  cgi.Draw2DString(x, y + ch, va("%3d", frags), HUD_COLOR_STAT);
-
   cgi.BindFont(NULL, NULL, NULL);
 
   return y + HUD_PIC_HEIGHT + ch;
 }
 
 /**
+ * @brief Draws the player's frag count in the top-right corner of the HUD.
+ */
+int32_t Cg_DrawFrags(const player_state_t *ps, int32_t y) {
+
+  if (ps->stats[STAT_SPECTATOR] && !ps->stats[STAT_CHASE]) {
+    return Cg_ReserveStat(y);
+  }
+
+  return Cg_DrawStat(y, "Frags", ps->stats[STAT_FRAGS]);
+}
+
+/**
  * @brief Draws the player's death count in the top-right corner of the HUD.
  */
 int32_t Cg_DrawDeaths(const player_state_t *ps, int32_t y) {
-  const int16_t deaths = ps->stats[STAT_DEATHS];
-  int32_t x, cw, ch;
-
-  cgi.BindFont("small", NULL, &ch);
 
   if (ps->stats[STAT_SPECTATOR] && !ps->stats[STAT_CHASE]) {
-    cgi.BindFont(NULL, NULL, NULL);
-    return y + HUD_PIC_HEIGHT + ch;
+    return Cg_ReserveStat(y);
   }
 
-  x = cgi.context->w - cgi.StringWidth("Deaths");
-
-  cgi.Draw2DString(x, y, "Deaths", color_green);
-
-  cgi.BindFont("large", &cw, NULL);
-
-  x = cgi.context->w - 3 * cw;
-
-  cgi.Draw2DString(x, y + ch, va("%3d", deaths), HUD_COLOR_STAT);
-
-  cgi.BindFont(NULL, NULL, NULL);
-
-  return y + HUD_PIC_HEIGHT + ch;
+  return Cg_DrawStat(y, "Deaths", ps->stats[STAT_DEATHS]);
 }
 
 /**

--- a/src/cgame/common/cg_hud.c
+++ b/src/cgame/common/cg_hud.c
@@ -369,6 +369,8 @@ void Cg_DrawHud(const player_state_t *ps) {
     Cg_DrawTime(ps, layout.stat_y);
   }
 
+  Cg_Vote_Draw();
+
   Cg_DrawCenterPrint(ps);
 
   Cg_DrawTargetName(ps);

--- a/src/cgame/common/cg_hud_draw.c
+++ b/src/cgame/common/cg_hud_draw.c
@@ -109,6 +109,23 @@ void Cg_DrawVital(int32_t x, int32_t ch, const int16_t value, const r_image_t *i
 }
 
 /**
+ * @see cg_hud_draw.h
+ */
+int32_t Cg_DrawStat(int32_t y, const char *label, int32_t value) {
+  int32_t cw, ch;
+
+  cgi.BindFont("small", NULL, &ch);
+  cgi.Draw2DString(cgi.context->w - cgi.StringWidth(label), y, label, color_green);
+
+  cgi.BindFont("large", &cw, NULL);
+  cgi.Draw2DString(cgi.context->w - 3 * cw, y + ch, va("%3d", value), HUD_COLOR_STAT);
+
+  cgi.BindFont(NULL, NULL, NULL);
+
+  return y + HUD_PIC_HEIGHT + ch;
+}
+
+/**
  * @brief Draws the powerup and the time remaining
  */
 int32_t Cg_DrawPowerup(int32_t y, const int16_t value, const r_image_t *icon, const int32_t ch) {

--- a/src/cgame/common/cg_hud_draw.h
+++ b/src/cgame/common/cg_hud_draw.h
@@ -91,6 +91,13 @@ extern cvar_t *cg_select_weapon_interval;
 void Cg_DrawIcon(const int32_t x, const int32_t y, const r_image_t *image, const color_t color);
 void Cg_DrawVital(int32_t x, int32_t ch, const int16_t value, const r_image_t *icon, int16_t med, int16_t low);
 int32_t Cg_DrawPowerup(int32_t y, const int16_t value, const r_image_t *icon, const int32_t ch);
+
+/**
+ * @brief Draws a stat row in the right-hand column: the label small, the value
+ * large beneath it.
+ * @return The y of the next stat row.
+ */
+int32_t Cg_DrawStat(int32_t y, const char *label, int32_t value);
 void Cg_DrawBlend(const player_state_t *ps);
 void Cg_DrawCrosshair(const player_state_t *ps);
 void Cg_DrawCenterPrint(const player_state_t *ps);

--- a/src/cgame/common/cg_module.h
+++ b/src/cgame/common/cg_module.h
@@ -113,8 +113,8 @@ void Cg_Module_Shutdown(void);
  * owns every element: nothing it declines to call gets drawn.
  *
  * What this does not decide is the framing - the `cg_draw_hud` cvar, the
- * intermission, the crosshair, the editor, the clock beneath the stat column, and
- * the overlays that place themselves. `Cg_DrawHud` keeps those, so that a module
+ * intermission, the crosshair, the editor, the clock beneath the stat column, the
+ * vote in progress, and the overlays that place themselves. `Cg_DrawHud` keeps those, so that a module
  * cannot lose the damage blend or the hit sound by forgetting to draw them. A
  * module that wants the clock somewhere else overrides `cg_hud.c` outright, which
  * vpath has always allowed.

--- a/src/cgame/common/cg_score.c
+++ b/src/cgame/common/cg_score.c
@@ -21,10 +21,6 @@
 
 #include "cg_local.h"
 
-#define SCORES_COL_WIDTH 240
-#define SCORES_ROW_HEIGHT 48
-#define SCORES_ICON_WIDTH 48
-
 typedef struct {
   g_score_t scores[MAX_CLIENTS + MAX_TEAMS];
   size_t num_scores;
@@ -105,23 +101,61 @@ void Cg_ClearScores(void) {
 }
 
 /**
+ * @see cg_score.h
+ */
+int32_t Cg_DrawScoresTitle(void) {
+  int32_t ch;
+
+  cgi.BindFont("medium", NULL, &ch);
+
+  const int32_t y = 64 - ch - 4;
+  const char *title = cgi.ConfigString(CS_MESSAGE);
+
+  cgi.Draw2DString((cgi.context->w - cgi.StringWidth(title)) / 2, y, title, color_white);
+
+  cgi.BindFont(NULL, NULL, NULL);
+
+  return y + ch;
+}
+
+/**
+ * @see cg_score.h
+ */
+int32_t Cg_DrawScoreRow(int32_t x, int32_t y, int32_t width, const g_score_t *s) {
+  int32_t cw, ch;
+
+  const cg_client_info_t *info = &cg_state.clients[s->client];
+
+  cgi.Draw2DImage(x + 1, y + 1, SCORES_ICON_WIDTH - 2, SCORES_ICON_WIDTH - 2, info->icon, color_white);
+
+  x += SCORES_ICON_WIDTH;
+
+  const int32_t fw = width - SCORES_ICON_WIDTH - 1;
+
+  if (s->color >= 0) {
+    color_t c = ColorHSV(s->color, 1.f, 1.f);
+    c.a = s->client == cgi.client->frame.ps.client ? .3f : .15f;
+
+    cgi.Draw2DFill(x, y, fw, SCORES_ROW_HEIGHT - 1, c);
+  }
+
+  cgi.BindFont("small", &cw, &ch);
+
+  cgi.Draw2DString(x, y, info->name, color_white);
+  cgi.Draw2DString(x + fw + 1 - 6 * cw, y, va("%3dms", s->ping), color_white);
+
+  cgi.BindFont(NULL, NULL, NULL);
+
+  return y + ch;
+}
+
+/**
  * @brief Returns the vertical screen coordinate where scores should be drawn.
  */
 static int32_t Cg_DrawScoresHeader(void) {
-  int32_t cw, ch, x, y;
+  int32_t cw, ch, x;
 
-  cgi.BindFont("medium", &cw, &ch);
-
-  y = 64 - ch - 4;
-
-  const char *title = cgi.ConfigString(CS_MESSAGE);
-  const int32_t sw = cgi.StringWidth(title);
-
-  // map title
-  x = cgi.context->w / 2 - sw / 2;
-  cgi.Draw2DString(x, y, title, color_white);
-
-  y += ch;
+  int32_t y = Cg_DrawScoresTitle();
 
   // team names and scores
   if (cg_state.num_teams) {
@@ -156,47 +190,28 @@ static int32_t Cg_DrawScoresHeader(void) {
  * @brief Draws a single player score row including icon, name, frags, deaths, and captures.
  */
 static bool Cg_DrawScore(int32_t x, int32_t y, const g_score_t *s) {
-  int32_t cw, ch;
-
-  const cg_client_info_t *info = &cg_state.clients[s->client];
-
-  // icon
-  cgi.Draw2DImage(x + 1, y + 1, SCORES_ICON_WIDTH - 2, SCORES_ICON_WIDTH - 2, info->icon, color_white);
+  int32_t ch;
 
 #if defined(G_CTF)
-  // flag carrier icon
+  const int32_t top = y;
+#endif
+
+  y = Cg_DrawScoreRow(x, y, SCORES_COL_WIDTH, s);
+
+#if defined(G_CTF)
+  // flag carrier icon, over the corner of the player's
   if (s->flags & SCORE_CTF_FLAG) {
     const int32_t team = s->team;
     const r_image_t *flag = cgi.LoadImage(va("pics/i_flag%d", team), IMG_PIC);
-    cgi.Draw2DImage(x + 1, y + 1, SCORES_ICON_WIDTH * 0.3f, SCORES_ICON_WIDTH * .3f, flag, color_white);
+    cgi.Draw2DImage(x + 1, top + 1, SCORES_ICON_WIDTH * 0.3f, SCORES_ICON_WIDTH * .3f, flag, color_white);
   }
 #endif
 
   x += SCORES_ICON_WIDTH;
 
-  // background
-  const float fa = s->client == cgi.client->frame.ps.client ? 0.3 : 0.15;
   const int32_t fw = SCORES_COL_WIDTH - SCORES_ICON_WIDTH - 1;
-  const int32_t fh = SCORES_ROW_HEIGHT - 1;
 
-  if (s->color != 0) {
-    color_t c = ColorHSV(s->color, 1.0, 1.0);
-    c.a = fa;
-
-    cgi.Draw2DFill(x, y, fw, fh, c);
-  }
-
-  cgi.BindFont("small", &cw, &ch);
-
-  // name
-  cgi.Draw2DString(x, y, info->name, color_white);
-
-  // ping
-  {
-    const int32_t px = x + SCORES_COL_WIDTH - SCORES_ICON_WIDTH - 6 * cw;
-    cgi.Draw2DString(px, y, va("%3dms", s->ping), color_white);
-    y += ch;
-  }
+  cgi.BindFont("small", NULL, &ch);
 
   // spectating
   if (s->flags & SCORE_SPECTATOR) {

--- a/src/cgame/common/cg_score.h
+++ b/src/cgame/common/cg_score.h
@@ -24,6 +24,11 @@
 #include "cg_types.h"
 
 #if defined(__CG_LOCAL_H__)
+
+#define SCORES_COL_WIDTH 240
+#define SCORES_ROW_HEIGHT 48
+#define SCORES_ICON_WIDTH 48
+
 void Cg_ParseScores(void);
 void Cg_ClearScores(void);
 
@@ -31,4 +36,17 @@ void Cg_ClearScores(void);
  * @brief The scores as last parsed, sorted, for a module drawing its own board.
  */
 const g_score_t *Cg_Scores(size_t *count);
+
+/**
+ * @brief Draws the map's title across the top of the board.
+ * @return The y beneath it.
+ */
+int32_t Cg_DrawScoresTitle(void);
+
+/**
+ * @brief Draws what every board's row begins with: the icon, the team fill
+ * across `width`, the name and the ping.
+ * @return The y of the row's second line, whose x is `x + SCORES_ICON_WIDTH`.
+ */
+int32_t Cg_DrawScoreRow(int32_t x, int32_t y, int32_t width, const g_score_t *s);
 #endif

--- a/src/cgame/common/cg_vote.c
+++ b/src/cgame/common/cg_vote.c
@@ -24,7 +24,6 @@
 
 static struct {
   ParseConfigString ParseConfigString;
-  DrawHudElements DrawHudElements;
 } previous;
 
 /**
@@ -90,11 +89,9 @@ static bool Cg_ParseConfigString_Vote(int32_t index) {
 }
 
 /**
- * @brief Draws the vote in progress beneath the center of the screen.
+ * @see cg_vote.h
  */
-static void Cg_DrawHudElements_Vote(const player_state_t *ps, cg_hud_layout_t *layout) {
-
-  previous.DrawHudElements(ps, layout);
+void Cg_Vote_Draw(void) {
 
   if (!cg_state.vote.active) {
     return;
@@ -152,8 +149,6 @@ void Cg_Vote_Init(void) {
   previous.ParseConfigString = Cg_ParseConfigString;
   Cg_ParseConfigString = Cg_ParseConfigString_Vote;
 
-  previous.DrawHudElements = Cg_DrawHudElements;
-  Cg_DrawHudElements = Cg_DrawHudElements_Vote;
 
   installed = true;
 }

--- a/src/cgame/common/cg_vote.h
+++ b/src/cgame/common/cg_vote.h
@@ -25,6 +25,12 @@
 
 #if defined(__CG_LOCAL_H__)
 void Cg_Vote_Init(void);
+
+/**
+ * @brief Draws the vote in progress beneath the center of the screen. Framing,
+ * drawn by `Cg_DrawHud` so that a module arranging its own HUD cannot lose it.
+ */
+void Cg_Vote_Draw(void);
 void Cg_Vote_Cast(bool yes);
 void Cg_Vote_Call(const char *type, const char *arg);
 #endif

--- a/src/cgame/race/cg_race_hud.c
+++ b/src/cgame/race/cg_race_hud.c
@@ -88,24 +88,6 @@ static void Cg_Race_DrawRun(const player_state_t *ps) {
 }
 
 /**
- * @brief A stat row in the right-hand column, in the shape of the frags and
- * deaths it stands in for: the label small, the value large beneath it.
- */
-static int32_t Cg_Race_DrawStat(int32_t y, const char *label, int32_t value) {
-  int32_t cw, ch;
-
-  cgi.BindFont("small", NULL, &ch);
-  cgi.Draw2DString(cgi.context->w - cgi.StringWidth(label), y, label, color_green);
-
-  cgi.BindFont("large", &cw, NULL);
-  cgi.Draw2DString(cgi.context->w - 3 * cw, y + ch, va("%3d", value), HUD_COLOR_STAT);
-
-  cgi.BindFont(NULL, NULL, NULL);
-
-  return y + HUD_PIC_HEIGHT + ch;
-}
-
-/**
  * @brief The horizontal speed, smoothed over frames.
  */
 static int32_t Cg_Race_DrawSpeed(const player_state_t *ps, int32_t y) {
@@ -115,7 +97,7 @@ static int32_t Cg_Race_DrawSpeed(const player_state_t *ps, int32_t y) {
 
   cg_race_speed += (Vec3_Length(velocity) - cg_race_speed) * RACE_HUD_SPEED_LERP;
 
-  return Cg_Race_DrawStat(y, "Speed", (int32_t) cg_race_speed);
+  return Cg_DrawStat(y, "Speed", (int32_t) cg_race_speed);
 }
 
 void Cg_Race_DrawHud(const player_state_t *ps, cg_hud_layout_t *layout) {
@@ -137,5 +119,5 @@ void Cg_Race_DrawHud(const player_state_t *ps, cg_hud_layout_t *layout) {
   Cg_Race_DrawRun(ps);
 
   layout->stat_y = Cg_Race_DrawSpeed(ps, layout->stat_y);
-  layout->stat_y = Cg_Race_DrawStat(layout->stat_y, "Runs", ps->stats[STAT_RACE_RUNS]);
+  layout->stat_y = Cg_DrawStat(layout->stat_y, "Runs", ps->stats[STAT_RACE_RUNS]);
 }

--- a/src/cgame/race/cg_race_score.c
+++ b/src/cgame/race/cg_race_score.c
@@ -28,12 +28,8 @@
  * their best on this map and their runs, in the order the server ranked them.
  */
 
+// wider than the common board's column, for a best time beside a run count
 #define RACE_SCORES_COL_WIDTH 280
-#define RACE_SCORES_ROW_HEIGHT 48
-#define RACE_SCORES_ICON_WIDTH 48
-
-// the most records the config string carries, as the server publishes it
-#define RACE_SCORES_RECORDS 15
 
 static const char *Cg_Race_ModeName(g_race_mode_t mode) {
 
@@ -45,25 +41,6 @@ static const char *Cg_Race_ModeName(g_race_mode_t mode) {
     default:
       return "spectating";
   }
-}
-
-/**
- * @brief The map's title across the top, as the common board has it.
- * @return The y beneath it.
- */
-static int32_t Cg_Race_DrawScoresHeader(void) {
-  int32_t ch;
-
-  cgi.BindFont("medium", NULL, &ch);
-
-  const int32_t y = 64 - ch - 4;
-  const char *title = cgi.ConfigString(CS_MESSAGE);
-
-  cgi.Draw2DString((cgi.context->w - cgi.StringWidth(title)) / 2, y, title, color_white);
-
-  cgi.BindFont(NULL, NULL, NULL);
-
-  return y + ch;
 }
 
 /**
@@ -87,7 +64,7 @@ static void Cg_Race_DrawRecords(int32_t x, int32_t y) {
   }
 
   char *s = string;
-  for (int32_t rank = 1; rank <= RACE_SCORES_RECORDS && *s; rank++) {
+  for (int32_t rank = 1; rank <= RACE_RECORDS_SHOWN && *s; rank++) {
 
     char *name = s;
     char *time = strchr(name, '\\');
@@ -114,32 +91,17 @@ static void Cg_Race_DrawRecords(int32_t x, int32_t y) {
 }
 
 /**
- * @brief One racer: their icon and name with their ping, then what they are
- * doing, their best and their runs.
+ * @brief One racer: the row every board begins with, then what they are doing,
+ * their best and their runs.
  */
 static void Cg_Race_DrawScore(int32_t x, int32_t y, const g_score_t *s) {
-  int32_t cw, ch;
 
-  const cg_client_info_t *info = &cg_state.clients[s->client];
+  y = Cg_DrawScoreRow(x, y, RACE_SCORES_COL_WIDTH, s);
+  x += SCORES_ICON_WIDTH;
 
-  cgi.Draw2DImage(x + 1, y + 1, RACE_SCORES_ICON_WIDTH - 2, RACE_SCORES_ICON_WIDTH - 2, info->icon, color_white);
+  const int32_t fw = RACE_SCORES_COL_WIDTH - SCORES_ICON_WIDTH - 1;
 
-  x += RACE_SCORES_ICON_WIDTH;
-
-  const int32_t fw = RACE_SCORES_COL_WIDTH - RACE_SCORES_ICON_WIDTH - 1;
-
-  if (s->color >= 0) {
-    color_t c = ColorHSV(s->color, 1.f, 1.f);
-    c.a = s->client == cgi.client->frame.ps.client ? .3f : .15f;
-
-    cgi.Draw2DFill(x, y, fw, RACE_SCORES_ROW_HEIGHT - 1, c);
-  }
-
-  cgi.BindFont("small", &cw, &ch);
-
-  cgi.Draw2DString(x, y, info->name, color_white);
-  cgi.Draw2DString(x + fw - 5 * cw, y, va("%3dms", s->ping), color_white);
-  y += ch;
+  cgi.BindFont("small", NULL, NULL);
 
   cgi.Draw2DString(x, y, Cg_Race_ModeName(s->race_mode), color_white);
 
@@ -159,8 +121,8 @@ void Cg_Race_DrawScores(const player_state_t *ps) {
     return;
   }
 
-  const int32_t start_y = Cg_Race_DrawScoresHeader();
-  const int32_t gap = RACE_SCORES_ICON_WIDTH / 2;
+  const int32_t start_y = Cg_DrawScoresTitle();
+  const int32_t gap = SCORES_ICON_WIDTH / 2;
 
   const int32_t left = cgi.context->w / 2 - RACE_SCORES_COL_WIDTH - gap / 2;
   const int32_t right = cgi.context->w / 2 + gap / 2;
@@ -171,11 +133,11 @@ void Cg_Race_DrawScores(const player_state_t *ps) {
   const g_score_t *scores = Cg_Scores(&count);
 
   // a second column of racers opens to the right once the first is full
-  const size_t rows = Maxz(3, (cgi.context->h - 2 * start_y) / RACE_SCORES_ROW_HEIGHT);
+  const size_t rows = Maxz(3, (cgi.context->h - 2 * start_y) / SCORES_ROW_HEIGHT);
 
   for (size_t i = 0; i < count && i < 2 * rows; i++) {
     const int32_t x = right + (int32_t) (i / rows) * (RACE_SCORES_COL_WIDTH + gap);
-    const int32_t y = start_y + (int32_t) (i % rows) * RACE_SCORES_ROW_HEIGHT;
+    const int32_t y = start_y + (int32_t) (i % rows) * SCORES_ROW_HEIGHT;
 
     Cg_Race_DrawScore(x, y, &scores[i]);
   }

--- a/src/game/common/bg_pmove.c
+++ b/src/game/common/bg_pmove.c
@@ -63,7 +63,7 @@ box3_t Pm_Bounds(const pm_params_t *params, bool ducked) {
  * the server's movement cvars, which is what makes it the default.
  */
 static const pm_movement_info_t pm_movements[] = {
-  [PM_MOVEMENT_QUETOO] = { .name = "quetoo", .label = "Quetoo",      .params = NULL },
+  [PM_MOVEMENT_QUETOO] = { .name = "quetoo", .label = "Quetoo",      .params = NULL, .hook = true },
   [PM_MOVEMENT_RACE]   = { .name = "race",   .label = "Quetoo Race", .params = &pm_race_params },
   [PM_MOVEMENT_QUAKE]  = { .name = "quake",  .label = "Quake",       .params = &pm_quake_params },
   [PM_MOVEMENT_QUAKE2] = { .name = "quake2", .label = "Quake2",      .params = &pm_quake2_params },

--- a/src/game/common/bg_pmove.h
+++ b/src/game/common/bg_pmove.h
@@ -237,6 +237,13 @@ typedef struct {
    * move it would not be a movement anyone could set a record under.
    */
   const pm_params_t *params;
+
+  /**
+   * @brief Whether this movement implements the `PM_HOOK_*` types and honours
+   * `hook_length`, so that the grapple has something to swing on. A movement
+   * ported from another game does not, and the hook feature stays out of it.
+   */
+  bool hook;
 } pm_movement_info_t;
 
 /**

--- a/src/game/common/bg_pmove.h
+++ b/src/game/common/bg_pmove.h
@@ -214,6 +214,31 @@ typedef struct pm_move_s {
 } pm_move_t;
 
 /**
+ * @brief The movements `Pm_Move` can run, selected per-player through
+ * `pm_params_t.movement`, which carries one of these as a byte.
+ * @details One of these owns everything about how a player moves once the move
+ * is initialized: the ground, water and duck checks, the slide and the step, and
+ * the parameters it moves by. Each lives in its own `bg_pmove_*.c` and is
+ * finished rather than maintained, so that a movement a record was set under
+ * cannot drift. This changes how a player moves, not how the world behaves.
+ *
+ * These values are networked. The list is append-only: an id names a movement
+ * forever, and reordering it would silently put every client on a different
+ * one. It is the name `g_movement`, the worldspawn `movement` key and the menu
+ * all use. Every movement is in this tree and available to every module, so
+ * there is no module-defined range: unlike `CS_GAME` or `EF_GAME`, which the
+ * engine forwards without interpreting, an id has to resolve to code that
+ * both the game and the client game hold.
+ */
+typedef enum {
+  PM_MOVEMENT_QUETOO,
+  PM_MOVEMENT_RACE,
+  PM_MOVEMENT_QUAKE,
+  PM_MOVEMENT_QUAKE2,
+  PM_MOVEMENT_QUAKE3,
+} pm_movement_t;
+
+/**
  * @brief One movement: the name it answers to, and the parameters that define
  * it.
  */

--- a/src/game/common/g_hook.c
+++ b/src/game/common/g_hook.c
@@ -550,14 +550,12 @@ static void G_HookCheckFire(g_client_t *cl, const bool refire) {
 
 /**
  * @brief The tail of the `G_AllowHook` chain: every client may hook, unless the
- * movement they are running has no hook to swing on.
- * @details The hook is a Quetoo feature, and a movement ported from another game
- * neither implements the `PM_HOOK_*` types nor honours `hook_length`. Declining
- * here is how the feature stays out of a ruleset that cannot carry it, rather
- * than the ruleset having to know the feature exists.
+ * movement they are running has no hook to swing on. Declining here is how the
+ * feature stays out of a ruleset that cannot carry it, rather than the ruleset
+ * having to know the feature exists.
  */
 static bool G_AllowHook_Common(const g_client_t *cl) {
-  return g_level.movement == PM_MOVEMENT_QUETOO;
+  return Pm_Movement(g_level.movement)->hook;
 }
 
 AllowHook G_AllowHook = G_AllowHook_Common;

--- a/src/game/common/g_module.h
+++ b/src/game/common/g_module.h
@@ -292,10 +292,11 @@ typedef bool (*ClipEntity)(const g_entity_t *mover, const g_entity_t *ent, const
 
 extern ClipEntity G_ClipEntity;
 
+#if defined(G_HOOK)
 /**
  * @brief Whether a client may use the grapple hook right now. The default says
- * yes whenever the hook feature is built and enabled; a client refused here has
- * their hook detached. Exists only when the module builds `G_HOOK`.
+ * yes whenever the movement they are running has a hook; a client refused here
+ * has their hook detached.
  * @details Chainable. A mode that allows the hook only some of the time answers
  * for its cases and defers to previous.
  * @return True if the client may hook.
@@ -303,6 +304,7 @@ extern ClipEntity G_ClipEntity;
 typedef bool (*AllowHook)(const g_client_t *cl);
 
 extern AllowHook G_AllowHook;
+#endif
 
 /**
  * @}

--- a/src/game/race/g_race_records.c
+++ b/src/game/race/g_race_records.c
@@ -44,9 +44,6 @@
  * `maps.lst` entry without a name is.
  */
 
-// how many of the best are published for the scoreboard
-#define RACE_RECORDS_SHOWN 15
-
 static const char *G_Race_RecordsPath(void) {
   return va("records/%s.rec", g_level.name);
 }

--- a/src/game/race/g_types.h
+++ b/src/game/race/g_types.h
@@ -141,6 +141,9 @@ _Static_assert(STAT_RACE_RUNS < MAX_STATS, "the race stats must fit the stat arr
 // how many func_race_* brushes a level may have, one config string each
 #define RACE_MAX_BARRIERS 32
 
+// how many of a map's records CS_RACE_RECORDS carries, and the board shows
+#define RACE_RECORDS_SHOWN 15
+
 /**
  * @brief How a client is taking part. Spectating is derived from
  * `g_client_persistent_t.spectator` rather than stored, so the two cannot

--- a/src/net/net_message.c
+++ b/src/net/net_message.c
@@ -375,37 +375,11 @@ void Net_WriteDeltaPlayerState(mem_buf_t *msg, const player_state_t *from, const
   }
 
   if (bits & PS_PM_PARAMS) {
-    Net_WriteFloat(msg, to->pm_state.params.accel_ground);
-    Net_WriteFloat(msg, to->pm_state.params.accel_ground_slick);
-    Net_WriteFloat(msg, to->pm_state.params.accel_air);
-    Net_WriteFloat(msg, to->pm_state.params.accel_water);
-    Net_WriteFloat(msg, to->pm_state.params.accel_spectator);
-    Net_WriteFloat(msg, to->pm_state.params.accel_ladder);
-    Net_WriteFloat(msg, to->pm_state.params.friction_ground);
-    Net_WriteFloat(msg, to->pm_state.params.friction_ground_slick);
-    Net_WriteFloat(msg, to->pm_state.params.friction_air);
-    Net_WriteFloat(msg, to->pm_state.params.friction_water);
-    Net_WriteFloat(msg, to->pm_state.params.friction_spectator);
-    Net_WriteFloat(msg, to->pm_state.params.friction_ladder);
-    Net_WriteFloat(msg, to->pm_state.params.speed_ground);
-    Net_WriteFloat(msg, to->pm_state.params.speed_air);
-    Net_WriteFloat(msg, to->pm_state.params.speed_water);
-    Net_WriteFloat(msg, to->pm_state.params.speed_ladder);
-    Net_WriteFloat(msg, to->pm_state.params.speed_spectator);
-    Net_WriteFloat(msg, to->pm_state.params.speed_stop);
-    Net_WriteFloat(msg, to->pm_state.params.speed_jump);
-    Net_WriteFloat(msg, to->pm_state.params.speed_ducked);
-    Net_WriteFloat(msg, to->pm_state.params.speed_duck_stand);
-    Net_WriteFloat(msg, to->pm_state.params.speed_water_jump);
-    // Net_WriteBounds is the obvious call and the wrong one: it casts each
-    // component to int16, and a box quantized on the way to the client is a
-    // client predicting against a box the server did not run
-    Net_WritePosition(msg, to->pm_state.params.bounds.mins);
-    Net_WritePosition(msg, to->pm_state.params.bounds.maxs);
-    Net_WritePosition(msg, to->pm_state.params.bounds_ducked.mins);
-    Net_WritePosition(msg, to->pm_state.params.bounds_ducked.maxs);
-    Net_WritePosition(msg, to->pm_state.params.bounds_dead.mins);
-    Net_WritePosition(msg, to->pm_state.params.bounds_dead.maxs);
+    const float *params = &to->pm_state.params.accel_ground;
+
+    for (size_t i = 0; i < PM_PARAMS_FLOATS; i++) {
+      Net_WriteFloat(msg, params[i]);
+    }
   }
 
   uint32_t stat_bits = 0;
@@ -905,34 +879,11 @@ void Net_ReadDeltaPlayerState(mem_buf_t *msg, const player_state_t *from, player
   }
 
   if (bits & PS_PM_PARAMS) {
-    to->pm_state.params.accel_ground = Net_ReadFloat(msg);
-    to->pm_state.params.accel_ground_slick = Net_ReadFloat(msg);
-    to->pm_state.params.accel_air = Net_ReadFloat(msg);
-    to->pm_state.params.accel_water = Net_ReadFloat(msg);
-    to->pm_state.params.accel_spectator = Net_ReadFloat(msg);
-    to->pm_state.params.accel_ladder = Net_ReadFloat(msg);
-    to->pm_state.params.friction_ground = Net_ReadFloat(msg);
-    to->pm_state.params.friction_ground_slick = Net_ReadFloat(msg);
-    to->pm_state.params.friction_air = Net_ReadFloat(msg);
-    to->pm_state.params.friction_water = Net_ReadFloat(msg);
-    to->pm_state.params.friction_spectator = Net_ReadFloat(msg);
-    to->pm_state.params.friction_ladder = Net_ReadFloat(msg);
-    to->pm_state.params.speed_ground = Net_ReadFloat(msg);
-    to->pm_state.params.speed_air = Net_ReadFloat(msg);
-    to->pm_state.params.speed_water = Net_ReadFloat(msg);
-    to->pm_state.params.speed_ladder = Net_ReadFloat(msg);
-    to->pm_state.params.speed_spectator = Net_ReadFloat(msg);
-    to->pm_state.params.speed_stop = Net_ReadFloat(msg);
-    to->pm_state.params.speed_jump = Net_ReadFloat(msg);
-    to->pm_state.params.speed_ducked = Net_ReadFloat(msg);
-    to->pm_state.params.speed_duck_stand = Net_ReadFloat(msg);
-    to->pm_state.params.speed_water_jump = Net_ReadFloat(msg);
-    to->pm_state.params.bounds.mins = Net_ReadPosition(msg);
-    to->pm_state.params.bounds.maxs = Net_ReadPosition(msg);
-    to->pm_state.params.bounds_ducked.mins = Net_ReadPosition(msg);
-    to->pm_state.params.bounds_ducked.maxs = Net_ReadPosition(msg);
-    to->pm_state.params.bounds_dead.mins = Net_ReadPosition(msg);
-    to->pm_state.params.bounds_dead.maxs = Net_ReadPosition(msg);
+    float *params = &to->pm_state.params.accel_ground;
+
+    for (size_t i = 0; i < PM_PARAMS_FLOATS; i++) {
+      params[i] = Net_ReadFloat(msg);
+    }
   }
 
   const int32_t stat_bits = Net_ReadLong(msg);

--- a/src/net/net_message.c
+++ b/src/net/net_message.c
@@ -375,7 +375,8 @@ void Net_WriteDeltaPlayerState(mem_buf_t *msg, const player_state_t *from, const
   }
 
   if (bits & PS_PM_PARAMS) {
-    const float *params = &to->pm_state.params.accel_ground;
+    float params[PM_PARAMS_FLOATS];
+    memcpy(params, &to->pm_state.params.accel_ground, sizeof(params));
 
     for (size_t i = 0; i < PM_PARAMS_FLOATS; i++) {
       Net_WriteFloat(msg, params[i]);
@@ -879,11 +880,13 @@ void Net_ReadDeltaPlayerState(mem_buf_t *msg, const player_state_t *from, player
   }
 
   if (bits & PS_PM_PARAMS) {
-    float *params = &to->pm_state.params.accel_ground;
+    float params[PM_PARAMS_FLOATS];
 
     for (size_t i = 0; i < PM_PARAMS_FLOATS; i++) {
       params[i] = Net_ReadFloat(msg);
     }
+
+    memcpy(&to->pm_state.params.accel_ground, params, sizeof(params));
   }
 
   const int32_t stat_bits = Net_ReadLong(msg);

--- a/src/net/net_message.h
+++ b/src/net/net_message.h
@@ -34,14 +34,14 @@
 #define PS_PM_FLAGS         (1 << 5)
 #define PS_PM_TIME          (1 << 6)
 #define PS_PM_GRAVITY       (1 << 7)
-#define PS_PM_VIEW_OFFSET   (1 << 8)
-#define PS_PM_VIEW_ANGLES   (1 << 9)
-#define PS_PM_DELTA_ANGLES  (1 << 10)
-#define PS_PM_HOOK_POSITION (1 << 11)
-#define PS_PM_HOOK_LENGTH   (1 << 12)
-#define PS_PM_STEP_OFFSET   (1 << 13)
-#define PS_PM_PARAMS        (1 << 14)
-#define PS_PM_MOVEMENT      (1 << 15)
+#define PS_PM_MOVEMENT      (1 << 8)
+#define PS_PM_VIEW_OFFSET   (1 << 9)
+#define PS_PM_VIEW_ANGLES   (1 << 10)
+#define PS_PM_DELTA_ANGLES  (1 << 11)
+#define PS_PM_HOOK_POSITION (1 << 12)
+#define PS_PM_HOOK_LENGTH   (1 << 13)
+#define PS_PM_STEP_OFFSET   (1 << 14)
+#define PS_PM_PARAMS        (1 << 15)
 
 /**
  * @brief Delta compression flags for `user_cmd_t`.

--- a/src/shared/shared.h
+++ b/src/shared/shared.h
@@ -315,6 +315,8 @@ typedef struct {
 
 _Static_assert(offsetof(pm_params_t, accel_ground) == sizeof(float),
                "pm_params_t.movement must fit in the padding after gravity");
+_Static_assert(offsetof(pm_params_t, bounds_dead) + sizeof(box3_t) == sizeof(pm_params_t),
+               "pm_params_t must not end in padding, which the block would carry");
 _Static_assert(sizeof(box3_t) == 6 * sizeof(float),
                "box3_t must be six floats for pm_params_t to travel");
 

--- a/src/shared/shared.h
+++ b/src/shared/shared.h
@@ -304,25 +304,17 @@ typedef struct {
 
 /**
  * @brief This layout is the wire format. `Net_WriteDeltaPlayerState` sends
- * `gravity` and `movement` on their own bits and compares everything from
- * `accel_ground` on with one `memcmp`, so two things must stay true: `movement`
- * must keep sitting in the padding `gravity` leaves, or the compared region
- * moves, and that region must hold nothing but the floats the encoder writes,
- * or the comparison reads padding and resends the block at random. A field
- * added anywhere but the end breaks the first; a field of another width breaks
- * the second. Both are asserted rather than commented so that the build says so.
+ * `gravity` and `movement` on their own bits, and everything from `accel_ground`
+ * on as one block of `PM_PARAMS_FLOATS` floats, compared with one `memcmp` and
+ * written in a loop. So `movement` must keep sitting in the padding `gravity`
+ * leaves, or the block moves; and the block must hold nothing but floats, or
+ * the loop sends padding as a parameter. Add a float at the end and the count
+ * follows; the boxes qualify only because a `box3_t` is six plain floats.
  */
+#define PM_PARAMS_FLOATS ((sizeof(pm_params_t) - offsetof(pm_params_t, accel_ground)) / sizeof(float))
+
 _Static_assert(offsetof(pm_params_t, accel_ground) == sizeof(float),
                "pm_params_t.movement must fit in the padding after gravity");
-_Static_assert(sizeof(pm_params_t) - offsetof(pm_params_t, accel_ground) ==
-               40 * sizeof(float),
-               "the delta-compared region of pm_params_t must be floats only");
-
-/**
- * @brief And the boxes are part of that region, so they must be plain floats
- * too: a `vec3_t` that ever acquired an alignment wider than a float would pad
- * `box3_t` and put unwritten bytes inside the block `memcmp` compares.
- */
 _Static_assert(sizeof(box3_t) == 6 * sizeof(float),
                "box3_t must be six floats for pm_params_t to travel");
 

--- a/src/shared/shared.h
+++ b/src/shared/shared.h
@@ -279,31 +279,6 @@ typedef enum {
 #define PMF_GAME (1 << 0)
 
 /**
- * @brief The movements `Pm_Move` can run, selected per-player through
- * `pm_params_t.movement`.
- * @details One of these owns everything about how a player moves once the move
- * is initialized: the ground, water and duck checks, the slide and the step, and
- * the parameters it moves by. Each lives in its own `bg_pmove_*.c` and is
- * finished rather than maintained, so that a movement a record was set under
- * cannot drift. This changes how a player moves, not how the world behaves.
- *
- * These values are networked. The list is append-only: an id names a movement
- * forever, and reordering it would silently put every client on a different
- * one. It is the name `g_movement`, the worldspawn `movement` key and the menu
- * all use. Every movement is in this tree and available to every module, so
- * there is no module-defined range: unlike `CS_GAME` or `EF_GAME`, which the
- * engine forwards without interpreting, an id has to resolve to code that
- * both the game and the client game hold.
- */
-typedef enum {
-  PM_MOVEMENT_QUETOO,
-  PM_MOVEMENT_RACE,
-  PM_MOVEMENT_QUAKE,
-  PM_MOVEMENT_QUAKE2,
-  PM_MOVEMENT_QUAKE3,
-} pm_movement_t;
-
-/**
  * @brief Server-tunable player-movement parameters, networked per-player
  * inside `pm_state_t` so that client-side prediction matches the server.
  * Each field defaults to the `PM_*` constant it replaces (see bg_pmove.h).
@@ -313,7 +288,7 @@ typedef enum {
  */
 typedef struct {
   int16_t gravity;     // world gravity; default from g_gravity / map (int16)
-  uint8_t movement;      // pm_movement_t; which movement Pm_Move runs
+  uint8_t movement;    // which movement Pm_Move runs; a pm_movement_t, see bg_pmove.h
 
   float accel_ground, accel_ground_slick, accel_air, accel_water,
         accel_spectator, accel_ladder;

--- a/src/tests/check_net_message.c
+++ b/src/tests/check_net_message.c
@@ -22,6 +22,7 @@
 #include "tests.h"
 
 #include "net/net_message.h"
+#include "game/common/bg_pmove.h"
 
 quetoo_t quetoo;
 

--- a/src/tests/check_net_message.c
+++ b/src/tests/check_net_message.c
@@ -135,9 +135,9 @@ START_TEST(check_PlayerState_Params_DeltaCompressed) {
  */
 START_TEST(check_PlayerState_Movement_DeltaCompressed) {
   byte buf_a[MAX_MSG_SIZE], buf_b[MAX_MSG_SIZE];
-  mem_buf_t movement_only, everything;
+  mem_buf_t movement_only, unchanged;
   Mem_InitBuffer(&movement_only, buf_a, sizeof(buf_a));
-  Mem_InitBuffer(&everything, buf_b, sizeof(buf_b));
+  Mem_InitBuffer(&unchanged, buf_b, sizeof(buf_b));
 
   player_state_t from;
   memset(&from, 0, sizeof(from));
@@ -146,15 +146,12 @@ START_TEST(check_PlayerState_Movement_DeltaCompressed) {
   player_state_t to = from;
   to.pm_state.params.movement = PM_MOVEMENT_QUAKE; // Fill_TestParams left it elsewhere
 
-  player_state_t zero;
-  memset(&zero, 0, sizeof(zero));
-
   Net_WriteDeltaPlayerState(&movement_only, &from, &to);
-  Net_WriteDeltaPlayerState(&everything, &zero, &to);
+  Net_WriteDeltaPlayerState(&unchanged, &from, &from);
 
-  ck_assert_msg(movement_only.size < everything.size,
-                "a movement change wrote the whole parameter block (%zu vs %zu)",
-                movement_only.size, everything.size);
+  ck_assert_msg(movement_only.size == unchanged.size + 1,
+                "a movement change should cost one byte over no change (%zu vs %zu)",
+                movement_only.size, unchanged.size);
 
   movement_only.read = 0;
 


### PR DESCRIPTION
Items 6-10 of the review of pre-existing `.c`/`.h` changes since #975 (#963); follows #1009. One commit per item.

6. **The hook is a property of the movement.** `pm_movement_info_t.hook` replaces common's `g_level.movement == PM_MOVEMENT_QUETOO`; `AllowHook` is guarded by `G_HOOK` as its comment claimed.
7. **`pm_movement_t` moves to `bg_pmove.h`.** No engine TU reads it; the wire carries a byte.
8. **The vote overlay is framing.** Drawn by `Cg_DrawHud` via `Cg_Vote_Draw()` instead of chaining `DrawHudElements`, which race replaces outright and so lost votes.
9. **Shared stat row and scoreboard row.** `Cg_DrawStat` replaces three copies; `Cg_DrawScoresTitle` / `Cg_DrawScoreRow(x, y, width, s)` are public and both boards use them. Fixes the `color != 0` vs `>= 0` drift the right way (`-1` is "no colour", `0` is red; the common board was painting spectators). `RACE_RECORDS_SHOWN` shared with the client.
10. **`PS_PM_PARAMS` as a float loop** over `PM_PARAMS_FLOATS`; the hand-counted 40 assert goes; `PS_PM_MOVEMENT` renumbered to bit 8 so bit order matches write order; the delta test asserts exactly one byte over a no-change write.

Visual check wanted: the CTF flag-carrier icon stays at the row's top corner (the row now returns the second line's y); the common board's ping keeps its one-character margin; the vote draws where it did (after the clock, before the centre print).

Verified: full build clean; `make check` 20/20; `racetest` loads headlessly. Read-only review pass applied. Not run under a renderer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)