### PR TITLE
Ask ClipEntity only who is moving and what is in the way

### DIFF
--- a/src/cgame/cgame.h
+++ b/src/cgame/cgame.h
@@ -36,7 +36,7 @@
 #include <Objectively/RESTClient.h>
 #include <Objectively/Vector.h>
 
-#define CGAME_API_VERSION 38
+#define CGAME_API_VERSION 39
 
 /**
  * @brief The client game import struct imports engine functionailty to the client game.
@@ -1110,7 +1110,7 @@ typedef struct cg_export_s {
    * that prediction clips exactly what the server does.
    * @param mover The entity the trace is on behalf of, or `NULL`.
    */
-  bool (*ClipEntity)(const cl_entity_t *mover, const cl_entity_t *ent, const vec3_t start, const vec3_t end, const box3_t bounds);
+  bool (*ClipEntity)(const cl_entity_t *mover, const cl_entity_t *ent);
 } cg_export_t;
 
 #endif

--- a/src/cgame/common/cg_module.h
+++ b/src/cgame/common/cg_module.h
@@ -160,7 +160,7 @@ extern ListGameplayModes Cg_ListGameplayModes;
  * Prediction traces on behalf of `cgi.client->entity`; `mover` is `NULL` for a
  * trace with no entity behind it. An implementation MUST be pure.
  */
-typedef bool (*ClipEntity)(const cl_entity_t *mover, const cl_entity_t *ent, const vec3_t start, const vec3_t end, const box3_t bounds);
+typedef bool (*ClipEntity)(const cl_entity_t *mover, const cl_entity_t *ent);
 
 extern ClipEntity Cg_ClipEntity;
 

