### PR TITLE
Tighten the hook APIs from the #963 sweep, part 4

### DIFF
--- a/src/client/renderer/r_bsp_draw.c
+++ b/src/client/renderer/r_bsp_draw.c
@@ -532,7 +532,7 @@ void R_DrawOpaqueBspEntities(const r_view_t *view, RenderPass *pass) {
     r_lights.bsp_buffer->buffer,
     r_lights.dynamic_buffer->buffer,
     bsp->voxels.light_data_buffer->buffer,
-    bsp->voxels.light_indices_buffer ? bsp->voxels.light_indices_buffer->buffer : r_lights.bsp_buffer->buffer,
+    bsp->voxels.light_indices_buffer ? bsp->voxels.light_indices_buffer->buffer : r_lights.voxel_fallback_buffer->buffer,
   };
   $(pass, bindFragmentStorageBuffers, R_STORAGE_BSP_LIGHTS, storage, R_STORAGE_MATERIAL_TOTAL);
   $(pass, bindVertexStorageBuffers, R_STORAGE_BSP_LIGHTS, storage, R_STORAGE_MATERIAL_TOTAL);
@@ -745,7 +745,7 @@ void R_DrawBlendBspEntities(const r_view_t *view, RenderPass *pass) {
     r_lights.bsp_buffer->buffer,
     r_lights.dynamic_buffer->buffer,
     bsp->voxels.light_data_buffer->buffer,
-    bsp->voxels.light_indices_buffer ? bsp->voxels.light_indices_buffer->buffer : r_lights.bsp_buffer->buffer,
+    bsp->voxels.light_indices_buffer ? bsp->voxels.light_indices_buffer->buffer : r_lights.voxel_fallback_buffer->buffer,
   };
   $(pass, bindFragmentStorageBuffers, R_STORAGE_BSP_LIGHTS, storage, R_STORAGE_MATERIAL_TOTAL);
   $(pass, bindVertexStorageBuffers, R_STORAGE_BSP_LIGHTS, storage, R_STORAGE_MATERIAL_TOTAL);

--- a/src/client/renderer/r_decal.c
+++ b/src/client/renderer/r_decal.c
@@ -555,7 +555,7 @@ void R_DrawDecals(const r_view_t *view, RenderPass *pass) {
     r_lights.bsp_buffer->buffer,
     r_lights.dynamic_buffer->buffer,
     bsp->voxels.light_data_buffer->buffer,
-    bsp->voxels.light_indices_buffer ? bsp->voxels.light_indices_buffer->buffer : r_lights.bsp_buffer->buffer,
+    bsp->voxels.light_indices_buffer ? bsp->voxels.light_indices_buffer->buffer : r_lights.voxel_fallback_buffer->buffer,
   };
   $(pass, bindFragmentStorageBuffers, 0, storage, 4);
 

--- a/src/client/renderer/r_light.c
+++ b/src/client/renderer/r_light.c
@@ -183,6 +183,10 @@ void R_InitLights(void) {
     .usage = SDL_GPU_TRANSFERBUFFERUSAGE_UPLOAD,
     .size = Maxi(sizeof(r_lights.bsp_block), sizeof(r_lights.dynamic_block)),
   });
+
+  const int32_t no_lights[2] = { 0, 0 };
+  r_lights.voxel_fallback_buffer = $(r_context.device, createBufferWithConstMem,
+      SDL_GPU_BUFFERUSAGE_GRAPHICS_STORAGE_READ, no_lights, sizeof(no_lights));
 }
 
 /**
@@ -193,4 +197,5 @@ void R_ShutdownLights(void) {
   r_lights.bsp_buffer = release(r_lights.bsp_buffer);
   r_lights.dynamic_buffer = release(r_lights.dynamic_buffer);
   r_lights.transfer_buffer = release(r_lights.transfer_buffer);
+  r_lights.voxel_fallback_buffer = release(r_lights.voxel_fallback_buffer);
 }

--- a/src/client/renderer/r_light.h
+++ b/src/client/renderer/r_light.h
@@ -110,6 +110,12 @@ typedef struct {
    * lifetime because they are uploaded every frame.
    */
   TransferBuffer *transfer_buffer;
