### PR TITLE
Publish each client's standing box in their client info

### DIFF
--- a/src/cgame/common/cg_client.c
+++ b/src/cgame/common/cg_client.c
@@ -23,13 +23,14 @@
 #include "game/common/bg_pmove.h"
 
 // team\name\model/skin\shirt\pants\helmet\hue, and the standing box's floor/ceiling
-// since 1.0.85; fields beyond these are ignored, so that a newer server still dresses
+// since 1.0.85; fields beyond these are ignored, so that a newer server's string
+// still dresses a player here
 #define MIN_CLIENT_INFO_ENTRIES 7
 #define MAX_CLIENT_INFO_ENTRIES 8
 
-// what a standing box may plausibly span, against a garbled field
+// where a standing box may plausibly sit and how much it may span, against a garbled field
+#define MAX_CLIENT_INFO_EXTENT 128.f
 #define MIN_CLIENT_INFO_HEIGHT 16.f
-#define MAX_CLIENT_INFO_HEIGHT 128.f
 
 #define DEFAULT_MODEL "qforcer"
 #define DEFAULT_SKIN "default"
@@ -326,8 +327,10 @@ void Cg_LoadClient(cg_client_info_t *ci, const char *s) {
 
     if (entries > MIN_CLIENT_INFO_ENTRIES) {
       float floor, ceiling;
-      if (sscanf(info[7], "%f/%f", &floor, &ceiling) == 2 &&
-          ceiling - floor >= MIN_CLIENT_INFO_HEIGHT && ceiling - floor <= MAX_CLIENT_INFO_HEIGHT) {
+      int32_t n = 0;
+      if (sscanf(info[7], "%f/%f%n", &floor, &ceiling, &n) == 2 && !info[7][n] &&
+          floor >= -MAX_CLIENT_INFO_EXTENT && ceiling <= MAX_CLIENT_INFO_EXTENT &&
+          ceiling - floor >= MIN_CLIENT_INFO_HEIGHT) {
         ci->standing_floor = floor;
         ci->standing_ceiling = ceiling;
       } else {

--- a/src/cgame/common/cg_client.c
+++ b/src/cgame/common/cg_client.c
@@ -22,7 +22,14 @@
 #include "cg_local.h"
 #include "game/common/bg_pmove.h"
 
-#define MAX_CLIENT_INFO_ENTRIES 7
+// team\name\model/skin\shirt\pants\helmet\hue, and the standing box's floor/ceiling
+// since 1.0.85; fields beyond these are ignored, so that a newer server still dresses
+#define MIN_CLIENT_INFO_ENTRIES 7
+#define MAX_CLIENT_INFO_ENTRIES 8
+
+// what a standing box may plausibly span, against a garbled field
+#define MIN_CLIENT_INFO_HEIGHT 16.f
+#define MAX_CLIENT_INFO_HEIGHT 128.f
 
 #define DEFAULT_MODEL "qforcer"
 #define DEFAULT_SKIN "default"
@@ -264,7 +271,9 @@ void Cg_LoadClient(cg_client_info_t *ci, const char *s) {
   char *info[MAX_CLIENT_INFO_ENTRIES];
   q_strlcpy(info_string, s, sizeof(info_string));
 
-  if (Cg_SplitClientInfo(info_string, info, lengthof(info)) != MAX_CLIENT_INFO_ENTRIES) { // invalid info
+  const size_t entries = Cg_SplitClientInfo(info_string, info, lengthof(info));
+
+  if (entries < MIN_CLIENT_INFO_ENTRIES) { // invalid info
     Cg_LoadClient(ci, DEFAULT_CLIENT_INFO);
   } else {
 
@@ -310,6 +319,20 @@ void Cg_LoadClient(cg_client_info_t *ci, const char *s) {
       ci->hue = hue;
     } else {
       ci->hue = -1;
+    }
+
+    ci->standing_floor = PM_BOUNDS.mins.z;
+    ci->standing_ceiling = PM_BOUNDS.maxs.z;
+
+    if (entries > MIN_CLIENT_INFO_ENTRIES) {
+      float floor, ceiling;
+      if (sscanf(info[7], "%f/%f", &floor, &ceiling) == 2 &&
+          ceiling - floor >= MIN_CLIENT_INFO_HEIGHT && ceiling - floor <= MAX_CLIENT_INFO_HEIGHT) {
+        ci->standing_floor = floor;
+        ci->standing_ceiling = ceiling;
+      } else {
+        Cg_Warn("Invalid standing box \"%s\" for %s\n", info[7], ci->name);
+      }
     }
 
     // ensure we were able to load everything
@@ -739,11 +762,10 @@ void Cg_AddClientEntity(cl_entity_t *ent, r_entity_t *e) {
   legs.bounds = legs.model->bounds;
   memcpy(legs.skins, skin->legs_skins, sizeof(legs.skins));
 
-  // the model is built for PM_BOUNDS; under a movement with a shorter box, the
-  // whole rig shrinks to fit it, with its feet kept where the box's are
-  const box3_t standing = Cg_PlayerBounds(false);
-  legs.scale = e->scale * Box3_Size(standing).z / Box3_Size(PM_BOUNDS).z;
-  legs.origin.z += standing.mins.z - legs.scale * PM_BOUNDS.mins.z;
+  // the model is built for PM_BOUNDS; a client whose standing box is another
+  // size has the whole rig scaled to its height and seated on its floor
+  legs.scale = e->scale * (ci->standing_ceiling - ci->standing_floor) / Box3_Size(PM_BOUNDS).z;
+  legs.origin.z += ci->standing_floor - legs.scale * PM_BOUNDS.mins.z;
 
   torso.model = skin->torso;
   torso.origin = Vec3_Zero();

--- a/src/cgame/common/cg_entity.c
+++ b/src/cgame/common/cg_entity.c
@@ -200,10 +200,11 @@ box3_t Cg_PlayerBounds(bool ducked) {
  */
 bool Cg_IsDucking(const cl_entity_t *ent) {
 
-  const float standing_height = Box3_Size(Cg_PlayerBounds(false)).z;
   const float height = Box3_Size(ent->current.bounds).z;
 
-  return standing_height - height > PM_STOP_EPSILON;
+  const cg_client_info_t *ci = Cg_ClientInfo(ent);
+
+  return (ci->standing_ceiling - ci->standing_floor) - height > PM_STOP_EPSILON;
 }
 
 /**

--- a/src/cgame/common/cg_types.h
+++ b/src/cgame/common/cg_types.h
@@ -123,6 +123,12 @@ typedef struct {
   float hue;
 
   /**
+   * @brief The floor and ceiling of the client's standing box, which their model
+   * is scaled and seated to.
+   */
+  float standing_floor, standing_ceiling;
+
+  /**
    * @brief The head model and materials.
    */
   r_model_t *head;

--- a/src/game/common/g_client.c
+++ b/src/game/common/g_client.c
@@ -1551,9 +1551,6 @@ void G_ClientBegin(g_client_t *cl) {
 }
 
 /**
- * @brief Applies updates from a client's user info string to their persistent state.
- */
-/**
  * @brief The client's standing box, which the client game sizes their model by:
  * their own movement parameters once they have moved, and the level's until then.
  */
@@ -1564,6 +1561,9 @@ box3_t G_ClientStandingBounds(const g_client_t *cl) {
   return Box3_Size(bounds).z > 0.f ? bounds : G_PlayerBounds();
 }
 
+/**
+ * @brief Applies updates from a client's user info string to their persistent state.
+ */
 void G_ClientUserInfoChanged(g_client_t *cl, const char *user_info) {
   char name[MAX_NET_NAME];
 

--- a/src/game/common/g_client.c
+++ b/src/game/common/g_client.c
@@ -1553,6 +1553,17 @@ void G_ClientBegin(g_client_t *cl) {
 /**
  * @brief Applies updates from a client's user info string to their persistent state.
  */
+/**
+ * @brief The client's standing box, which the client game sizes their model by:
+ * their own movement parameters once they have moved, and the level's until then.
+ */
+box3_t G_ClientStandingBounds(const g_client_t *cl) {
+
+  const box3_t bounds = cl->ps.pm_state.params.bounds;
+
+  return Box3_Size(bounds).z > 0.f ? bounds : G_PlayerBounds();
+}
+
 void G_ClientUserInfoChanged(g_client_t *cl, const char *user_info) {
   char name[MAX_NET_NAME];
 
@@ -1704,6 +1715,12 @@ void G_ClientUserInfoChanged(g_client_t *cl, const char *user_info) {
 
   q_strlcat(client_info, "\\", sizeof(client_info));
   q_strlcat(client_info, va("%i", cl->persistent.color), sizeof(client_info));
+
+  cl->persistent.standing_bounds = G_ClientStandingBounds(cl);
+
+  q_strlcat(client_info, "\\", sizeof(client_info));
+  q_strlcat(client_info, va("%g/%g", cl->persistent.standing_bounds.mins.z,
+                            cl->persistent.standing_bounds.maxs.z), sizeof(client_info));
 
   // send it to clients
   gi.SetConfigString(CS_CLIENTS + cl->ps.client, client_info);

--- a/src/game/common/g_client.h
+++ b/src/game/common/g_client.h
@@ -30,6 +30,7 @@ bool G_ClientConnect(g_client_t *cl, char *user_info);
 void G_ClientDisconnect(g_client_t *cl);
 void G_ClientRespawn(g_client_t *cl, bool voluntary);
 void G_ClientThink(g_client_t *cl, pm_cmd_t *cmd);
+box3_t G_ClientStandingBounds(const g_client_t *cl);
 void G_ClientUserInfoChanged(g_client_t *cl, const char *user_info);
 void G_Giblets(const g_giblets_t *giblets);
 #endif

--- a/src/game/common/g_client_view.c
+++ b/src/game/common/g_client_view.c
@@ -491,6 +491,11 @@ void G_ClientEndFrame(g_client_t *cl) {
     return;
   }
 
+  // a change of movement parameters is a change of client info
+  if (!Box3_Equal(G_ClientStandingBounds(cl), cl->persistent.standing_bounds)) {
+    G_ClientUserInfoChanged(cl, cl->persistent.user_info);
+  }
+
   // check for water entry / exit, burn from lava, slime, etc
   G_ClientWaterInteraction(cl);
 

--- a/src/game/common/g_main.c
+++ b/src/game/common/g_main.c
@@ -772,8 +772,7 @@ static void G_CheckRules(void) {
       // player state, so the change reaches everyone without a restart; the one
       // cost is a frame of misprediction, and a taller box has to fit where the
       // player is standing
-      gi.BroadcastPrint(PRINT_HIGH, "Movement has changed to %s\n",
-                        Pm_Movement(movement)->label);
+      gi.BroadcastPrint(PRINT_HIGH, "Movement has changed to %s\n", Pm_Movement(movement)->label);
     }
   }
 

--- a/src/game/ctf/g_types.h
+++ b/src/game/ctf/g_types.h
@@ -1236,6 +1236,12 @@ typedef struct {
   g_hand_t hand;
 
   /**
+   * @brief The standing box last published on `CS_CLIENTS`, so that a change of
+   * movement parameters republishes it.
+   */
+  box3_t standing_bounds;
+
+  /**
    * @brief Non-zero if weapons should auto-switch on pickup.
    */
   uint16_t auto_switch;

--- a/src/game/default/g_types.h
+++ b/src/game/default/g_types.h
@@ -1188,6 +1188,12 @@ typedef struct {
   g_hand_t hand;
 
   /**
+   * @brief The standing box last published on `CS_CLIENTS`, so that a change of
+   * movement parameters republishes it.
+   */
+  box3_t standing_bounds;
+
+  /**
    * @brief Non-zero if weapons should auto-switch on pickup.
    */
   uint16_t auto_switch;

--- a/src/game/lithium/g_types.h
+++ b/src/game/lithium/g_types.h
@@ -1195,6 +1195,12 @@ typedef struct {
   g_hand_t hand;
 
   /**
+   * @brief The standing box last published on `CS_CLIENTS`, so that a change of
+   * movement parameters republishes it.
+   */
+  box3_t standing_bounds;
+
+  /**
    * @brief Non-zero if weapons should auto-switch on pickup.
    */
   uint16_t auto_switch;

--- a/src/game/race/g_types.h
+++ b/src/game/race/g_types.h
@@ -1407,6 +1407,12 @@ typedef struct {
   g_hand_t hand;
 
   /**
+   * @brief The standing box last published on `CS_CLIENTS`, so that a change of
+   * movement parameters republishes it.
+   */
+  box3_t standing_bounds;
+
+  /**
    * @brief Non-zero if weapons should auto-switch on pickup.
    */
   uint16_t auto_switch;


### PR DESCRIPTION
Follows #1013. Jay's proposal: the standing box belongs in `CS_CLIENTS` beside model, skin and colour.

- Server: `G_ClientStandingBounds` (the client's `params.bounds` once they have moved, the level's before) is published as an eighth field, `floor/ceiling`, from `G_ClientUserInfoChanged`; `G_ClientEndFrame` republishes when it changes (a movement switch, a mod's class assignment). `g_client_persistent_t.standing_bounds` remembers what was published; no republish loop, since `G_MovementParams` and `G_PlayerBounds` draw from the same source.
- Client: `Cg_LoadClient` accepts 7 or more fields (surplus ignored, so the next field does not undress everyone), parses the eighth into `standing_floor`/`standing_ceiling` with a plausibility clamp (16..128 tall) and a warning; absent, `PM_BOUNDS`. `Cg_AddClientEntity` scales the rig by the box's height and seats it on the box's *floor* (not `PM_BOUNDS`'s, so a movement with a different `mins.z` is right too). `Cg_IsDucking` compares against the entity's own client info instead of the local player's params.
- The race ghost stores the live `CS_CLIENTS` string in its `.ghost`, so new records carry the holder's box; existing `.ghost` files have seven fields and draw the ghost at 60 until beaten - cosmetic.
- An older client (pre-change cgame, exact-7 check) would reject the 8-field string and fall back to `newbie/qforcer` for everyone; the 1.0.85 protocol bump covers that.

Verified: all modules incl. race build clean; `make check` 20/20; `racetest` and `edge` load headlessly. Read-only review applied (floor published, not just height; surplus fields tolerated; clamp). Not run under a renderer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)