--- a/src/cgame/race/cg_race.c
+++ b/src/cgame/race/cg_race.c
@@ -131,7 +131,7 @@ static void Cg_MediaDidLoad_Race(void) {
  * server let this client pass does not clip this client's own moves; it clips
  * everything else, as it does on the server.
  */
-static bool Cg_ClipEntity_Race(const cl_entity_t *mover, const cl_entity_t *ent, const vec3_t start, const vec3_t end, const box3_t bounds) {
+static bool Cg_ClipEntity_Race(const cl_entity_t *mover, const cl_entity_t *ent) {
 
   for (size_t i = 0; mover == cgi.client->entity && i < cg_race_passable_count; i++) {
     if (cg_race_passable[i] == ent->current.number) {
@@ -139,7 +139,7 @@ static bool Cg_ClipEntity_Race(const cl_entity_t *mover, const cl_entity_t *ent,
     }
   }
 
-  return previous.ClipEntity ? previous.ClipEntity(mover, ent, start, end, bounds) : true;
+  return previous.ClipEntity ? previous.ClipEntity(mover, ent) : true;
 }
 
 /**

--- a/src/client/cl_predict.c
+++ b/src/client/cl_predict.c
@@ -160,7 +160,7 @@ static bool Cl_ClipTraceToEntity(cl_trace_t *trace, cl_entity_t *ent) {
     return false;
   }
 
-  if (cls.cgame->ClipEntity && !cls.cgame->ClipEntity(trace->skip, ent, trace->start, trace->end, trace->bounds)) {
+  if (cls.cgame->ClipEntity && !cls.cgame->ClipEntity(trace->skip, ent)) {
     return false;
   }
 

--- a/src/game/common/g_module.h
+++ b/src/game/common/g_module.h
@@ -288,7 +288,7 @@ extern PrepareMove G_PrepareMove;
  * `Sv_Trace` and `Cl_Trace`, and speculative traces such as the bots' lookahead
  * run it many times for a move that never happens.
  */
-typedef bool (*ClipEntity)(const g_entity_t *mover, const g_entity_t *ent, const vec3_t start, const vec3_t end, const box3_t bounds);
+typedef bool (*ClipEntity)(const g_entity_t *mover, const g_entity_t *ent);
 
 extern ClipEntity G_ClipEntity;
 

--- a/src/game/game.h
+++ b/src/game/game.h
@@ -25,7 +25,7 @@
 #include "collision/cm_types.h"
 #include <Objectively/Vector.h>
 
-#define GAME_API_VERSION 35
+#define GAME_API_VERSION 36
 
 /**
  * @brief Server flags for `g_entity_t`.
@@ -800,5 +800,5 @@ typedef struct g_export_s {
    * an entity solid to some movers and not others.
    * @param mover The entity the trace is on behalf of, or `NULL`.
    */
-  bool (*ClipEntity)(const g_entity_t *mover, const g_entity_t *ent, const vec3_t start, const vec3_t end, const box3_t bounds);
+  bool (*ClipEntity)(const g_entity_t *mover, const g_entity_t *ent);
 } g_export_t;

--- a/src/game/race/g_race.c
+++ b/src/game/race/g_race.c
@@ -620,13 +620,13 @@ static bool G_InitEntity_Race(g_entity_t *ent) {
   return previous.InitEntity(ent);
 }
 
-static bool G_ClipEntity_Race(const g_entity_t *mover, const g_entity_t *ent, const vec3_t start, const vec3_t end, const box3_t bounds) {
+static bool G_ClipEntity_Race(const g_entity_t *mover, const g_entity_t *ent) {
 
-  if (!G_Race_ClipEntity(mover, ent, start, end, bounds)) {
+  if (!G_Race_ClipEntity(mover, ent)) {
     return false;
   }
 
-  return previous.ClipEntity ? previous.ClipEntity(mover, ent, start, end, bounds) : true;
+  return previous.ClipEntity ? previous.ClipEntity(mover, ent) : true;
 }
 
 /**

--- a/src/game/race/g_race.h
+++ b/src/game/race/g_race.h
@@ -158,4 +158,4 @@ void G_Race_UpdateBarriers(g_client_t *cl);
  * `G_Race_UpdateBarriers` let the mover pass it. Chained under `ClipEntity` by
  * `G_Race_Init`.
  */
-bool G_Race_ClipEntity(const g_entity_t *mover, const g_entity_t *ent, const vec3_t start, const vec3_t end, const box3_t bounds);
+bool G_Race_ClipEntity(const g_entity_t *mover, const g_entity_t *ent);

--- a/src/game/race/g_race_entity.c
+++ b/src/game/race/g_race_entity.c
@@ -430,7 +430,7 @@ void G_Race_UpdateBarriers(g_client_t *cl) {
  * answer is the one `G_Race_UpdateBarriers` settled and sent at the end of the
  * last frame, so that the client predicts against the same set.
  */
-bool G_Race_ClipEntity(const g_entity_t *mover, const g_entity_t *ent, const vec3_t start, const vec3_t end, const box3_t bounds) {
+bool G_Race_ClipEntity(const g_entity_t *mover, const g_entity_t *ent) {
 
   if (ent->race_barrier == RACE_BARRIER_NONE || !mover || !mover->client) {
     return true;

--- a/src/server/sv_world.c
+++ b/src/server/sv_world.c
@@ -476,7 +476,7 @@ static void Sv_ClipTraceToEntity(sv_trace_t *trace, const g_entity_t *ent) {
     return;
   }
 
-  if (svs.game->ClipEntity && !svs.game->ClipEntity(trace->skip, ent, trace->start, trace->end, trace->bounds)) {
+  if (svs.game->ClipEntity && !svs.game->ClipEntity(trace->skip, ent)) {
     return;
   }
 


### PR DESCRIPTION
Follows #1016. With the server deciding the barriers, neither `ClipEntity` implementation reads the trace geometry: the game tests a bit of the mover's set, the client game tests membership. The hook is now `(mover, ent)` on both sides.

Considered and not done: passing the engine's `sv_trace_t`/`cl_trace_t` by pointer. Those are the engine's in-progress accumulators; exposing them makes their layout part of the game API and hands a module the running trace to mutate, which the hook's purity contract exists to forbid. If a feature ever needs geometry here, a small read-only request struct is the shape - but nothing needs it today.

`GAME_API_VERSION` 36, `CGAME_API_VERSION` 39. All modules incl. race build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)