+
+  /**
+   * @brief One voxel with no lights, bound where a level has no clustered light
+   * data, or a view has no level.
+   */
+  Buffer *voxel_fallback_buffer;
 } r_lights_t;
 
 /**

--- a/src/client/renderer/r_mesh_draw.c
+++ b/src/client/renderer/r_mesh_draw.c
@@ -87,7 +87,6 @@ static struct {
   Texture *voxel_caustics_fallback;
   Texture *voxel_occlusion_fallback;
   Texture *sky_fallback;
-  Buffer *voxel_lights_fallback;
 
   /**
    * @brief Cached stage pipelines keyed by blend function.
@@ -623,8 +622,8 @@ void R_DrawMeshEntities(const r_view_t *view, RenderPass *pass) {
   SDL_GPUBuffer *storage[] = {
     r_lights.bsp_buffer->buffer,
     r_lights.dynamic_buffer->buffer,
-    bsp && bsp->voxels.light_data_buffer ? bsp->voxels.light_data_buffer->buffer : r_mesh_draw.voxel_lights_fallback->buffer,
-    bsp && bsp->voxels.light_indices_buffer ? bsp->voxels.light_indices_buffer->buffer : r_mesh_draw.voxel_lights_fallback->buffer,
+    bsp && bsp->voxels.light_data_buffer ? bsp->voxels.light_data_buffer->buffer : r_lights.voxel_fallback_buffer->buffer,
+    bsp && bsp->voxels.light_indices_buffer ? bsp->voxels.light_indices_buffer->buffer : r_lights.voxel_fallback_buffer->buffer,
   };
   $(pass, bindFragmentStorageBuffers, R_STORAGE_BSP_LIGHTS, storage, R_STORAGE_MATERIAL_TOTAL);
   $(pass, bindVertexStorageBuffers, R_STORAGE_BSP_LIGHTS, storage, R_STORAGE_MATERIAL_TOTAL);
@@ -754,11 +753,6 @@ void R_InitMeshPipeline(void) {
   }, NULL);
 
   r_mesh_draw.sky_fallback = $(r_context.device, createSolidColorTexture, SDL_GPU_TEXTURETYPE_CUBE, 6, 0x00000000);
-
-  // one voxel with no lights, for a view whose voxel uniforms name a 1x1x1 grid
-  static const int32_t no_lights[2];
-  r_mesh_draw.voxel_lights_fallback = $(r_context.device, createBufferWithConstMem,
-      SDL_GPU_BUFFERUSAGE_GRAPHICS_STORAGE_READ, no_lights, sizeof(no_lights));
 }
 
 /**
@@ -773,7 +767,6 @@ void R_ShutdownMeshPipeline(void) {
   r_mesh_draw.voxel_caustics_fallback = release(r_mesh_draw.voxel_caustics_fallback);
   r_mesh_draw.voxel_occlusion_fallback = release(r_mesh_draw.voxel_occlusion_fallback);
   r_mesh_draw.sky_fallback = release(r_mesh_draw.sky_fallback);
-  r_mesh_draw.voxel_lights_fallback = release(r_mesh_draw.voxel_lights_fallback);
 
   for (int32_t i = 0; i < r_mesh_draw.num_stage_pipelines; i++) {
     release(r_mesh_draw.stage_pipelines[i].pipeline);

--- a/src/client/renderer/r_sprite.c
+++ b/src/client/renderer/r_sprite.c
@@ -406,7 +406,7 @@ void R_DrawSprites(const r_view_t *view, RenderPass *pass) {
     r_lights.bsp_buffer->buffer,
     r_lights.dynamic_buffer->buffer,
     bsp->voxels.light_data_buffer->buffer,
-    bsp->voxels.light_indices_buffer ? bsp->voxels.light_indices_buffer->buffer : r_lights.bsp_buffer->buffer,
+    bsp->voxels.light_indices_buffer ? bsp->voxels.light_indices_buffer->buffer : r_lights.voxel_fallback_buffer->buffer,
     r_sprite_draw.instance_buffer->buffer,
   };
   $(pass, bindVertexStorageBuffers, 0, storage, 5);

--- a/src/game/common/g_client.c
+++ b/src/game/common/g_client.c
@@ -1532,16 +1532,14 @@ void G_ClientBegin(g_client_t *cl) {
     q_strlcat(welcome, "\n^2Gameplay is ^1", sizeof(welcome));
     q_strlcat(welcome, G_GameplayById(g_level.gameplay)->label, sizeof(welcome));
 
+    q_strlcat(welcome, "\n^2Movement is ^1", sizeof(welcome));
+    q_strlcat(welcome, Pm_Movement(g_level.movement)->label, sizeof(welcome));
+
     if (g_level.teams) {
       q_strlcat(welcome, "\n^2Teams are enabled", sizeof(welcome));
     }
 
-    // FIXME: Move these tidbits into ConfigStrings so that the client can display a menu
-#if 0
-    gi.WriteByte(SV_CMD_CENTER_PRINT);
-    gi.WriteString(welcome);
-    gi.Unicast(ent, true);
-#endif
+    gi.ClientPrint(cl, PRINT_HIGH, "%s\n", welcome);
   }
 
   // make sure all view stuff is valid

--- a/src/game/common/g_cmd.c
+++ b/src/game/common/g_cmd.c
@@ -485,8 +485,15 @@ static void G_Say_f(g_client_t *cl) {
     cl->chat_time = g_level.time + 250;
   }
 
+  char message[MAX_STRING_CHARS];
+  q_strlcpy(message, s, sizeof(message));
+
+  if (!G_ClientWillChat(cl, message, sizeof(message), team)) {
+    return;
+  }
+
   const int32_t color = team ? ESC_COLOR_TEAM_CHAT : ESC_COLOR_CHAT;
-  q_snprintf(text, sizeof(text), "%s^%d: %s\n", cl->persistent.net_name, color, s);
+  q_snprintf(text, sizeof(text), "%s^%d: %s\n", cl->persistent.net_name, color, message);
 
   G_ForEachClient(other, {
     if (team) {
@@ -717,6 +724,15 @@ static bool G_HandleClientCommand_Common(g_client_t *cl, const char *cmd) {
 }
 
 HandleClientCommand G_HandleClientCommand = G_HandleClientCommand_Common;
+
+/**
+ * @brief The tail of the `G_ClientWillChat` chain: everyone may speak.
+ */
+static bool G_ClientWillChat_Common(g_client_t *cl, char *text, size_t size, bool team) {
+  return true;
+}
+
+ClientWillChat G_ClientWillChat = G_ClientWillChat_Common;
 
 /**
  * @brief The tail of the `G_ClientDidChat` chain: a notification, so it does nothing.

--- a/src/game/common/g_entity.c
+++ b/src/game/common/g_entity.c
@@ -150,10 +150,10 @@ static void G_InitEntityFields(g_entity_t *ent) {
 }
 
 /**
- * @brief The tail of the `G_SpawnEntity` chain: the items, the weapons'
+ * @brief The tail of the `G_InitEntity` chain: the items, the weapons'
  * projectiles and the built-in classes.
  */
