### PR TITLE
Tighten the hook APIs from the #963 sweep, part 3

### DIFF
--- a/src/cgame/common/cg_module.h
+++ b/src/cgame/common/cg_module.h
@@ -54,7 +54,7 @@
  */
 
 /**
- * @defgroup module-contract Module contract
+ * @defgroup cg-module-contract Module contract
  * @brief What every client game module defines for itself. A missing definition is
  * a link error, which is how a new module learns what it owes.
  * @{
@@ -334,8 +334,7 @@ extern EntityEffects Cg_EntityEffects;
  * a ghost, a dummy - answers its own info for it and defers to previous for
  * the rest.
  */
-struct cg_client_info_s;
-typedef struct cg_client_info_s *(*ClientInfo)(const cl_entity_t *ent);
+typedef cg_client_info_t *(*ClientInfo)(const cl_entity_t *ent);
 
 extern ClientInfo Cg_ClientInfo;
 

--- a/src/cgame/common/cg_types.h
+++ b/src/cgame/common/cg_types.h
@@ -56,9 +56,41 @@ typedef struct {
 } cg_team_info_t;
 
 /**
+ * @brief The vote in progress, as `CS_VOTE` describes it.
+ */
+typedef struct {
+
+  /**
+   * @brief Whether a vote is under way.
+   */
+  bool active;
+
+  /**
+   * @brief What is being voted on, and its argument, if any.
+   */
+  char type[MAX_QPATH];
+  char arg[MAX_QPATH];
+
+  /**
+   * @brief Who called it.
+   */
+  char initiator[MAX_QPATH];
+
+  /**
+   * @brief The tally so far, and how many may cast one.
+   */
+  int32_t yes, no, eligible;
+
+  /**
+   * @brief When it closes, in client time.
+   */
+  uint32_t deadline;
+} cg_vote_state_t;
+
+/**
  * @brief The client game representation of clients (players).
  */
