### PR TITLE
Present an entity through one chainable AddEntity

### DIFF
--- a/src/cgame/common/cg_entity.c
+++ b/src/cgame/common/cg_entity.c
@@ -226,12 +226,6 @@ static void Cg_EntitySound(cl_entity_t *ent) {
   s->sound = 0;
 }
 
-static bool Cg_FilterEntity_Common(const cl_entity_t *ent) {
-  return true;
-}
-
-FilterEntity Cg_FilterEntity = Cg_FilterEntity_Common;
-
 /**
  * @brief Interpolate the current frame, processing any new events and advancing the simulation.
  */
@@ -246,10 +240,8 @@ void Cg_Interpolate(const cl_frame_t *frame) {
 
     cl_entity_t *ent = &cgi.client->entities[s->number];
 
-    if (Cg_FilterEntity(ent)) {
-      Cg_EntitySound(ent);
-      Cg_EntityEvent(ent);
-    }
+    Cg_EntitySound(ent);
+    Cg_EntityEvent(ent);
 
     // the event is consumed whether or not it was shown, so that parsing the
     // same frame again does not fire it twice
@@ -258,9 +250,12 @@ void Cg_Interpolate(const cl_frame_t *frame) {
 }
 
 /**
- * @brief Adds the specified client entity to the view.
+ * @brief The tail of the `Cg_AddEntity` chain: the entity's trail, and the
+ * render entities its model and effects call for.
  */
-static void Cg_AddEntity(cl_entity_t *ent) {
+static void Cg_AddEntity_Common(cl_entity_t *ent) {
+
+  Cg_EntityTrail(ent);
 
   // set the origin and angles so that we know where to add effects
   r_entity_t e = {
@@ -313,6 +308,8 @@ static void Cg_AddEntity(cl_entity_t *ent) {
   cgi.AddEntity(cgi.view, &e);
 }
 
+AddEntity Cg_AddEntity = Cg_AddEntity_Common;
+
 /**
  * @brief Iterate all entities in the current frame, adding models, sprites,
  * lights, and anything else associated with them.
@@ -341,12 +338,6 @@ void Cg_AddEntities(const cl_frame_t *frame) {
     const uint32_t snum = (frame->entity_state + i) & ENTITY_STATE_MASK;
     const entity_state_t *s = &cgi.client->entity_states[snum];
     cl_entity_t *ent = &cgi.client->entities[s->number];
-
-    if (!Cg_FilterEntity(ent)) {
-      continue;
-    }
-
-    Cg_EntityTrail(ent);
 
     Cg_AddEntity(ent);
   }

--- a/src/cgame/common/cg_module.h
+++ b/src/cgame/common/cg_module.h
@@ -303,16 +303,17 @@ extern ScreenDidUpdate Cg_ScreenDidUpdate;
  */
 
 /**
- * @brief Whether an entity the server sent is shown at all: interpolated, given
- * its sounds and events, trailed and added to the scene. The default shows
- * everything.
- * @details Chainable. A feature that hides other players, say, answers false
- * for them and defers to previous for the rest.
- * @return True to show the entity.
+ * @brief Presents an entity the server sent: its trail, and the render entities
+ * its model and effects call for. The default presents everything as the server
+ * described it.
+ * @details Chainable. A feature that hides an entity - another player's ghost,
+ * say - returns without calling previous; one that augments what an entity shows
+ * adds around the call. Sounds and events are not decided here; they have played
+ * by the time the scene is populated.
  */
-typedef bool (*FilterEntity)(const cl_entity_t *ent);
+typedef void (*AddEntity)(cl_entity_t *ent);
 
-extern FilterEntity Cg_FilterEntity;
+extern AddEntity Cg_AddEntity;
 
 /**
  * @brief Augments the renderer entity for an entity the server sent, from its

--- a/src/cgame/race/cg_race.c
+++ b/src/cgame/race/cg_race.c
@@ -42,7 +42,7 @@ static struct {
   ParseConfigString ParseConfigString;
   ParseServerCommand ParseServerCommand;
   MediaDidLoad MediaDidLoad;
-  FilterEntity FilterEntity;
+  AddEntity AddEntity;
   ClientInfo ClientInfo;
   EntityEffects EntityEffects;
   ClipEntity ClipEntity;
@@ -145,13 +145,13 @@ static bool Cg_ClipEntity_Race(const cl_entity_t *mover, const cl_entity_t *ent)
 /**
  * @brief Another player's ghost is theirs to see and not ours.
  */
-static bool Cg_FilterEntity_Race(const cl_entity_t *ent) {
+static void Cg_AddEntity_Race(cl_entity_t *ent) {
 
   if (Cg_Race_IsGhost(ent) && ent->current.client != cgi.client->frame.ps.client) {
-    return false;
+    return;
   }
 
-  return previous.FilterEntity(ent);
+  previous.AddEntity(ent);
 }
 
 /**
@@ -203,8 +203,8 @@ void Cg_Race_Init(void) {
   previous.MediaDidLoad = Cg_MediaDidLoad;
   Cg_MediaDidLoad = Cg_MediaDidLoad_Race;
 
-  previous.FilterEntity = Cg_FilterEntity;
-  Cg_FilterEntity = Cg_FilterEntity_Race;
+  previous.AddEntity = Cg_AddEntity;
+  Cg_AddEntity = Cg_AddEntity_Race;
 
   previous.ClientInfo = Cg_ClientInfo;
   Cg_ClientInfo = Cg_ClientInfo_Race;


### PR DESCRIPTION
Per discussion: `FilterEntity` read like a trace predicate and could only say yes or no. The hook is now `Cg_AddEntity` - the old static function becomes the `_Common` tail with `Cg_EntityTrail` folded in - so race hides other players' ghosts by not calling previous, and a future feature can augment an entity's presentation (extra render entities, trails, lights) around the call.

Semantic note: `Cg_Interpolate`'s sound/event dispatch is no longer gated. The race ghost emits neither (verified: the replay writes only origin/angles/animations/effects, and a freed slot is memset), so nothing changes today - but a mod hiding a *noisy* entity would now still hear it; if that mod ever exists, the gate wants its own hook rather than sharing this one.

Internal to the cgame - no export, no version bump. All modules incl. race build clean; `racetest` loads headlessly. Read-only review applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)