### PR TITLE
Scale the player model to the movement's box

### DIFF
--- a/src/cgame/common/cg_client.c
+++ b/src/cgame/common/cg_client.c
@@ -739,6 +739,12 @@ void Cg_AddClientEntity(cl_entity_t *ent, r_entity_t *e) {
   legs.bounds = legs.model->bounds;
   memcpy(legs.skins, skin->legs_skins, sizeof(legs.skins));
 
+  // the model is built for PM_BOUNDS; under a movement with a shorter box, the
+  // whole rig shrinks to fit it, with its feet kept where the box's are
+  const box3_t standing = Cg_PlayerBounds(false);
+  legs.scale = e->scale * Box3_Size(standing).z / Box3_Size(PM_BOUNDS).z;
+  legs.origin.z += standing.mins.z - legs.scale * PM_BOUNDS.mins.z;
+
   torso.model = skin->torso;
   torso.origin = Vec3_Zero();
   torso.angles.y = ent->angles.y - legs.angles.y; // legs twisted already, we just need to pitch/roll


### PR DESCRIPTION
Stacked on #1011; retargets to `main` when that merges.

The player models are built for `PM_BOUNDS` (60 tall). Quake, Quake II, Quake III and race move in a 56-tall box, so a player drawn at full size overhangs the box that stops them. `Cg_AddClientEntity` now scales the legs root by the standing height ratio (56/60 under those movements, 1 under Quetoo) and drops it by `mins.z - scale * PM_BOUNDS.mins.z` so the feet stay on the box's floor. Torso, head, weapon and flag compose onto the legs via `R_ApplyMeshTag`, so one scale carries the rig; the culling bounds come through the same matrix.

Decisions, per the discussion: scale from the *standing* box (crouching is animated, and chasing the crouch box would fight it); uniform scale (Quake III's 30-wide box differs from 32 by 0.4%); the box is the local player's, which is the level's until a mod actually selects movement per player - that is the one seam to revisit then. First person needs nothing, since each kernel sets its own `view_offset`.

Not run under a renderer - wants a third-person look under `g_movement quake3`, including the shadow and muzzle flash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)