### PR TITLE
Let the server say which barriers pass each client

### DIFF
--- a/src/cgame/cgame.h
+++ b/src/cgame/cgame.h
@@ -36,7 +36,7 @@
 #include <Objectively/RESTClient.h>
 #include <Objectively/Vector.h>
 
-#define CGAME_API_VERSION 37
+#define CGAME_API_VERSION 38
 
 /**
  * @brief The client game import struct imports engine functionailty to the client game.
@@ -628,19 +628,6 @@ typedef struct cg_import_s {
    * @return A trace result.
    */
   cm_trace_t (*Trace)(const vec3_t start, const vec3_t end, const box3_t bounds, const cl_entity_t *skip, int32_t contents);
-
-  /**
-   * @brief Clips a box trace against a single entity, the reciprocal of the
-   * game's `Clip`. The client's skip rules and `ClipEntity` still apply, the
-   * latter with no mover.
-   * @param start The trace start point.
-   * @param end The trace end point.
-   * @param bounds The trace bounds, or `Box3_Zero()` for point/line trace.
-   * @param test The entity to clip against.
-   * @param contents Solids matching this mask will clip the returned trace.
-   * @return A trace result.
-   */
-  cm_trace_t (*Clip)(const vec3_t start, const vec3_t end, const box3_t bounds, const cl_entity_t *test, int32_t contents);
 
   /**
    * @brief Traces a point ray from `start` to `end` against a single brush.

--- a/src/cgame/common/cg_module.h
+++ b/src/cgame/common/cg_module.h
@@ -158,8 +158,7 @@ extern ListGameplayModes Cg_ListGameplayModes;
  * @details Chainable, and the reciprocal of the game's `ClipEntity`: a feature
  * installs the same rule on both sides, or prediction disagrees with the server.
  * Prediction traces on behalf of `cgi.client->entity`; `mover` is `NULL` for a
- * trace with no entity behind it, as it is for `cgi.Clip`. An implementation
- * MUST be pure.
+ * trace with no entity behind it. An implementation MUST be pure.
  */
 typedef bool (*ClipEntity)(const cl_entity_t *mover, const cl_entity_t *ent, const vec3_t start, const vec3_t end, const box3_t bounds);
 

--- a/src/cgame/race/cg_race.c
+++ b/src/cgame/race/cg_race.c
@@ -30,11 +30,9 @@
  * whose client info arrives on `CS_RACE_GHOST`, and drawn translucent. Another
  * player's ghost is theirs to see and not ours.
  *
- * The barriers are the `func_race_*` brushes, whose conditions arrive on
- * `CS_RACE_BARRIERS` so that prediction clips them as the server will, from
- * the run the stats describe. The client predicts only itself, so the racer
- * `G_Race_ClipEntity` asks after is this client's entity, and anything else
- * that traces meets a wall.
+ * The barriers are the `func_race_*` brushes. The server decides which of them
+ * pass this client and says so every frame, as `SV_CMD_RACE_BARRIERS`, so that
+ * prediction clips exactly the set the server will.
  */
 
 // how much of the ghost is there