-typedef struct cg_client_info_s {
+typedef struct {
 
   /**
    * @brief The client info string, e.g. "newbie\qforcer/default."
@@ -209,14 +241,7 @@ typedef struct {
   /**
    * @brief The vote in progress, from `CS_VOTE`.
    */
-  struct {
-    bool active;
-    char type[MAX_QPATH];
-    char arg[MAX_QPATH];
-    char initiator[MAX_QPATH];
-    int32_t yes, no, eligible;
-    uint32_t deadline;
-  } vote;
+  cg_vote_state_t vote;
 } cg_state_t;
 
 extern cg_state_t cg_state;

--- a/src/cgame/common/ui/play/CreateServerViewController.c
+++ b/src/cgame/common/ui/play/CreateServerViewController.c
@@ -99,14 +99,13 @@ static void loadView(ViewController *self) {
 
   CreateServerViewController *this = (CreateServerViewController *) self;
 
-  View *gameplayInput, *movementInput, *hookInput, *techsInput;
+  View *gameplayInput, *hookInput, *techsInput;
 
   Outlet outlets[] = MakeOutlets(
     MakeOutlet("bots", &this->bots),
     MakeOutlet("gameplay", &this->gameplay),
     MakeOutlet("gameplayInput", &gameplayInput),
     MakeOutlet("movement", &this->movement),
-    MakeOutlet("movementInput", &movementInput),
     MakeOutlet("hookInput", &hookInput),
     MakeOutlet("techsInput", &techsInput),
     MakeOutlet("mapList", &this->mapList),
@@ -148,14 +147,9 @@ static void loadView(ViewController *self) {
   // "Default" defers to the level, as it does for gameplay
   $(this->movement, addOption, "Default", "default");
 
-  const size_t num_movements = Pm_MovementCount();
-  if (num_movements <= 1) {
-    $(movementInput, removeFromSuperview);
-  } else {
-    for (size_t i = 0; i < num_movements; i++) {
-      const pm_movement_info_t *movement = Pm_Movement((pm_movement_t) i);
-      $(this->movement, addOption, movement->label, (ident) movement->name);
-    }
+  for (size_t i = 0; i < Pm_MovementCount(); i++) {
+    const pm_movement_info_t *movement = Pm_Movement((pm_movement_t) i);
+    $(this->movement, addOption, movement->label, (ident) movement->name);
   }
 
   this->create->delegate.didClick = createServer;

--- a/src/game/common/g_ai_node.c
+++ b/src/game/common/g_ai_node.c
@@ -540,7 +540,7 @@ bool G_Ai_Node_CanPathTo(const vec3_t position) {
   const vec3_t end = Vec3_Subtract(position, Vec3(0, 0, PM_GROUND_DIST * 3.f));
 
   // check if the destination has ground
-  cm_trace_t tr = gi.Trace(position, end, Box3_Expand3(G_PlayerBounds(false), Vec3(1.f, 1.f, 0.f)), NULL, CONTENTS_MASK_CLIP_CORPSE | CONTENTS_MASK_LIQUID);
+  cm_trace_t tr = gi.Trace(position, end, Box3_Expand3(G_PlayerBounds(), Vec3(1.f, 1.f, 0.f)), NULL, CONTENTS_MASK_CLIP_CORPSE | CONTENTS_MASK_LIQUID);
 
   // bad ground
   bool stuck_in_mover = tr.ent
@@ -557,7 +557,7 @@ bool G_Ai_Node_CanPathTo(const vec3_t position) {
   if (stuck_in_mover) {
 
     // check with a thinner box; it might be a button press or rotating thing
-    const box3_t bounds = G_PlayerBounds(false);
+    const box3_t bounds = G_PlayerBounds();
     tr = gi.Trace(position,
                Vec3_Subtract(position, Vec3(0, 0, PM_GROUND_DIST * 3.f)),
                Box3(Vec3(-4.f, -4.f, bounds.mins.z), Vec3(4.f, 4.f, bounds.maxs.z)),
@@ -1740,7 +1740,7 @@ bool G_Ai_DropItemLikeNode(g_entity_t *ent) {
   if (down.fraction == 1.0) {
     pos = ent->s.origin;
   } else {
-    pos = Vec3_Subtract(down.end, Vec3(0.f, 0.f, G_PlayerBounds(false).mins.z));
+    pos = Vec3_Subtract(down.end, Vec3(0.f, 0.f, G_PlayerBounds().mins.z));
   }
 
   // grab all the links of the node that brought us here

--- a/src/game/common/g_client.c
+++ b/src/game/common/g_client.c
@@ -1044,7 +1044,7 @@ static float G_EnemyRangeFromSpot(g_client_t *cl, g_entity_t *spot) {
  */
 static bool G_WouldTelefrag(const vec3_t spot) {
   g_entity_t *ents[MAX_ENTITIES];
-  box3_t bounds = Box3_Translate(G_PlayerBounds(false), spot);
+  box3_t bounds = Box3_Translate(G_PlayerBounds(), spot);
 
   bounds.mins.z -= PM_STEP_HEIGHT;
   bounds.maxs.z += PM_STEP_HEIGHT;
@@ -1254,26 +1254,41 @@ static void G_PrepareSpawn_Common(g_client_t *cl, g_client_spawn_t *spawn) {
 
 PrepareSpawn G_PrepareSpawn = G_PrepareSpawn_Common;
 
+/**
+ * @brief The tail of the `G_ClientDidBegin` chain: a notification, so it does nothing.
+ */
 static void G_ClientDidBegin_Common(g_client_t *cl) {
 }
 
 ClientDidBegin G_ClientDidBegin = G_ClientDidBegin_Common;
 
+/**
+ * @brief The tail of the `G_ClientDidChangeUserInfo` chain: a notification, so it does nothing.
+ */
 static void G_ClientDidChangeUserInfo_Common(g_client_t *cl) {
 }
 
 ClientDidChangeUserInfo G_ClientDidChangeUserInfo = G_ClientDidChangeUserInfo_Common;
 
+/**
+ * @brief The tail of the `G_ClientWillDisconnect` chain: a notification, so it does nothing.
+ */
 static void G_ClientWillDisconnect_Common(g_client_t *cl) {
 }
 
 ClientWillDisconnect G_ClientWillDisconnect = G_ClientWillDisconnect_Common;
 
+/**
+ * @brief The tail of the `G_ClientWillThink` chain: a notification, so it does nothing.
+ */
 static void G_ClientWillThink_Common(g_client_t *cl, const pm_cmd_t *cmd) {
 }
 
 ClientWillThink G_ClientWillThink = G_ClientWillThink_Common;
 
+/**
+ * @brief The tail of the `G_ClientDidMove` chain: a notification, so it does nothing.
+ */
 static void G_ClientDidMove_Common(g_client_t *cl, const pm_cmd_t *cmd) {
 }
 
@@ -1376,7 +1391,7 @@ static void G_ClientRespawn_(g_client_t *cl) {
     ent->solid = SOLID_BOX;
     ent->sv_flags = 0;
 
-    ent->bounds = G_PlayerBounds(false);
+    ent->bounds = G_PlayerBounds();
 
     ent->s.model1 = MODEL_CLIENT;
     ent->s.event = EV_CLIENT_TELEPORT;

--- a/src/game/common/g_client_stats.c
+++ b/src/game/common/g_client_stats.c
@@ -98,11 +98,17 @@ static void G_UpdateScore(const g_client_t *cl, g_score_t *s) {
   G_WriteScore(cl, s);
 }
 
+/**
+ * @brief The tail of the `G_WriteScore` chain: a notification, so it does nothing.
+ */
 static void G_WriteScore_Common(const g_client_t *cl, g_score_t *s) {
 }
 
 WriteScore G_WriteScore = G_WriteScore_Common;
 
+/**
+ * @brief The tail of the `G_WriteStats` chain: a notification, so it does nothing.
+ */
 static void G_WriteStats_Common(g_client_t *cl) {
 }
 

--- a/src/game/common/g_client_view.c
+++ b/src/game/common/g_client_view.c
@@ -523,6 +523,14 @@ void G_ClientEndFrame(g_client_t *cl) {
 }
 
 /**
+ * @brief The tail of the `G_FrameDidEnd` chain: a notification, so it does nothing.
+ */
+static void G_FrameDidEnd_Common(void) {
+}
+
+FrameDidEnd G_FrameDidEnd = G_FrameDidEnd_Common;
+
+/**
  * @brief Finalizes all client frames and applies chase camera state.
  */
 void G_EndClientFrames(void) {
@@ -547,8 +555,3 @@ void G_EndClientFrames(void) {
 
   G_FrameDidEnd();
 }
-
-static void G_FrameDidEnd_Common(void) {
-}
-
-FrameDidEnd G_FrameDidEnd = G_FrameDidEnd_Common;

--- a/src/game/common/g_cmd.c
+++ b/src/game/common/g_cmd.c
@@ -712,12 +712,15 @@ void G_PlayPmove(void);
 /**
  * @brief The tail of the `G_HandleClientCommand` chain, which handles nothing.
  */
-static bool G_HandleClientCommand_Common(g_client_t *cl, const char *cmd, bool intermission) {
+static bool G_HandleClientCommand_Common(g_client_t *cl, const char *cmd) {
   return false;
 }
 
 HandleClientCommand G_HandleClientCommand = G_HandleClientCommand_Common;
 
+/**
+ * @brief The tail of the `G_ClientDidChat` chain: a notification, so it does nothing.
+ */
 static void G_ClientDidChat_Common(g_client_t *cl, const char *text, bool team) {
 }
 
@@ -730,7 +733,7 @@ void G_ClientCommand(g_client_t *cl) {
 
   const char *cmd = gi.Argv(0);
 
-  if (G_HandleClientCommand(cl, cmd, g_level.intermission_time != 0)) {
+  if (G_HandleClientCommand(cl, cmd)) {
     return;
   }
 

--- a/src/game/common/g_entity.c
+++ b/src/game/common/g_entity.c
@@ -182,7 +182,10 @@ static bool G_SpawnEntity_Common(g_entity_t *ent) {
 
 SpawnEntity G_SpawnEntity = G_SpawnEntity_Common;
 
-static void G_LevelWillSpawn_Common(const char *name) {
+/**
+ * @brief The tail of the `G_LevelWillSpawn` chain: a notification, so it does nothing.
+ */
+static void G_LevelWillSpawn_Common(void) {
 }
 
 LevelWillSpawn G_LevelWillSpawn = G_LevelWillSpawn_Common;
@@ -600,7 +603,7 @@ void G_SpawnEntities(const char *name, const cm_entity_t *props, cm_entity_t *co
 
   q_strlcpy(g_level.name, name, sizeof(g_level.name));
 
-  G_LevelWillSpawn(name);
+  G_LevelWillSpawn();
 
   g_level.frags    = $(alloc(Vector), initWithSize, sizeof(g_frag_t));
 

--- a/src/game/common/g_main.h
+++ b/src/game/common/g_main.h
@@ -28,6 +28,14 @@
 extern g_level_t g_level;
 extern g_media_t g_media;
 
+/**
+ * @brief The movement a level falls back to when neither `g_movement`, its
+ * metadata nor its worldspawn choose one. A module's `g_types.h` MAY say otherwise.
+ */
+#if !defined(G_MOVEMENT_DEFAULT)
+#define G_MOVEMENT_DEFAULT PM_MOVEMENT_QUETOO
+#endif
+
 pm_params_t G_MovementParams(void);
 float G_LevelGravity(void);
 pm_movement_t G_ResolveMovement(const char *name);

--- a/src/game/common/g_module.h
+++ b/src/game/common/g_module.h
@@ -117,7 +117,7 @@ extern InitMedia G_InitMedia;
  * settings over cvars the worldspawn reads does so here.
  * @details Notification; the tail does nothing.
  */
-typedef void (*LevelWillSpawn)(const char *name);
+typedef void (*LevelWillSpawn)(void);
 
 extern LevelWillSpawn G_LevelWillSpawn;
 
@@ -492,13 +492,14 @@ extern ClientDidMove G_ClientDidMove;
  * owns and defers to previous for the rest; one that overrides a built-in
  * command answers true for that name and the built-in never sees it. The tail
  * handles nothing, so an unclaimed command falls through to the built-in table
- * and, failing that, to chat. `intermission` is true while the level is ending,
- * when the built-in table ignores everything but chat. `cmd` is `gi.Argv(0)`;
+ * and, failing that, to chat. While the level is ending the built-in table
+ * ignores everything but chat; `g_level.intermission_time` says so. `cmd` is
+ * `gi.Argv(0)`;
  * an implementation MUST NOT call `gi.TokenizeString`, which would replace it
  * under the built-in table that runs next.
  * @return True if the command was handled.
  */
-typedef bool (*HandleClientCommand)(g_client_t *cl, const char *cmd, bool intermission);
+typedef bool (*HandleClientCommand)(g_client_t *cl, const char *cmd);
 
 extern HandleClientCommand G_HandleClientCommand;
 

--- a/src/game/common/g_util.c
+++ b/src/game/common/g_util.c
@@ -65,13 +65,14 @@ void G_SetSpawnPoints(g_spawn_points_t *points, const Vector *spawns) {
 }
 
 /**
- * @brief The player bounding box under the current movement parameters.
+ * @brief The standing player box under the level's movement. A client in hand
+ * has its own in `ps.pm_state.params`; this is for when there is none.
  */
-box3_t G_PlayerBounds(bool ducked) {
+box3_t G_PlayerBounds(void) {
 
-  const pm_params_t params = G_MovementParams();
+  const pm_movement_info_t *movement = Pm_Movement(g_level.movement);
 
-  return Pm_Bounds(&params, ducked);
+  return movement->params ? movement->params->bounds : PM_BOUNDS;
 }
 
 /**

--- a/src/game/common/g_util.h
+++ b/src/game/common/g_util.h
@@ -29,7 +29,7 @@ void G_KillBox(g_entity_t *ent);
 void G_Explode(g_entity_t *ent, int16_t damage, int16_t knockback, float radius, uint32_t mod);
 void G_Gib(g_entity_t *ent);
 void G_InitPlayerSpawn(g_entity_t *ent);
-box3_t G_PlayerBounds(bool ducked);
+box3_t G_PlayerBounds(void);
 void G_ClientProjectile(const g_client_t *cl, vec3_t *forward, vec3_t *right, vec3_t *up, vec3_t *org, float hand);
 g_entity_t *G_Find(g_entity_t *from, ptrdiff_t field, const char *match);
 

--- a/src/game/common/g_vote.c
+++ b/src/game/common/g_vote.c
@@ -363,10 +363,10 @@ static void G_Vote_Call(g_client_t *cl, const char *type, const char *arg) {
 /**
  * @brief `vote yes`, `vote no`, or `vote <type> [argument]`.
  */
-static bool G_HandleClientCommand_Vote(g_client_t *cl, const char *cmd, bool intermission) {
+static bool G_HandleClientCommand_Vote(g_client_t *cl, const char *cmd) {
 
   if (q_strcmp(cmd, "vote")) {
-    return previous.HandleClientCommand(cl, cmd, intermission);
+    return previous.HandleClientCommand(cl, cmd);
   }
 
   if (gi.Argc() < 2) {
@@ -380,7 +380,7 @@ static bool G_HandleClientCommand_Vote(g_client_t *cl, const char *cmd, bool int
     G_Vote_Cast(cl, BALLOT_YES);
   } else if (!q_strcasecmp(what, "no")) {
     G_Vote_Cast(cl, BALLOT_NO);
-  } else if (intermission) {
+  } else if (g_level.intermission_time) {
     gi.ClientPrint(cl, PRINT_HIGH, "The level is ending\n");
   } else {
     G_Vote_Call(cl, what, gi.Argc() > 2 ? gi.Argv(2) : "");

--- a/src/game/ctf/g_types.h
+++ b/src/game/ctf/g_types.h
@@ -40,7 +40,6 @@
 /**
  * @brief The movement a level runs when it names none and `g_movement` defers.
  */
-#define G_MOVEMENT_DEFAULT PM_MOVEMENT_QUETOO
 
 /**
  * @brief Game protocol version (protocol minor version). To be incremented

--- a/src/game/default/g_types.h
+++ b/src/game/default/g_types.h
@@ -38,7 +38,6 @@
 /**
  * @brief The movement a level runs when it names none and `g_movement` defers.
  */
-#define G_MOVEMENT_DEFAULT PM_MOVEMENT_QUETOO
 
 /**
  * @brief Game protocol version (protocol minor version). To be incremented

--- a/src/game/lithium/g_types.h
+++ b/src/game/lithium/g_types.h
@@ -40,7 +40,6 @@
 /**
  * @brief The movement a level runs when it names none and `g_movement` defers.
  */
-#define G_MOVEMENT_DEFAULT PM_MOVEMENT_QUETOO
 
 /**
  * @brief Game protocol version (protocol minor version). To be incremented

--- a/src/game/race/g_race.c
+++ b/src/game/race/g_race.c
@@ -575,13 +575,13 @@ static void G_Race_Status_f(g_client_t *cl) {
  * @brief The level's entities are about to go, the ghosts among them, and with
  * them every run.
  */
-static void G_LevelWillSpawn_Race(const char *name) {
+static void G_LevelWillSpawn_Race(void) {
 
   G_ForEachClient(cl, {
     G_Race_Reset(cl);
   });
 
-  previous.LevelWillSpawn(name);
+  previous.LevelWillSpawn();
 }
 
 static void G_ConfigureLevel_Race(void) {
@@ -684,10 +684,10 @@ static bool G_AllowHook_Race(const g_client_t *cl) {
   return previous.AllowHook(cl);
 }
 
-static bool G_HandleClientCommand_Race(g_client_t *cl, const char *cmd, bool intermission) {
+static bool G_HandleClientCommand_Race(g_client_t *cl, const char *cmd) {
 
-  if (intermission) {
-    return previous.HandleClientCommand(cl, cmd, intermission);
+  if (g_level.intermission_time) {
+    return previous.HandleClientCommand(cl, cmd);
   }
 
   if (!q_strcmp(cmd, "race")) {
@@ -703,7 +703,7 @@ static bool G_HandleClientCommand_Race(g_client_t *cl, const char *cmd, bool int
   } else if (!q_strcmp(cmd, "ghost")) {
     G_Race_Ghost_f(cl);
   } else {
-    return previous.HandleClientCommand(cl, cmd, intermission);
+    return previous.HandleClientCommand(cl, cmd);
   }
 
   return true;

--- a/src/server/sv_client.c
+++ b/src/server/sv_client.c
@@ -310,9 +310,20 @@ void Sv_ParseClientMessage(sv_client_t *cl) {
 
     switch (c) {
 
-      case CL_CMD_USER_INFO: // leave room for ip stuffing, as the connect does
-        q_strlcpy(cl->user_info, Net_ReadString(&net_message), sizeof(cl->user_info) - 25);
+      case CL_CMD_USER_INFO: {
+        const char *user_info = Net_ReadString(&net_message);
+
+        // leave room for ip stuffing, as the connect does; truncating instead
+        // could leave a dangling key for the ip to complete
+        if (q_strlen(user_info) >= sizeof(cl->user_info) - 25) {
+          Com_Print("Oversized user_info from %s\n", Sv_NetaddrToString(cl));
+          Sv_KickClient(cl, "Bad user info");
+          return;
+        }
+
+        q_strlcpy(cl->user_info, user_info, sizeof(cl->user_info));
         Sv_UserInfoChanged(cl);
+      }
         break;
 
       case CL_CMD_ENTITY_INFO: {

--- a/src/server/sv_client.c
+++ b/src/server/sv_client.c
@@ -310,8 +310,8 @@ void Sv_ParseClientMessage(sv_client_t *cl) {
 
     switch (c) {
 
-      case CL_CMD_USER_INFO:
-        q_strlcpy(cl->user_info, Net_ReadString(&net_message), sizeof(cl->user_info));
+      case CL_CMD_USER_INFO: // leave room for ip stuffing, as the connect does
+        q_strlcpy(cl->user_info, Net_ReadString(&net_message), sizeof(cl->user_info) - 25);
         Sv_UserInfoChanged(cl);
         break;
 

--- a/src/server/sv_main.c
+++ b/src/server/sv_main.c
@@ -721,13 +721,15 @@ void Sv_UserInfoChanged(sv_client_t *cl) {
     return;
   }
 
-  // force the ip so the game can filter on it, as the connect did: a client's
-  // update replaces the whole string, and the client never sends one
-  if (!InfoString_Set(cl->user_info, "ip", Sv_NetaddrToString(cl))) {
-    Com_Print("No room for ip in user_info from %s\n", Sv_NetaddrToString(cl));
+  if (q_strlen(InfoString_Get(cl->user_info, "ip"))) { // catch spoofed ips, as the connect does
+    Com_Print("Illegal user_info contained ip from %s\n", Sv_NetaddrToString(cl));
     Sv_KickClient(cl, "Bad user info");
     return;
   }
+
+  // force the ip so the game can filter on it, as the connect did: a client's
+  // update replaces the whole string, and the client never sends one
+  InfoString_Set(cl->user_info, "ip", Sv_NetaddrToString(cl));
 
   // call game code to allow overrides
   svs.game->ClientUserInfoChanged(cl->gclient, cl->user_info);


### PR DESCRIPTION
The smaller consistency items from the review of pre-existing `.c`/`.h` changes since #975 (#963); follows #1009 and #1010.

- **user_info updates** reserve room for the forced `ip` like the connect does, instead of kicking a client whose legal user_info is long; and, like the connect, refuse one that arrives carrying an `ip` (a duplicate key would shadow the forced one - pre-existing, found on the way).
- **`G_PlayerBounds(void)`** reads the movement's standing box instead of hydrating every cvar; every caller passed `false`.
- **Hook parameters that duplicated `g_level`**: `LevelWillSpawn` takes nothing, `HandleClientCommand` loses `bool intermission`.
- **Tidying**: `G_MOVEMENT_DEFAULT` defined once (`g_main.h`, module `g_types.h` overrides); `FrameDidEnd` tail above its caller; `@brief` on ten undocumented tails; `ClientInfo` typedef uses `cg_client_info_t` (struct tag dropped); `cg_vote_state_t` named and documented; doxygen group collision with `g_module.h` renamed; impossible `Pm_MovementCount() <= 1` branch and its outlet removed from the server menu.

Not done from the list, for your call: renaming `G_SpawnEntity`/`G_SpawnEntityDef`; unifying gameplay/movement resolution; the `BroadcastPrint` during `G_SpawnEntities`; the `r_mesh_draw.c` voxel fallback vs its four siblings; the `ClipEntity` typedef existing in both module headers.

Note: `race` is not in `GAME_MODULES`, so neither `make` nor CI compiles it - I build `src/game/race` and `src/cgame/race` explicitly. This caught a missed call site here; #1010's race-side edits were also only compiled now (they are clean).

Verified: full build + both race modules clean; `make check` 20/20; `racetest` and `edge` load headlessly. Read-only review pass applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)