-static bool G_SpawnEntity_Common(g_entity_t *ent) {
+static bool G_InitEntity_Common(g_entity_t *ent) {
 
   // check item spawn functions
   const g_item_t *it = G_FindItemByClassName(ent->classname);
@@ -180,7 +180,7 @@ static bool G_SpawnEntity_Common(g_entity_t *ent) {
   return false;
 }
 
-SpawnEntity G_SpawnEntity = G_SpawnEntity_Common;
+InitEntity G_InitEntity = G_InitEntity_Common;
 
 /**
  * @brief The tail of the `G_LevelWillSpawn` chain: a notification, so it does nothing.
@@ -193,7 +193,7 @@ LevelWillSpawn G_LevelWillSpawn = G_LevelWillSpawn_Common;
 /**
  * @brief Populates common entity fields and then dispatches the class initializer.
  */
-static void G_SpawnEntityDef(cm_entity_t *def) {
+static void G_SpawnEntity(cm_entity_t *def) {
 
   const char *classname = gi.EntityValue(def, "classname")->string;
   g_entity_t *ent = G_AllocEntity(classname);
@@ -202,7 +202,7 @@ static void G_SpawnEntityDef(cm_entity_t *def) {
 
   G_InitEntityFields(ent);
 
-  if (G_SpawnEntity(ent)) {
+  if (G_InitEntity(ent)) {
     return;
   }
 
@@ -639,7 +639,7 @@ void G_SpawnEntities(const char *name, const cm_entity_t *props, cm_entity_t *co
     if (editor->value) {
       G_SpawnEditorEntity((int32_t) i, entities[i]);
     } else {
-      G_SpawnEntityDef(entities[i]);
+      G_SpawnEntity(entities[i]);
     }
   }
 

--- a/src/game/common/g_entity.c
+++ b/src/game/common/g_entity.c
@@ -825,12 +825,6 @@ static void G_worldspawn(g_entity_t *ent) {
 
   g_level.movement = G_ResolveMovement(movement);
 
-  // say so when it is not the usual one, because a player who does not know they
-  // are on Quake movement will think the server is broken
-  if (g_level.movement != PM_MOVEMENT_QUETOO) {
-    gi.BroadcastPrint(PRINT_HIGH, "Movement is %s\n", Pm_Movement(g_level.movement)->label);
-  }
-
   gi.Print("  Movement:   ^2%s^7\n", Pm_Movement(g_level.movement)->name);
 
   g_level.teams = (g_level.gameplay & GAMEPLAY_TEAMS) != 0;

--- a/src/game/common/g_entity.c
+++ b/src/game/common/g_entity.c
@@ -794,27 +794,16 @@ static void G_worldspawn(g_entity_t *ent) {
   // can't overwrite the resolved value with g_gravity's default (runtime changes still apply)
   g_gravity->modified = false;
 
+  // the gameplay is g_gameplay if the admin named one, else this level's
+  // metadata, else its worldspawn, else deathmatch, as the movement is below
   const cm_entity_t *gameplay_map = G_MapValue("gameplay");
-  if (q_strcmp(g_gameplay->string, "default")) { // prefer g_gameplay
-    g_level.gameplay = G_GameplayByName(g_gameplay->string)->id;
-  } else if (gameplay_map && (gameplay_map->parsed & ENTITY_INTEGER) && gameplay_map->integer > -1) { // then map metadata gameplay
-    g_level.gameplay = gameplay_map->integer;
-  } else { // or fall back on worldspawn
-    const cm_entity_t *gameplay = gi.EntityValue(ent->def, "gameplay");
-    if (*gameplay->string) {
-      g_level.gameplay = G_GameplayByName(gameplay->string)->id;
-    } else {
-      g_level.gameplay = GAMEPLAY_DEATHMATCH;
-    }
-  }
-  g_level.gameplay = G_ClampGameplay(g_level.gameplay); // coerce to a mode this module supports
+  const char *gameplay = (gameplay_map && (gameplay_map->parsed & ENTITY_INTEGER) && gameplay_map->integer > -1)
+                         ? G_GameplayById(gameplay_map->integer)->name
+                         : gi.EntityValue(ent->def, "gameplay")->string;
+
+  g_level.gameplay = G_ResolveGameplay(gameplay);
 
   gi.SetConfigString(CS_GAMEPLAY, va("%d", g_level.gameplay));
-
-  // g_gameplay holds what the admin asked for, which may be an alias, or "default"
-  // to defer to this level's worldspawn; publish what it resolved to as well, since
-  // that is the only form a server browser can present
-  gi.ForceSetCvarString("g_gameplay_mode", G_GameplayById(g_level.gameplay)->name);
 
   const cm_entity_t *items = gi.EntityValue(ent->def, "items");
   if (q_strcasecmp(items->string, "quake") == 0) {

--- a/src/game/common/g_main.c
+++ b/src/game/common/g_main.c
@@ -142,6 +142,7 @@ cvar_t *g_movement;
  * back to "default" returns to it rather than to Quetoo's.
  */
 static pm_movement_t g_movement_level;
+static g_gameplay_id_t g_gameplay_level;
 
 // player movement parameters (hydrated into pm_params_t by G_MovementParams)
 cvar_t *g_air_acceleration;
@@ -686,28 +687,38 @@ pm_movement_t G_ResolveMovement(const char *name) {
 }
 
 /**
- * @brief Parses `g_gameplay`, lets the module clamp it to a mode it actually
- * supports, and coerces the cvar string itself back to whichever canonical
- * value results.
- * @return The resulting gameplay mode, `GAMEPLAY_TEAMS` included.
- * @details This is the one place that owns the parse-clamp-coerce logic, so
- * `G_Init` (to fix the string at startup, before anything has changed it) and
- * `G_CheckRules` (when the cvar changes at runtime) share it rather than
- * keeping two copies that could drift.
+ * @brief Parses `g_gameplay` over what the level asked for, lets the module
+ * clamp it to a mode it supports, and coerces the cvar itself to whichever
+ * canonical name results. "default" defers to the level, and is left alone.
  */
 static g_gameplay_id_t G_CoerceGameplay(void) {
 
-  // parse, then let the module coerce it to a mode it actually supports
-  // (e.g. captures is always GAMEPLAY_TEAM_DEATHMATCH, regardless of what was asked for)
-  const g_gameplay_id_t id = G_ClampGameplay(G_GameplayByName(g_gameplay->string)->id);
+  g_gameplay_id_t gameplay = g_gameplay_level;
 
-  // "default" is itself a meaningful, canonical value (it defers to map/worldspawn
-  // metadata in G_worldspawn), so leave it alone rather than coercing it to "deathmatch"
-  if (q_strcmp(g_gameplay->string, "default")) {
-    gi.SetCvarString(g_gameplay->name, G_GameplayById(id)->name); // reject garbage values
+  if (q_strcmp(g_gameplay->string, "default")) { // "default" defers to the level
+    gameplay = G_ClampGameplay(G_GameplayByName(g_gameplay->string)->id);
+
+    gi.SetCvarString(g_gameplay->name, G_GameplayById(gameplay)->name); // reject garbage values
+  } else {
+    gameplay = G_ClampGameplay(gameplay);
   }
 
-  return id;
+  // g_gameplay holds what the admin asked for, which may be an alias, or "default";
+  // publish what it resolved to as well, since that is what a server browser shows
+  gi.ForceSetCvarString("g_gameplay_mode", G_GameplayById(gameplay)->name);
+
+  return gameplay;
+}
+
+/**
+ * @brief Resolves the gameplay for a level that asks for `name`, which may be
+ * empty. `g_gameplay` still wins if the admin named one.
+ */
+g_gameplay_id_t G_ResolveGameplay(const char *name) {
+
+  g_gameplay_level = name && *name ? G_GameplayByName(name)->id : GAMEPLAY_DEATHMATCH;
+
+  return G_CoerceGameplay();
 }
 
 /**

--- a/src/game/common/g_main.h
+++ b/src/game/common/g_main.h
@@ -39,6 +39,7 @@ extern g_media_t g_media;
 pm_params_t G_MovementParams(void);
 float G_LevelGravity(void);
 pm_movement_t G_ResolveMovement(const char *name);
+g_gameplay_id_t G_ResolveGameplay(const char *name);
 
 extern g_import_t gi;
 

--- a/src/game/common/g_module.h
+++ b/src/game/common/g_module.h
@@ -504,6 +504,20 @@ typedef bool (*HandleClientCommand)(g_client_t *cl, const char *cmd);
 extern HandleClientCommand G_HandleClientCommand;
 
 /**
+ * @brief The client is about to say `text`: their message after variable
+ * expansion, without their name, in a buffer of `size` that is theirs to edit.
+ * A feature that muzzles returns false, and nothing is delivered or reported;
+ * one that filters rewrites `text` in place. Empty, flooding and muted messages
+ * never get this far.
+ * @details Chainable. A link that calls previous MUST return false when previous
+ * does. The tail says yes.
+ * @return True to deliver the message.
+ */
+typedef bool (*ClientWillChat)(g_client_t *cl, char *text, size_t size, bool team);
+
+extern ClientWillChat G_ClientWillChat;
+
+/**
  * @brief The client said something, and it was delivered. `text` is the line as
  * the other clients saw it: the name, its color escapes and a trailing newline,
  * in a buffer that lives only for this call; a feature that keeps it copies it.

--- a/src/game/common/g_module.h
+++ b/src/game/common/g_module.h
@@ -122,17 +122,17 @@ typedef void (*LevelWillSpawn)(void);
 extern LevelWillSpawn G_LevelWillSpawn;
 
 /**
- * @brief Spawns an entity by its class name. The default knows the items, the
- * weapons' projectiles and the built-in classes.
- * @details Chainable. A feature adding entities spawns the class names it owns
- * and defers to previous for the rest. An entity nobody spawns is warned about
- * and freed by the caller. The editor spawns its inert placeholders without
- * consulting the chain.
- * @return True if the entity was spawned.
+ * @brief Initializes a freshly spawned entity by its class name. The default
+ * knows the items, the weapons' projectiles and the built-in classes.
+ * @details Chainable. A feature adding entities initializes the class names it
+ * owns and defers to previous for the rest. An entity nobody claims is warned
+ * about and freed by `G_SpawnEntity`. The editor spawns its inert placeholders
+ * without consulting the chain.
+ * @return True if the entity was initialized.
  */
-typedef bool (*SpawnEntity)(g_entity_t *ent);
+typedef bool (*InitEntity)(g_entity_t *ent);
 
-extern SpawnEntity G_SpawnEntity;
+extern InitEntity G_InitEntity;
 
 /**
  * @}

--- a/src/game/race/g_race.c
+++ b/src/game/race/g_race.c
@@ -46,7 +46,7 @@
 static struct {
   LevelWillSpawn LevelWillSpawn;
   ConfigureLevel ConfigureLevel;
-  SpawnEntity SpawnEntity;
+  InitEntity InitEntity;
   ClipEntity ClipEntity;
   PrepareSpawn PrepareSpawn;
   TossInventory TossInventory;
@@ -610,13 +610,13 @@ static void G_ConfigureLevel_Race(void) {
   });
 }
 
-static bool G_SpawnEntity_Race(g_entity_t *ent) {
+static bool G_InitEntity_Race(g_entity_t *ent) {
 
-  if (G_Race_SpawnEntity(ent)) {
+  if (G_Race_InitEntity(ent)) {
     return true;
   }
 
-  return previous.SpawnEntity(ent);
+  return previous.InitEntity(ent);
 }
 
 static bool G_ClipEntity_Race(const g_entity_t *mover, const g_entity_t *ent, const vec3_t start, const vec3_t end, const box3_t bounds) {
@@ -850,8 +850,8 @@ void G_Race_Init(void) {
   previous.ConfigureLevel = G_ConfigureLevel;
   G_ConfigureLevel = G_ConfigureLevel_Race;
 
-  previous.SpawnEntity = G_SpawnEntity;
-  G_SpawnEntity = G_SpawnEntity_Race;
+  previous.InitEntity = G_InitEntity;
+  G_InitEntity = G_InitEntity_Race;
 
   previous.ClipEntity = G_ClipEntity;
   G_ClipEntity = G_ClipEntity_Race;

--- a/src/game/race/g_race.h
+++ b/src/game/race/g_race.h
@@ -83,8 +83,8 @@ void G_Race_ArmStart(g_client_t *cl, const g_entity_t *start);
 bool G_Race_Debounced(g_client_t *cl, const g_entity_t *ent, float wait);
 
 /**
- * @brief Spawns the race triggers by class name, or returns false for a class
- * that is not one. Chained under `InitEntity` by `G_Race_Init`.
+ * @brief Initializes the race triggers and barriers by class name, or returns
+ * false for a class that is not one. Chained under `InitEntity` by `G_Race_Init`.
  */
 bool G_Race_InitEntity(g_entity_t *ent);
 

--- a/src/game/race/g_race.h
+++ b/src/game/race/g_race.h
@@ -84,9 +84,9 @@ bool G_Race_Debounced(g_client_t *cl, const g_entity_t *ent, float wait);
 
 /**
  * @brief Spawns the race triggers by class name, or returns false for a class
- * that is not one. Chained under `SpawnEntity` by `G_Race_Init`.
+ * that is not one. Chained under `InitEntity` by `G_Race_Init`.
  */
-bool G_Race_SpawnEntity(g_entity_t *ent);
+bool G_Race_InitEntity(g_entity_t *ent);
 
 /**
  * @brief The records for this map, read from `records/<map>.rec` when the

--- a/src/game/race/g_race_entity.c
+++ b/src/game/race/g_race_entity.c
@@ -412,7 +412,7 @@ static const struct {
   { "func_race_oneway_wall", G_func_race_oneway_wall },
 };
 
-bool G_Race_SpawnEntity(g_entity_t *ent) {
+bool G_Race_InitEntity(g_entity_t *ent) {
 
   for (size_t i = 0; i < lengthof(g_race_entity_classes); i++) {
     if (!q_strcmp(g_race_entity_classes[i].classname, ent->classname)) {


### PR DESCRIPTION
The deferred decisions from the review, as settled; follows #1011 and #1014 (whose commit this branch carries until it merges). One commit per item.

- **`InitEntity`**: the hook is named for what it does; `G_SpawnEntity` is the allocator again (`G_SpawnEntityDef` gone).
- **`G_ResolveGameplay`** mirrors `G_ResolveMovement`: the level's choice is remembered, `g_gameplay` wins when named, and "default" defers to the level - including at runtime, where it used to mean deathmatch. `g_gameplay_mode` is published from the resolver, so runtime changes reach the browser. An out-of-range metadata id now resolves to deathmatch instead of being stored raw.
- **Movement announced on begin**, with the gameplay, instead of a broadcast during spawn that nobody was present for. Note: the welcome (`Welcome to`, MOTD, gameplay, teams) was built and discarded under `#if 0` all along; it is now sent with `gi.ClientPrint`. That is a visible change for every module - shout if you'd rather keep it silent.
- **`ClientWillChat(cl, text, size, team)`**: false muzzles, or rewrite `text` in place; `ClientDidChat` stays. Per your Will/Did rule, the hooks still missing a counterpart are `ClientDidBegin`, `ClientDidChangeUserInfo`, `ClientWillDisconnect`, `LevelWillSpawn`, `FrameDidEnd` - I have not added those speculatively; say if you want them in one go.
- **One voxel-light fallback buffer** in `r_lights`, bound at all five sites (mesh, BSP x2, decal, sprite).

Verified: all modules incl. race build clean; `make check` 20/20; `racetest` and `edge` load headlessly. Read-only review applied (it caught the dead welcome). Renderer change not run under a renderer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)