@@ -42,6 +40,7 @@
 
 static struct {
   ParseConfigString ParseConfigString;
+  ParseServerCommand ParseServerCommand;
   MediaDidLoad MediaDidLoad;
   FilterEntity FilterEntity;
   ClientInfo ClientInfo;
@@ -51,14 +50,9 @@ static struct {
 
 static cg_client_info_t cg_race_ghost;
 
-typedef struct {
-  int32_t entity; // the barrier's entity number
-  g_race_barrier_t barrier; // RACE_BARRIER_NONE for an empty slot
-  g_race_gate_t gate;
-  vec3_t move_dir;
-} cg_race_barrier_t;
-
-static cg_race_barrier_t cg_race_barriers[RACE_MAX_BARRIERS];
+// the entity numbers of the barriers that pass this client, as the server last said
+static int32_t cg_race_passable[RACE_MAX_BARRIERS];
+static size_t cg_race_passable_count;
 
 uint32_t Cg_Race_Time(const player_state_t *ps) {
   return (uint16_t) ps->stats[STAT_RACE_TIME_LOW] | ((uint32_t) (uint16_t) ps->stats[STAT_RACE_TIME_HIGH] << 16);
@@ -76,71 +70,6 @@ static bool Cg_Race_IsGhost(const cl_entity_t *ent) {
   return ent->current.effects & EF_RACE_GHOST;
 }
 
-/**
- * @brief Reads one barrier's slot, as `G_func_race_Init` wrote it; an empty
- * or malformed slot is no barrier, and the brush is then plainly solid.
- */
-static void Cg_Race_ParseBarrier(int32_t slot) {
-  cg_race_barrier_t *b = &cg_race_barriers[slot];
-  const char *s = cgi.ConfigString(CS_RACE_BARRIERS + slot);
-
-  *b = (cg_race_barrier_t) { .barrier = RACE_BARRIER_NONE };
-
-  if (!*s) {
-    return;
-  }
-
-  int32_t entity, barrier, mode, invert, n = 0;
-
-  if (sscanf(s, "%d\\%d\\%n", &entity, &barrier, &n) != 2 || !n || entity < 0 || entity >= MAX_ENTITIES) {
-    Cg_Warn("Invalid barrier \"%s\"\n", s);
-    return;
-  }
-
-  switch (barrier) {
-    case RACE_BARRIER_GATE:
-      if (sscanf(s + n, "%hu\\%d\\%d", &b->gate.checkpoint, &mode, &invert) != 3 ||
-          b->gate.checkpoint < 1 || b->gate.checkpoint > RACE_MAX_CHECKPOINTS ||
-          (mode != RACE_GATE_AT_LEAST && mode != RACE_GATE_EXACT)) {
-        Cg_Warn("Invalid gate \"%s\"\n", s);
-        return;
-      }
-      b->gate.mode = mode;
-      b->gate.invert = invert != 0;
-      break;
-    case RACE_BARRIER_WALL:
-      if (sscanf(s + n, "%f\\%f", &b->move_dir.x, &b->move_dir.y) != 2) {
-        Cg_Warn("Invalid one-way wall \"%s\"\n", s);
-        return;
-      }
-      break;
-    default:
-      Cg_Warn("Invalid barrier \"%s\"\n", s);
-      return;
-  }
-
-  b->entity = entity;
-  b->barrier = barrier;
-}
-
-static void Cg_Race_ParseBarriers(void) {
-
-  for (int32_t i = 0; i < RACE_MAX_BARRIERS; i++) {
-    Cg_Race_ParseBarrier(i);
-  }
-}
-
-static const cg_race_barrier_t *Cg_Race_BarrierFor(const cl_entity_t *ent) {
-
-  for (int32_t i = 0; i < RACE_MAX_BARRIERS; i++) {
-    if (cg_race_barriers[i].barrier != RACE_BARRIER_NONE && cg_race_barriers[i].entity == ent->current.number) {
-      return &cg_race_barriers[i];
-    }
-  }
-
-  return NULL;
-}
-
 static bool Cg_ParseConfigString_Race(int32_t index) {
 
   if (index == CS_RACE_GHOST) {
@@ -148,70 +77,60 @@ static bool Cg_ParseConfigString_Race(int32_t index) {
     return true;
   }
 
-  if (index >= CS_RACE_BARRIERS && index < CS_RACE_BARRIERS + RACE_MAX_BARRIERS) {
-    Cg_Race_ParseBarrier(index - CS_RACE_BARRIERS);
-    return true;
-  }
-
   return previous.ParseConfigString(index);
 }
 
 /**
- * @brief The client infos are media, and are reloaded with it; the barriers
- * are re-read so that a new level's slots replace the last one's.
+ * @brief The barriers that pass this client, which the server sends every frame.
+ * More than fit are read and dropped, so that the message stays in step.
+ */
+static bool Cg_ParseServerCommand_Race(int32_t cmd) {
+
+  if (cmd != SV_CMD_RACE_BARRIERS) {
+    return previous.ParseServerCommand(cmd);
+  }
+
+  const int32_t count = cgi.ReadByte();
+
+  cg_race_passable_count = 0;
+
+  for (int32_t i = 0; i < count; i++) {
+    const int32_t entity = cgi.ReadShort();
+
+    if (cg_race_passable_count < RACE_MAX_BARRIERS) {
+      cg_race_passable[cg_race_passable_count++] = entity;
+    }
+  }
+
+  return true;
+}
+
+/**
+ * @brief The client infos are media, and are reloaded with it; a new level
+ * starts with no barriers passed until the server says otherwise.
  */
 static void Cg_MediaDidLoad_Race(void) {
 
   previous.MediaDidLoad();
 
   Cg_Race_LoadGhost();
-  Cg_Race_ParseBarriers();
-}
-
-static bool Cg_Race_ClipPrevious(const cl_entity_t *mover, const cl_entity_t *ent, const vec3_t start, const vec3_t end, const box3_t bounds) {
-  return previous.ClipEntity ? previous.ClipEntity(mover, ent, start, end, bounds) : true;
+  cg_race_passable_count = 0;
 }
 
 /**
- * @brief `G_Race_ClipEntity`, as the client can apply it to itself.
+ * @brief `G_Race_ClipEntity`, from the set the server sent: a barrier the
+ * server let this client pass does not clip this client's own moves; it clips
+ * everything else, as it does on the server.
  */
 static bool Cg_ClipEntity_Race(const cl_entity_t *mover, const cl_entity_t *ent, const vec3_t start, const vec3_t end, const box3_t bounds) {
-  const cg_race_barrier_t *b = Cg_Race_BarrierFor(ent);
 
-  if (!b || !mover || mover != cgi.client->entity) {
-    return Cg_Race_ClipPrevious(mover, ent, start, end, bounds);
-  }
-
-  const player_state_t *ps = &cgi.client->frame.ps;
-
-  if (b->barrier == RACE_BARRIER_GATE) {
-
-    if (ps->stats[STAT_RACE_RUN] != RACE_RUN_ACTIVE) {
+  for (size_t i = 0; mover == cgi.client->entity && i < cg_race_passable_count; i++) {
+    if (cg_race_passable[i] == ent->current.number) {
       return false;
     }
-
-    const bool open = b->gate.mode == RACE_GATE_EXACT
-                      ? ps->stats[STAT_RACE_CHECKPOINTS] == b->gate.checkpoint
-                      : ps->stats[STAT_RACE_CHECKPOINTS] >= b->gate.checkpoint;
-
-    if (open != b->gate.invert) {
-      return false;
-    }
-
-    return Cg_Race_ClipPrevious(mover, ent, start, end, bounds);
   }
 
-  if (cgi.Clip(start, start, bounds, ent, CONTENTS_MASK_CLIP_PLAYER).start_solid) {
-    return false;
-  }
-
-  const vec3_t travel = Vec3_Subtract(end, start);
-
-  if (travel.x * b->move_dir.x + travel.y * b->move_dir.y > 0.f) {
-    return false;
-  }
-
-  return Cg_Race_ClipPrevious(mover, ent, start, end, bounds);
+  return previous.ClipEntity ? previous.ClipEntity(mover, ent, start, end, bounds) : true;
 }
 
 static bool Cg_FilterEntity_Race(const cl_entity_t *ent) {
@@ -256,6 +175,9 @@ void Cg_Race_Init(void) {
 
   previous.ParseConfigString = Cg_ParseConfigString;
   Cg_ParseConfigString = Cg_ParseConfigString_Race;
+
+  previous.ParseServerCommand = Cg_ParseServerCommand;
+  Cg_ParseServerCommand = Cg_ParseServerCommand_Race;
 
   previous.MediaDidLoad = Cg_MediaDidLoad;
   Cg_MediaDidLoad = Cg_MediaDidLoad_Race;

--- a/src/cgame/race/cg_race.c
+++ b/src/cgame/race/cg_race.c
@@ -54,6 +54,9 @@ static cg_client_info_t cg_race_ghost;
 static int32_t cg_race_passable[RACE_MAX_BARRIERS];
 static size_t cg_race_passable_count;
 
+/**
+ * @see cg_race.h
+ */
 uint32_t Cg_Race_Time(const player_state_t *ps) {
   return (uint16_t) ps->stats[STAT_RACE_TIME_LOW] | ((uint32_t) (uint16_t) ps->stats[STAT_RACE_TIME_HIGH] << 16);
 }
@@ -66,10 +69,16 @@ static void Cg_Race_LoadGhost(void) {
   Cg_LoadClient(&cg_race_ghost, cgi.ConfigString(CS_RACE_GHOST));
 }
 
+/**
+ * @brief Whether `ent` is the course record's ghost, which the server marks.
+ */
 static bool Cg_Race_IsGhost(const cl_entity_t *ent) {
   return ent->current.effects & EF_RACE_GHOST;
 }
 
+/**
+ * @brief The ghost is dressed again whenever the record holder changes.
+ */
 static bool Cg_ParseConfigString_Race(int32_t index) {
 
   if (index == CS_RACE_GHOST) {
@@ -133,6 +142,9 @@ static bool Cg_ClipEntity_Race(const cl_entity_t *mover, const cl_entity_t *ent,
   return previous.ClipEntity ? previous.ClipEntity(mover, ent, start, end, bounds) : true;
 }
 
+/**
+ * @brief Another player's ghost is theirs to see and not ours.
+ */
 static bool Cg_FilterEntity_Race(const cl_entity_t *ent) {
 
   if (Cg_Race_IsGhost(ent) && ent->current.client != cgi.client->frame.ps.client) {
@@ -142,6 +154,9 @@ static bool Cg_FilterEntity_Race(const cl_entity_t *ent) {
   return previous.FilterEntity(ent);
 }
 
+/**
+ * @brief The ghost wears the record holder's client info, not the slot it names.
+ */
 static cg_client_info_t *Cg_ClientInfo_Race(const cl_entity_t *ent) {
 
   if (Cg_Race_IsGhost(ent)) {
@@ -151,6 +166,9 @@ static cg_client_info_t *Cg_ClientInfo_Race(const cl_entity_t *ent) {
   return previous.ClientInfo(ent);
 }
 
+/**
+ * @brief The ghost is drawn translucent, and casts no shadow.
+ */
 static void Cg_EntityEffects_Race(cl_entity_t *ent, r_entity_t *e) {
 
   previous.EntityEffects(ent, e);
@@ -161,6 +179,9 @@ static void Cg_EntityEffects_Race(cl_entity_t *ent, r_entity_t *e) {
   }
 }
 
+/**
+ * @see cg_race.h
+ */
 void Cg_Race_Init(void) {
   static bool installed;
 

--- a/src/client/cl_cgame.c
+++ b/src/client/cl_cgame.c
@@ -269,7 +269,6 @@ void Cl_InitCgame(void) {
   import.BoxLeafnums = Cm_BoxLeafnums;
   import.PointInsideBrush = Cm_PointInsideBrush;
   import.Trace = Cl_Trace;
-  import.Clip = Cl_Clip;
   import.PointLeafnum = Cm_PointLeafnum;
   import.TraceToBrush = Cm_TraceToBrush;
 

--- a/src/client/cl_predict.c
+++ b/src/client/cl_predict.c
@@ -199,29 +199,6 @@ static void Cl_ClipTraceToEntities(cl_trace_t *trace) {
 }
 
 /**
- * @brief Tests a clip of the specified translation against the specified
- * entity. This is the reciprocal of `Sv_Clip`.
- */
-cm_trace_t Cl_Clip(const vec3_t start, const vec3_t end, const box3_t bounds, const cl_entity_t *test, int32_t contents) {
-
-  cl_trace_t trace = {
-    .start = start,
-    .end = end,
-    .bounds = bounds,
-    .abs_bounds = Cm_TraceBounds(start, end, bounds),
-    .contents = contents,
-    .trace = {
-      .fraction = 1.f,
-      .end = end,
-    }
-  };
-
-  Cl_ClipTraceToEntity(&trace, (cl_entity_t *) test);
-
-  return trace.trace;
-}
-
-/**
  * @brief Client-side collision model tracing. This is the reciprocal of
  * `Sv_Trace`.
  *

--- a/src/client/cl_predict.h
+++ b/src/client/cl_predict.h
@@ -25,7 +25,6 @@
 
 int32_t Cl_PointContents(const vec3_t point);
 int32_t Cl_BoxContents(const box3_t bounds);
-cm_trace_t Cl_Clip(const vec3_t start, const vec3_t end, const box3_t bounds, const cl_entity_t *test, int32_t contents);
 cm_trace_t Cl_Trace(const vec3_t start, const vec3_t end, const box3_t bounds, const cl_entity_t *skip, int32_t contents);
 
 #if defined(__CL_LOCAL_H__)

--- a/src/game/race/g_race.c
+++ b/src/game/race/g_race.c
@@ -55,6 +55,7 @@ static struct {
   HandleClientCommand HandleClientCommand;
   ClientWillThink ClientWillThink;
   ClientDidMove ClientDidMove;
+  FrameDidEnd FrameDidEnd;
   ClientWillDisconnect ClientWillDisconnect;
   WriteStats WriteStats;
   WriteScore WriteScore;
@@ -751,6 +752,20 @@ static void G_ClientWillThink_Race(g_client_t *cl, const pm_cmd_t *cmd) {
 }
 
 /**
+ * @brief Every client is told which barriers pass them, every frame.
+ */
+static void G_FrameDidEnd_Race(void) {
+
+  previous.FrameDidEnd();
+
+  G_ForEachClient(cl, {
+    if (cl->entity) {
+      G_Race_UpdateBarriers(cl);
+    }
+  });
+}
+
+/**
  * @brief Samples the speed for the finish report, and starts the run for a
  * client who has just left an exit-mode start zone.
  */
@@ -876,6 +891,9 @@ void G_Race_Init(void) {
 
   previous.ClientDidMove = G_ClientDidMove;
   G_ClientDidMove = G_ClientDidMove_Race;
+
+  previous.FrameDidEnd = G_FrameDidEnd;
+  G_FrameDidEnd = G_FrameDidEnd_Race;
 
   previous.ClientWillDisconnect = G_ClientWillDisconnect;
   G_ClientWillDisconnect = G_ClientWillDisconnect_Race;

--- a/src/game/race/g_race.h
+++ b/src/game/race/g_race.h
@@ -147,7 +147,15 @@ size_t G_Race_Rank(const g_race_record_t *record, size_t *count);
 void G_Race_ResolveStages(void);
 
 /**
- * @brief Whether `ent` clips `mover`, which is where a gate or one-way wall
- * decides. Pure, and chained under `ClipEntity` by `G_Race_Init`.
+ * @brief Decides which barriers pass `cl` as they stand now, keeps the answer
+ * for `G_Race_ClipEntity`, and sends it to them as `SV_CMD_RACE_BARRIERS`.
+ * Called for every client at the end of every frame, so nothing goes stale.
+ */
+void G_Race_UpdateBarriers(g_client_t *cl);
+
+/**
+ * @brief Whether `ent` clips `mover`: a barrier does unless the last
+ * `G_Race_UpdateBarriers` let the mover pass it. Chained under `ClipEntity` by
+ * `G_Race_Init`.
  */
 bool G_Race_ClipEntity(const g_entity_t *mover, const g_entity_t *ent, const vec3_t start, const vec3_t end, const box3_t bounds);

--- a/src/game/race/g_race_entity.c
+++ b/src/game/race/g_race_entity.c
@@ -266,8 +266,7 @@ static void G_trigger_race_finish(g_entity_t *ent) {
 
 /**
  * @brief The common half of every barrier's setup: an inline brush, solid,
- * whose conditions `G_Race_ClipEntity` applies, published on the barrier's
- * `CS_RACE_BARRIERS` slot so that the client applies them too.
+ * listed with the course so that `G_Race_UpdateBarriers` can decide it.
  */
 static void G_func_race_Init(g_entity_t *ent, g_race_barrier_t barrier) {
 
@@ -284,24 +283,21 @@ static void G_func_race_Init(g_entity_t *ent, g_race_barrier_t barrier) {
   }
 
   ent->race_barrier = barrier;
+  ent->race_barrier_slot = g_level.race_course.barrier_count;
   ent->solid = SOLID_BSP;
   ent->move_type = MOVE_TYPE_NONE;
 
   gi.SetModel(ent, ent->model);
   gi.LinkEntity(ent);
 
-  const char *params = barrier == RACE_BARRIER_GATE
-                       ? va("%u\\%d\\%d", ent->race_gate.checkpoint, ent->race_gate.mode, ent->race_gate.invert)
-                       : va("%g\\%g", ent->move_dir.x, ent->move_dir.y);
-
-  gi.SetConfigString(CS_RACE_BARRIERS + g_level.race_course.barrier_count++,
-                     va("%u\\%d\\%s", ent->s.number, barrier, params));
+  g_level.race_course.barriers[g_level.race_course.barrier_count++] = ent;
 }
 
 /*QUAKED func_race_checkpoint_gate (0 .5 .8) ?
  A brush that is solid to a racer until the run satisfies its checkpoint
  condition, and solid to everything else always. A client with no run under way
- passes freely. Texture it with clip so that it is never seen.
+ passes freely. Texture it with clip so that it is never seen. The gate opens
+ the frame after its checkpoint is reached, so leave a stride between them.
 
  -------- Keys --------
  cp : The checkpoint the gate is about, from 1.
@@ -342,6 +338,9 @@ static void G_func_race_checkpoint_gate(g_entity_t *ent) {
 /*QUAKED func_race_oneway_wall (0 .5 .8) ?
  A brush that a racer passes through in one direction and not the other, and
  that is solid to everything else. Texture it with clip so that it is never seen.
+ The wall is judged by which side of its centre a racer stands: it passes them
+ from its entry side in any direction, and stops them from the far side. Make it
+ one thin brush from floor to ceiling, so that there is no over, under or gap.
 
  -------- Keys --------
  angle : The direction of travel that passes, in the horizontal plane.
@@ -361,25 +360,20 @@ static void G_func_race_oneway_wall(g_entity_t *ent) {
 }
 
 /**
- * @brief Called for every entity a trace considers, so the ones that are not
- * barriers, and everything that is not a client, are turned away first.
+ * @brief Whether `ent`, a barrier, lets `cl` pass as they stand right now.
  *
- * A wall the client is already inside never clips: the only way in was the way
- * it allows, and clipping it from within would wedge the client. The test asks
- * the server for this one brush, which asks back here with no mover and is told
- * the wall is a wall, so the recursion ends there.
+ * A gate opens on the run's checkpoints. A wall passes a client on its entry
+ * side or already inside it, and stops one on the far side, which is the one
+ * direction it allows without anyone measuring a direction: a client who is
+ * inside came in the way it permits, and one who has crossed is behind it.
  */
-bool G_Race_ClipEntity(const g_entity_t *mover, const g_entity_t *ent, const vec3_t start, const vec3_t end, const box3_t bounds) {
-
-  if (ent->race_barrier == RACE_BARRIER_NONE || !mover || !mover->client) {
-    return true;
-  }
+static bool G_Race_Passes(const g_client_t *cl, const g_entity_t *ent) {
 
   if (ent->race_barrier == RACE_BARRIER_GATE) {
-    const g_race_run_t *run = &mover->client->race_run;
+    const g_race_run_t *run = &cl->race_run;
 
     if (run->state != RACE_RUN_ACTIVE) {
-      return false;
+      return true;
     }
 
     const g_race_gate_t *gate = &ent->race_gate;
@@ -387,16 +381,60 @@ bool G_Race_ClipEntity(const g_entity_t *mover, const g_entity_t *ent, const vec
                       ? run->checkpoint_count == gate->checkpoint
                       : run->checkpoint_count >= gate->checkpoint;
 
-    return open == gate->invert;
+    return open != gate->invert;
   }
 
-  if (gi.Clip(start, start, bounds, ent, CONTENTS_MASK_CLIP_PLAYER).start_solid) {
-    return false;
+  const g_entity_t *self = cl->entity;
+
+  if (gi.Clip(self->s.origin, self->s.origin, self->bounds, ent, CONTENTS_MASK_CLIP_PLAYER).start_solid) {
+    return true;
   }
 
-  const vec3_t travel = Vec3_Subtract(end, start);
+  const vec3_t offset = Vec3_Subtract(self->s.origin, Box3_Center(ent->abs_bounds));
 
-  return travel.x * ent->move_dir.x + travel.y * ent->move_dir.y <= 0.f;
+  return offset.x * ent->move_dir.x + offset.y * ent->move_dir.y < 0.f;
+}
+
+void G_Race_UpdateBarriers(g_client_t *cl) {
+  const g_race_course_t *course = &g_level.race_course;
+
+  if (!course->barrier_count) {
+    return;
+  }
+
+  cl->race_passable = 0;
+
+  for (uint16_t i = 0; i < course->barrier_count; i++) {
+    if (G_Race_Passes(cl, course->barriers[i])) {
+      cl->race_passable |= 1u << i;
+    }
+  }
+
+  gi.WriteByte(SV_CMD_RACE_BARRIERS);
+  gi.WriteByte(__builtin_popcount(cl->race_passable));
+
+  for (uint16_t i = 0; i < course->barrier_count; i++) {
+    if (cl->race_passable & (1u << i)) {
+      gi.WriteShort(course->barriers[i]->s.number);
+    }
+  }
+
+  gi.Unicast(cl, false);
+}
+
+/**
+ * @brief Called for every entity a trace considers, so the ones that are not
+ * barriers, and everything that is not a client, are turned away first. The
+ * answer is the one `G_Race_UpdateBarriers` settled and sent at the end of the
+ * last frame, so that the client predicts against the same set.
+ */
+bool G_Race_ClipEntity(const g_entity_t *mover, const g_entity_t *ent, const vec3_t start, const vec3_t end, const box3_t bounds) {
+
+  if (ent->race_barrier == RACE_BARRIER_NONE || !mover || !mover->client) {
+    return true;
+  }
+
+  return !(mover->client->race_passable & (1u << ent->race_barrier_slot));
 }
 
 static const struct {

--- a/src/game/race/g_race_entity.c
+++ b/src/game/race/g_race_entity.c
@@ -403,15 +403,17 @@ void G_Race_UpdateBarriers(g_client_t *cl) {
   }
 
   cl->race_passable = 0;
+  int32_t count = 0;
 
   for (uint16_t i = 0; i < course->barrier_count; i++) {
     if (G_Race_Passes(cl, course->barriers[i])) {
       cl->race_passable |= 1u << i;
+      count++;
     }
   }
 
   gi.WriteByte(SV_CMD_RACE_BARRIERS);
-  gi.WriteByte(__builtin_popcount(cl->race_passable));
+  gi.WriteByte(count);
 
   for (uint16_t i = 0; i < course->barrier_count; i++) {
     if (cl->race_passable & (1u << i)) {

--- a/src/game/race/g_types.h
+++ b/src/game/race/g_types.h
@@ -59,6 +59,7 @@ typedef enum {
   SV_CMD_CENTER_PRINT,
   SV_CMD_SCORES,
   SV_CMD_SNAP_ANGLES,
+  SV_CMD_RACE_BARRIERS, // [byte] count, [short] entity...: the barriers that pass this client
 } g_sv_packet_cmd_t;
 
 /**
@@ -90,7 +91,6 @@ typedef enum {
 #define CS_RACE_COURSE     (CS_GAME + 10) // checkpoints\finishes\valid, for the HUD
 #define CS_RACE_RECORDS    (CS_GAME + 11) // the top times under this movement, name\time pairs
 #define CS_RACE_GHOST      (CS_GAME + 12) // the course record holder as a CS_CLIENTS string, for the ghost's skin
-#define CS_RACE_BARRIERS   (CS_GAME + 13) // RACE_MAX_BARRIERS of entity\\barrier\\params, so the client predicts them
 
 /**
  * @brief Player state statistics (inventory, score, etc).
@@ -138,7 +138,7 @@ _Static_assert(STAT_RACE_RUNS < MAX_STATS, "the race stats must fit the stat arr
  */
 #define RACE_MAX_CHECKPOINTS 64
 
-// how many func_race_* brushes a level may have, one config string each
+// how many func_race_* brushes a level may have
 #define RACE_MAX_BARRIERS 32
 
 // how many of a map's records CS_RACE_RECORDS carries, and the board shows
@@ -216,7 +216,8 @@ typedef struct {
   uint16_t checkpoint_count, split_count, stage_count;
   uint16_t start_count;
   uint16_t finish_count;
-  uint16_t barrier_count; // func_race_* brushes published so far
+  struct g_entity_s *barriers[RACE_MAX_BARRIERS]; // the func_race_* brushes, in spawn order
+  uint16_t barrier_count;
   bool malformed, splits_malformed, stages_malformed; // a number out of range was seen
   bool valid;        // checkpoints 1 through N and a finish; nothing else bears on it
   bool splits_valid; // splits 1 through N, so they time
@@ -1525,6 +1526,12 @@ struct g_client_s {
   g_race_run_t race_run;
 
   /**
+   * @brief Bit N is set while `race_course.barriers[N]` lets this client pass,
+   * as decided at the end of the last frame and sent to them then.
+   */
+  uint32_t race_passable;
+
+  /**
    * @brief The race trigger last touched and when, so that standing in one does
    * not fire it every frame.
    */
@@ -2129,6 +2136,7 @@ struct g_entity_s {
    */
   g_race_barrier_t race_barrier;
   g_race_gate_t race_gate;
+  uint16_t race_barrier_slot; // its index in race_course.barriers
 };
 
 typedef struct g_entity_s g_entity_t;


### PR DESCRIPTION
Item 6 of the #963 sweep, as Jay proposed: instead of the client mirroring each barrier's rule (which needed `cgi.Clip`, a mover-aware predicate and `CS_RACE_BARRIERS`), the server decides which barriers pass each client and says so every frame.

- **Server**: `G_Race_UpdateBarriers(cl)` from a `FrameDidEnd` link, for every client with an entity: a gate passes by the run's checkpoints (as before); a wall passes a client on its *entry side* or inside it, and stops one across - no direction measured. The set is kept in `cl->race_passable` (a bit per barrier, `race_course.barriers[]`) and unicast unreliably as `SV_CMD_RACE_BARRIERS [byte count][short entity]...` in the same frame, so the client's replay always sees a frame and a set that agree. `G_Race_ClipEntity` is a bit test on the mover's set. Nothing is sent on a map with no barriers.
- **Client**: `Cg_ParseServerCommand` (first consumer of that hook) reads the set; `Cg_ClipEntity_Race` is a membership test for this client's own moves and clips everything else, as the server does.
- **Gone**: `cgi.Clip`/`Cl_Clip`, `CS_RACE_BARRIERS` and its slot accounting and parser. `CGAME_API_VERSION` 38. Net -50 lines.

Two properties of judging a wall by side, now in the QUAKED docs: a wall passes from its entry side in *any* direction (so a short one can be dropped through) and its bounds centre must be inside it (so one thin convex brush, floor to ceiling); and a gate opens the frame after its checkpoint (so a stride between them). Review note I did not act on: `G_ClientRespawn_` zeroes `race_passable` (all solid) for the remainder of the spawn frame; the frame's end recomputes it.

Verified: all modules incl. race build clean; `make check` 20/20; `racetest` loads headlessly. Read-only review applied. Not lap-tested with a client - gates and the one-way wall on `racetest` want a lap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)