### PR TITLE
Complete the Will/Did pairs, and the documentation behind the sweep

### DIFF
--- a/.github/subsystems/cgame-module.md
+++ b/.github/subsystems/cgame-module.md
@@ -37,7 +37,7 @@ Module initialization and main loop:
 
 ### cg_entity.c / cg_entity.h
 Entity state management:
-- `Cg_AddEntity()` - Add entity to render view
+- `Cg_AddEntity` - Chainable hook presenting an entity: its trail, models and effects
 - `Cg_AddEntities()` - Process all entities for this frame
 - Entity interpolation (lerp between old and new state)
 - Bounding box visualization (`cg_draw_bbox`)

--- a/.github/subsystems/game-module.md
+++ b/.github/subsystems/game-module.md
@@ -274,8 +274,8 @@ typedef struct {
     void (*Init)(void);
     void (*Shutdown)(void);
     
-    // Entity spawning
-    void (*SpawnEntity)(g_entity_t *ent);
+    // Level spawning
+    void (*SpawnEntities)(const char *name, const cm_entity_t *props, cm_entity_t *const *entities, size_t num_entities);
     
     // Main game loop
     void (*Frame)(void);
@@ -349,7 +349,7 @@ struct g_entity_s {
 
 **Map loads**:
 1. Server parses BSP entities
-2. For each entity definition, server calls `ge->SpawnEntity()`
+2. Server hands every entity definition to `ge->SpawnEntities()`; the game spawns each through its `InitEntity` chain
 3. Game looks up spawn function by classname:
    - `"weapon_rocketlauncher"` → `G_weapon_rocketlauncher()`
    - `"func_door"` → `G_func_door()`

--- a/.github/subsystems/server.md
+++ b/.github/subsystems/server.md
@@ -82,7 +82,7 @@ Game module interface (loads game.so/.dll):
 **Game module exports** (`game_export_t`):
 - `ge->Init()` - Game initialization
 - `ge->Shutdown()` - Game cleanup
-- `ge->SpawnEntity()` - Spawn entity from BSP entity definition
+- `ge->SpawnEntities()` - Spawn the level from its BSP entity definitions
 - `ge->Frame()` - Run game logic for one tick
 - `ge->ClientConnect()` / `ge->ClientDisconnect()` - Client events
 - `ge->ClientCommand()` - Handle client console commands
@@ -387,7 +387,7 @@ This separation allows different game modes/mods without changing server code.
 3. Load BSP with `Cm_LoadBSP()`
 4. Initialize game module: `ge->Init()`
 5. Parse BSP entities: `Cm_Entities()`
-6. Spawn each entity: `ge->SpawnEntity()` for each
+6. Spawn the level: `ge->SpawnEntities()` with every entity definition
 7. Server is now ready for client connections
 
 ## File Downloads

--- a/configure.ac
+++ b/configure.ac
@@ -201,11 +201,6 @@ PKG_CHECK_MODULES([PHYSFS], [physfs])
 dnl PhysicsFS itself links zlib but its .pc doesn't declare the dependency.
 PHYSFS_LIBS="$PHYSFS_LIBS -lz"
 
-dnl -----------------------------------
-dnl Sort out OpenAL flags and libraries
-dnl -----------------------------------
-
-
 dnl -------------------------------
 dnl Check for execinfo.h (optional)
 dnl -------------------------------
@@ -222,7 +217,7 @@ dnl ---------------------------------
 
 AC_MSG_CHECKING(which game modules to build)
 
-GAME_MODULES="default ctf lithium"
+GAME_MODULES="ctf default lithium race"
 
 AC_ARG_WITH(games,
 	AS_HELP_STRING([--with-games='default ...'],

--- a/doc/game-module-hooks.md
+++ b/doc/game-module-hooks.md
@@ -269,8 +269,8 @@ have produced a module that did not compile.
 | --- | --- | --- |
 | `ResetDroppedItem` | `g_item.c` | ctf, techs |
 | `ResolveInventoryItem` | `g_item.c` | ctf, techs |
-| `TossInventory` | `g_item.c` | ctf, techs, hook |
-| `ModifyDamage` | `g_combat.c` | techs |
+| `TossInventory` | `g_item.c` | ctf, techs, hook, race |
+| `ModifyDamage` | `g_combat.c` | techs, race |
 | `CheckCvars` | `g_rules.c` | ctf, techs, hook |
 | `CheckWinner` | `g_rules.c` | ctf |
 | `FormatGameName` | `g_rules.c` | ctf |
@@ -278,27 +278,32 @@ have produced a module that did not compile.
 | `InhibitItem` | `g_item.c` | ctf |
 | `InitItem` | `g_item.c` | ctf, techs |
 | `InitMedia` | `g_entity.c` | ctf, techs, hook |
-| `ConfigureLevel` | `g_entity.c` | techs, hook |
+| `ConfigureLevel` | `g_entity.c` | techs, hook, race |
 | `PrepareMove` | `g_client.c` | hook |
-| `ClipEntity` | `g_client.c` | — |
+| `ClipEntity` | `g_client.c` | race |
 | `InitInventory` | `g_client.c` | — |
-| `PrepareSpawn` | `g_client.c` | — |
+| `PrepareSpawn` | `g_client.c` | race |
+| `ClientWillBegin` | `g_client.c` | — |
 | `ClientDidBegin` | `g_client.c` | — |
+| `ClientWillChangeUserInfo` | `g_client.c` | — |
 | `ClientDidChangeUserInfo` | `g_client.c` | — |
-| `ClientWillDisconnect` | `g_client.c` | — |
-| `ClientWillThink` | `g_client.c` | — |
-| `ClientDidMove` | `g_client.c` | — |
-| `HandleClientCommand` | `g_cmd.c` | — |
+| `ClientWillDisconnect` | `g_client.c` | race |
+| `ClientDidDisconnect` | `g_client.c` | — |
+| `ClientWillThink` | `g_client.c` | race |
+| `ClientDidMove` | `g_client.c` | race |
+| `HandleClientCommand` | `g_cmd.c` | vote, race |
+| `ClientWillChat` | `g_cmd.c` | — |
 | `ClientDidChat` | `g_cmd.c` | — |
-| `WriteStats` | `g_client_stats.c` | — |
-| `WriteScore` | `g_client_stats.c` | — |
-| `LevelWillSpawn` | `g_entity.c` | — |
-| `SpawnEntity` | `g_entity.c` | — |
+| `WriteStats` | `g_client_stats.c` | race |
+| `WriteScore` | `g_client_stats.c` | race |
+| `LevelWillSpawn` | `g_entity.c` | race |
+| `InitEntity` | `g_entity.c` | race |
 | `AllowNextMap` | `g_rules.c` | — |
 | `PrepareVote` | `g_vote.c` | — |
 | `ApplyVote` | `g_vote.c` | — |
-| `AllowHook` | `g_hook.c` | — |
-| `FrameDidEnd` | `g_client_view.c` | — |
+| `AllowHook` | `g_hook.c` | race |
+| `FrameWillBegin` | `g_main.c` | — |
+| `FrameDidEnd` | `g_client_view.c` | vote, race |
 
 The tail of each chain lives beside the code that calls it, never in a catch-all:
 `g_module.c` was deleted once its last default moved out, because a file that
@@ -353,23 +358,25 @@ and make the block additive instead.
 
 | hook | tail lives in | installed by |
 | --- | --- | --- |
-| `DrawHudElements` | `cg_hud.c` | ctf, techs |
+| `DrawHudElements` | `cg_hud.c` | ctf, techs, race |
 | `ListGameplayModes` | `cg_main.c` | ctf |
-| `ClipEntity` | `cg_predict.c` | — |
+| `ClipEntity` | `cg_predict.c` | race |
 | `UsePrediction` | `cg_predict.c` | — |
 | `Move` | `cg_input.c` | — |
 | `MoveCommandWillRun` | `cg_predict.c` | — |
 | `MoveCommandDidRun` | `cg_predict.c` | — |
 | `PredictionDidComplete` | `cg_predict.c` | — |
-| `ParseServerCommand` | `cg_main.c` | — |
-| `ParseConfigString` | `cg_main.c` | — |
+| `ParseServerCommand` | `cg_main.c` | race |
+| `ParseConfigString` | `cg_main.c` | vote, race |
 | `StateDidClear` | `cg_main.c` | — |
-| `MediaDidLoad` | `cg_media.c` | — |
+| `MediaDidLoad` | `cg_media.c` | race |
 | `SceneDidPopulate` | `cg_main.c` | — |
 | `ScreenDidUpdate` | `cg_main.c` | — |
-| `FilterEntity` | `cg_entity.c` | — |
+| `AddEntity` | `cg_entity.c` | race |
+| `ClientInfo` | `cg_client.c` | race |
+| `EntityEffects` | `cg_entity_effect.c` | race |
 | `DescribeGameMode` | `cg_discord.c` | — |
-| `DrawScores` | `cg_score.c` | — |
+| `DrawScores` | `cg_score.c` | race |
 | `ListVoteTypes` | `cg_vote.c` | — |
 
 `cg_hud_layout_t.draw_time` lets a module that arranges the whole HUD keep the

--- a/src/cgame/common/cg_client.c
+++ b/src/cgame/common/cg_client.c
@@ -38,6 +38,9 @@
 //                         team name    skin             shirt    pants    helmet   hue
 #define DEFAULT_CLIENT_INFO "-1\\newbie\\qforcer/default\\default\\default\\default\\default"
 
+/**
+ * @brief Trims leading and trailing whitespace in place.
+ */
 static char *Cg_StripWhitespace(char *str) {
 
   while (isspace((unsigned char) *str)) {
@@ -54,6 +57,9 @@ static char *Cg_StripWhitespace(char *str) {
   return str;
 }
 
+/**
+ * @brief Splits a client info string on backslashes, in place, up to `len` fields.
+ */
 static size_t Cg_SplitClientInfo(char *str, char **info, size_t len) {
 
   size_t count = 0;

--- a/src/cgame/common/cg_main.c
+++ b/src/cgame/common/cg_main.c
@@ -262,6 +262,9 @@ static void Cg_ParseTeamInfo(const char *s) {
   release(info);
 }
 
+/**
+ * @brief The tail of the `Cg_ParseConfigString` chain: nothing claimed, so common parses it.
+ */
 static bool Cg_ParseConfigString_Common(int32_t index) {
   return false;
 }
@@ -344,6 +347,9 @@ static void Cg_ParsedMessage(int32_t cmd, void *data) {
   }
 }
 
+/**
+ * @brief The tail of the `Cg_ParseServerCommand` chain: nothing claimed, so common parses it.
+ */
 static bool Cg_ParseServerCommand_Common(int32_t cmd) {
   return false;
 }
@@ -443,6 +449,9 @@ static void Cg_ClearState(void) {
   Cg_StateDidClear();
 }
 
+/**
+ * @brief The tail of the `Cg_StateDidClear` chain: a notification, so it does nothing.
+ */
 static void Cg_StateDidClear_Common(void) {
 }
 
@@ -476,6 +485,9 @@ static void Cg_PopulateScene(const cl_frame_t *frame) {
   Cg_SceneDidPopulate(frame);
 }
 
+/**
+ * @brief The tail of the `Cg_SceneDidPopulate` chain: a notification, so it does nothing.
+ */
 static void Cg_SceneDidPopulate_Common(const cl_frame_t *frame) {
 }
 
@@ -548,6 +560,9 @@ static void Cg_UpdateScreen(const cl_frame_t *frame) {
   Cg_ScreenDidUpdate(frame);
 }
 
+/**
+ * @brief The tail of the `Cg_ScreenDidUpdate` chain: a notification, so it does nothing.
+ */
 static void Cg_ScreenDidUpdate_Common(const cl_frame_t *frame) {
 }
 

--- a/src/cgame/common/cg_predict.c
+++ b/src/cgame/common/cg_predict.c
@@ -65,16 +65,25 @@ bool Cg_ExportUsePrediction(void) {
   return Cg_UsePrediction();
 }
 
+/**
+ * @brief The tail of the `Cg_MoveCommandWillRun` chain: a notification, so it does nothing.
+ */
 static void Cg_MoveCommandWillRun_Common(pm_move_t *pm, const cl_cmd_t *cmd) {
 }
 
 MoveCommandWillRun Cg_MoveCommandWillRun = Cg_MoveCommandWillRun_Common;
 
+/**
+ * @brief The tail of the `Cg_MoveCommandDidRun` chain: a notification, so it does nothing.
+ */
 static void Cg_MoveCommandDidRun_Common(const pm_move_t *pm, const cl_cmd_t *cmd) {
 }
 
 MoveCommandDidRun Cg_MoveCommandDidRun = Cg_MoveCommandDidRun_Common;
 
+/**
+ * @brief The tail of the `Cg_PredictionDidComplete` chain: a notification, so it does nothing.
+ */
 static void Cg_PredictionDidComplete_Common(const pm_move_t *pm) {
 }
 

--- a/src/cgame/common/cg_score.c
+++ b/src/cgame/common/cg_score.c
@@ -86,6 +86,9 @@ void Cg_ParseScores(void) {
   }
 }
 
+/**
+ * @see cg_score.h
+ */
 const g_score_t *Cg_Scores(size_t *count) {
   *count = cg_score_state.num_scores;
   return cg_score_state.scores;

--- a/src/cgame/race/cg_race_hud.c
+++ b/src/cgame/race/cg_race_hud.c
@@ -42,10 +42,16 @@
 
 static float cg_race_speed;
 
+/**
+ * @see cg_race.h
+ */
 const char *Cg_Race_FormatTime(uint32_t ms) {
   return va("%u:%02u.%03u", ms / 60000, ms / 1000 % 60, ms % 1000);
 }
 
+/**
+ * @brief Draws a line centered on the view, as the run and its milestones are shown.
+ */
 static void Cg_Race_DrawCentered(int32_t y, const char *string, const color_t color) {
   cgi.Draw2DString((cgi.context->w - cgi.StringWidth(string)) / 2, y, string, color);
 }
@@ -100,6 +106,9 @@ static int32_t Cg_Race_DrawSpeed(const player_state_t *ps, int32_t y) {
   return Cg_DrawStat(y, "Speed", (int32_t) cg_race_speed);
 }
 
+/**
+ * @see cg_race.h
+ */
 void Cg_Race_DrawHud(const player_state_t *ps, cg_hud_layout_t *layout) {
 
   Cg_DrawVitals(ps);

--- a/src/cgame/race/cg_race_score.c
+++ b/src/cgame/race/cg_race_score.c
@@ -31,6 +31,9 @@
 // wider than the common board's column, for a best time beside a run count
 #define RACE_SCORES_COL_WIDTH 280
 
+/**
+ * @brief What a racer is doing, as the board says it.
+ */
 static const char *Cg_Race_ModeName(g_race_mode_t mode) {
 
   switch (mode) {
@@ -115,6 +118,9 @@ static void Cg_Race_DrawScore(int32_t x, int32_t y, const g_score_t *s) {
   cgi.BindFont(NULL, NULL, NULL);
 }
 
+/**
+ * @see cg_race.h
+ */
 void Cg_Race_DrawScores(const player_state_t *ps) {
 
   if (!ps->stats[STAT_SCORES]) {

--- a/src/game/common/bg_pmove.c
+++ b/src/game/common/bg_pmove.c
@@ -70,6 +70,9 @@ static const pm_movement_info_t pm_movements[] = {
   [PM_MOVEMENT_QUAKE3] = { .name = "quake3", .label = "Quake3",      .params = &pm_quake3_params },
 };
 
+/**
+ * @see bg_pmove.h
+ */
 const pm_movement_info_t *Pm_Movement(pm_movement_t movement) {
 
   if ((size_t) movement >= lengthof(pm_movements)) {
@@ -79,10 +82,16 @@ const pm_movement_info_t *Pm_Movement(pm_movement_t movement) {
   return &pm_movements[movement];
 }
 
+/**
+ * @see bg_pmove.h
+ */
 size_t Pm_MovementCount(void) {
   return lengthof(pm_movements);
 }
 
+/**
+ * @see bg_pmove.h
+ */
 bool Pm_MovementByName(const char *name, pm_movement_t *movement) {
 
   assert(movement);

--- a/src/game/common/g_ai_node.c
+++ b/src/game/common/g_ai_node.c
@@ -189,6 +189,9 @@ typedef struct {
   bool prefer_level;
 } ai_node_query_filter_t;
 
+/**
+ * @brief Whether a node qualifies for `G_Ai_Node_FindClosest`, and at what distance.
+ */
 static bool G_Ai_Node_FindClosestFilter(const size_t nodenum, void *data, float *distance) {
   const ai_node_query_filter_t *filter = data;
   const ai_node_t *node = AI_NODE(g_ai_nodes, nodenum);
@@ -1370,6 +1373,9 @@ static ai_node_priority_t *g_ai_node_path_entries;
 static size_t g_ai_node_path_capacity;
 static size_t g_ai_node_path_count;
 
+/**
+ * @brief Releases the pathfinding queue and its entries.
+ */
 static void G_Ai_Node_FreePathPool(void) {
 
   gheap_free(&g_ai_node_path_queue);
@@ -1379,6 +1385,9 @@ static void G_Ai_Node_FreePathPool(void) {
   g_ai_node_path_count = 0;
 }
 
+/**
+ * @brief Readies the pathfinding queue and entry pool for `capacity` nodes, reusing them when they suffice.
+ */
 static bool G_Ai_Node_EnsurePathPool(const size_t capacity) {
 
   if (g_ai_node_path_queue && g_ai_node_path_capacity >= capacity) {
@@ -1401,6 +1410,9 @@ static bool G_Ai_Node_EnsurePathPool(const size_t capacity) {
   return true;
 }
 
+/**
+ * @brief The next free pathfinding entry, or `NULL` when the pool is spent.
+ */
 static ai_node_priority_t *G_Ai_Node_AllocPathEntry(void) {
 
   if (g_ai_node_path_count == g_ai_node_path_capacity) {
@@ -1416,6 +1428,9 @@ static ai_node_priority_t *G_Ai_Node_AllocPathEntry(void) {
 #define AI_DROP_HEALTH_MARGIN 8.f
 #define AI_DROP_DAMAGE_PENALTY_SCALE 6.f
 
+/**
+ * @brief The stored cost of the link from `a` to `b`.
+ */
 static inline float G_Ai_LinkCost(const ai_node_id_t a, const ai_node_id_t b) {
   const ai_node_t *node = AI_NODE(g_ai_nodes, a);
 
@@ -1483,6 +1498,9 @@ static float G_Ai_EstimatedFallDamage(const float drop, const int32_t gravity, c
   return Maxf(0.f, damage);
 }
 
+/**
+ * @see g_ai_node.h
+ */
 Vector *G_Ai_Node_FindPath(const g_client_t *cl, const ai_node_id_t start, const ai_node_id_t end, const G_Ai_NodeCostFunc heuristic, float *length) {
   
   if (length) {
@@ -1688,6 +1706,9 @@ Vector *G_Ai_Node_FindPath(const g_client_t *cl, const ai_node_id_t start, const
   return return_path;
 }
 
+/**
+ * @brief Translates every node by the given offset, for repairing a graph after a map shifts.
+ */
 void G_Ai_OffsetNodes_f(void) {
 
   vec3_t translate;

--- a/src/game/common/g_client.c
+++ b/src/game/common/g_client.c
@@ -1255,12 +1255,28 @@ static void G_PrepareSpawn_Common(g_client_t *cl, g_client_spawn_t *spawn) {
 PrepareSpawn G_PrepareSpawn = G_PrepareSpawn_Common;
 
 /**
+ * @brief The tail of the `G_ClientWillBegin` chain: a notification, so it does nothing.
+ */
+static void G_ClientWillBegin_Common(g_client_t *cl) {
+}
+
+ClientWillBegin G_ClientWillBegin = G_ClientWillBegin_Common;
+
+/**
  * @brief The tail of the `G_ClientDidBegin` chain: a notification, so it does nothing.
  */
 static void G_ClientDidBegin_Common(g_client_t *cl) {
 }
 
 ClientDidBegin G_ClientDidBegin = G_ClientDidBegin_Common;
+
+/**
+ * @brief The tail of the `G_ClientWillChangeUserInfo` chain: a notification, so it does nothing.
+ */
+static void G_ClientWillChangeUserInfo_Common(g_client_t *cl, const char *user_info) {
+}
+
+ClientWillChangeUserInfo G_ClientWillChangeUserInfo = G_ClientWillChangeUserInfo_Common;
 
 /**
  * @brief The tail of the `G_ClientDidChangeUserInfo` chain: a notification, so it does nothing.
@@ -1277,6 +1293,14 @@ static void G_ClientWillDisconnect_Common(g_client_t *cl) {
 }
 
 ClientWillDisconnect G_ClientWillDisconnect = G_ClientWillDisconnect_Common;
+
+/**
+ * @brief The tail of the `G_ClientDidDisconnect` chain: a notification, so it does nothing.
+ */
+static void G_ClientDidDisconnect_Common(g_client_t *cl) {
+}
+
+ClientDidDisconnect G_ClientDidDisconnect = G_ClientDidDisconnect_Common;
 
 /**
  * @brief The tail of the `G_ClientWillThink` chain: a notification, so it does nothing.
@@ -1489,6 +1513,8 @@ void G_ClientRespawn(g_client_t *cl, bool voluntary) {
 void G_ClientBegin(g_client_t *cl) {
   char welcome[MAX_STRING_CHARS];
 
+  G_ClientWillBegin(cl);
+
   // setup the client's entity
   cl->entity = G_AllocEntity("client");
   cl->entity->client = cl;
@@ -1564,6 +1590,8 @@ box3_t G_ClientStandingBounds(const g_client_t *cl) {
  */
 void G_ClientUserInfoChanged(g_client_t *cl, const char *user_info) {
   char name[MAX_NET_NAME];
+
+  G_ClientWillChangeUserInfo(cl, user_info);
 
   // check for malformed or illegal info strings
   if (!InfoString_Validate(user_info)) {
@@ -1830,6 +1858,8 @@ void G_ClientDisconnect(g_client_t *cl) {
   if (cl->entity) {
     G_FreeEntity(cl->entity);
   }
+
+  G_ClientDidDisconnect(cl);
 
   memset(cl, 0, sizeof(g_client_t));
   cl->ps.client = client;

--- a/src/game/common/g_client.c
+++ b/src/game/common/g_client.c
@@ -1881,6 +1881,9 @@ static file_t *g_pmove_file;
 static uint64_t pmove_frame = 0;
 static uint64_t pmove_frames = 0;
 
+/**
+ * @brief Begins recording every `Pm_Move` to a file, for playback through `G_PlayPmove`.
+ */
 void G_RecordPmove(void) {
   if (g_play_pmove) {
     return;
@@ -1898,6 +1901,9 @@ void G_RecordPmove(void) {
   gi.Print("Starting pmove recording\n");
 }
 
+/**
+ * @brief Begins replaying a `G_RecordPmove` file through `Pm_Move`, frame for frame.
+ */
 void G_PlayPmove(void) {
   if (g_recording_pmove) {
     return;

--- a/src/game/common/g_combat.c
+++ b/src/game/common/g_combat.c
@@ -168,6 +168,9 @@ static const char *G_WeaponNameForMod(g_means_of_death mod) {
   }
 }
 
+/**
+ * @see g_combat.h
+ */
 bool G_CanDamage(const g_entity_t *targ, const g_entity_t *inflictor) {
   vec3_t dest;
   cm_trace_t tr;

--- a/src/game/common/g_entity.c
+++ b/src/game/common/g_entity.c
@@ -109,6 +109,9 @@ static const g_entity_class_t g_entity_classes[] = {
 
 static const cm_entity_t *g_map;
 
+/**
+ * @brief The value `key` holds in the map's own metadata, or `NULL` before it is loaded.
+ */
 static const cm_entity_t *G_MapValue(const char *key) {
   return g_map ? gi.EntityValue(g_map, key) : NULL;
 }

--- a/src/game/common/g_main.c
+++ b/src/game/common/g_main.c
@@ -907,13 +907,23 @@ static void G_CheckRules(void) {
 #define INTERMISSION (10.0 * 1000) // intermission duration
 
 /**
- * @brief The main game module "think" function, called once per server frame.
- * Nothing would happen in Quake land if this weren't called.
+ * @brief The tail of the `G_FrameWillBegin` chain: a notification, so it does nothing.
+ */
+static void G_FrameWillBegin_Common(void) {
+}
+
+FrameWillBegin G_FrameWillBegin = G_FrameWillBegin_Common;
+
+/**
+ * @brief Runs one server frame: the timers, every entity, the rules, and the
+ * client frames that close it.
  */
 static void G_Frame(void) {
 
   g_level.frame_num++;
   g_level.time = g_level.frame_num * QUETOO_TICK_MILLIS;
+
+  G_FrameWillBegin();
 
   // check for level change after running intermission
   if (g_level.intermission_time) {

--- a/src/game/common/g_module.h
+++ b/src/game/common/g_module.h
@@ -441,12 +441,29 @@ typedef void (*PrepareSpawn)(g_client_t *cl, g_client_spawn_t *spawn);
 extern PrepareSpawn G_PrepareSpawn;
 
 /**
+ * @brief The client is about to enter the game: nothing of their entity exists yet.
+ * @details Notification; the tail does nothing.
+ */
+typedef void (*ClientWillBegin)(g_client_t *cl);
+
+extern ClientWillBegin G_ClientWillBegin;
+
+/**
  * @brief The client has entered the game: their entity exists and is placed.
  * @details Notification; the tail does nothing.
  */
 typedef void (*ClientDidBegin)(g_client_t *cl);
 
 extern ClientDidBegin G_ClientDidBegin;
+
+/**
+ * @brief The client's user info is about to be applied: `cl->persistent` still
+ * holds what it held, and `user_info` what they sent.
+ * @details Notification; the tail does nothing.
+ */
+typedef void (*ClientWillChangeUserInfo)(g_client_t *cl, const char *user_info);
+
+extern ClientWillChangeUserInfo G_ClientWillChangeUserInfo;
 
 /**
  * @brief The client's user info was applied: name, skin, colors and the rest
@@ -466,6 +483,15 @@ extern ClientDidChangeUserInfo G_ClientDidChangeUserInfo;
 typedef void (*ClientWillDisconnect)(g_client_t *cl);
 
 extern ClientWillDisconnect G_ClientWillDisconnect;
+
+/**
+ * @brief The client has left: their entity is freed and their slot is about to
+ * be forgotten.
+ * @details Notification; the tail does nothing.
+ */
+typedef void (*ClientDidDisconnect)(g_client_t *cl);
+
+extern ClientDidDisconnect G_ClientDidDisconnect;
 
 /**
  * @brief A movement command has arrived and the buttons are latched, before
@@ -555,6 +581,15 @@ extern WriteScore G_WriteScore;
  * @brief The server frame. Tail in g_client_view.c.
  * @{
  */
+
+/**
+ * @brief The frame is about to run: the level's time has advanced, and nothing
+ * has thought yet.
+ * @details Notification; the tail does nothing.
+ */
+typedef void (*FrameWillBegin)(void);
+
+extern FrameWillBegin G_FrameWillBegin;
 
 /**
  * @brief The frame is complete: every entity has run, the rules are checked and

--- a/src/game/common/g_physics.c
+++ b/src/game/common/g_physics.c
@@ -685,6 +685,9 @@ static g_entity_t *G_Physics_Push_Translate(g_entity_t *ent, const vec3_t move) 
   return NULL;
 }
 
+/**
+ * @brief Rotates the mover to `angles` and clips `ent` against it there.
+ */
 static cm_trace_t G_Physics_Push_Rotate_And_Trace(g_entity_t *ent, g_entity_t *mover, const vec3_t angles) {
   mover->s.angles = angles;
   

--- a/src/game/common/g_vote.c
+++ b/src/game/common/g_vote.c
@@ -95,6 +95,9 @@ static g_client_t *G_Vote_ClientByName(const char *name) {
   return NULL;
 }
 
+/**
+ * @brief The common vote type `name` names, or `NULL`.
+ */
 static const vote_type_t *G_Vote_Type(const char *name) {
 
   for (size_t i = 0; i < lengthof(vote_types_common); i++) {
@@ -252,6 +255,9 @@ static void G_Vote_Publish(void) {
                                  g_vote_state.deadline, g_vote_state.initiator));
 }
 
+/**
+ * @brief Announces the verdict, applies a passed vote, and clears the state either way.
+ */
 static void G_Vote_End(bool passed) {
 
   gi.BroadcastPrint(PRINT_HIGH, "Vote %s%s%s %s\n", g_vote_state.type,
@@ -298,6 +304,9 @@ static void G_Vote_Check(void) {
   }
 }
 
+/**
+ * @brief Records a ballot, once per client per vote.
+ */
 static void G_Vote_Cast(g_client_t *cl, g_ballot_t ballot) {
 
   if (!g_vote_state.active) {
@@ -315,6 +324,9 @@ static void G_Vote_Cast(g_client_t *cl, g_ballot_t ballot) {
   G_Vote_Check();
 }
 
+/**
+ * @brief Opens a vote, if voting is enabled and nothing else is in progress.
+ */
 static void G_Vote_Call(g_client_t *cl, const char *type, const char *arg) {
 
   if (!g_vote->integer) {
@@ -389,6 +401,9 @@ static bool G_HandleClientCommand_Vote(g_client_t *cl, const char *cmd) {
   return true;
 }
 
+/**
+ * @brief Watches the deadline and the tally, and ends the vote that settles.
+ */
 static void G_FrameDidEnd_Vote(void) {
 
   G_Vote_Check();

--- a/src/game/race/g_race.c
+++ b/src/game/race/g_race.c
@@ -63,6 +63,9 @@ static struct {
 
 static bool installed;
 
+/**
+ * @see g_race.h
+ */
 g_race_mode_t G_Race_Mode(const g_client_t *cl) {
 
   if (cl->persistent.spectator) {
@@ -72,6 +75,9 @@ g_race_mode_t G_Race_Mode(const g_client_t *cl) {
   return cl->persistent.race_mode == RACE_MODE_PRACTICE ? RACE_MODE_PRACTICE : RACE_MODE_RACE;
 }
 
+/**
+ * @brief What a mode is called when it is announced or listed.
+ */
 static const char *G_Race_ModeName(g_race_mode_t mode) {
 
   switch (mode) {
@@ -101,6 +107,9 @@ static const char *G_Race_FormatTime(uint32_t ms) {
   return va("%u:%02u.%03u", ms / 60000, ms / 1000 % 60, ms % 1000);
 }
 
+/**
+ * @see g_race.h
+ */
 void G_Race_CenterPrint(const g_client_t *cl, const char *fmt, ...) {
   char string[MAX_STRING_CHARS];
 
@@ -114,6 +123,9 @@ void G_Race_CenterPrint(const g_client_t *cl, const char *fmt, ...) {
   gi.Unicast(cl, true);
 }
 
+/**
+ * @brief Abandons the run, wherever it stood.
+ */
 static void G_Race_Reset(g_client_t *cl) {
 
   G_Race_DropLine(cl);
@@ -126,6 +138,9 @@ static void G_Race_Reset(g_client_t *cl) {
 
 // ---------------------------------------------------------------- the course
 
+/**
+ * @see g_race.h
+ */
 void G_Race_AddStart(void) {
   g_level.race_course.start_count++;
 }
@@ -145,18 +160,30 @@ static bool G_Race_AddToSequence(uint64_t *sequence, bool *malformed, int32_t n,
   return true;
 }
 
+/**
+ * @see g_race.h
+ */
 bool G_Race_AddCheckpoint(int32_t checkpoint) {
   return G_Race_AddToSequence(&g_level.race_course.checkpoints, &g_level.race_course.malformed, checkpoint, 1);
 }
 
+/**
+ * @see g_race.h
+ */
 bool G_Race_AddSplit(int32_t split) {
   return G_Race_AddToSequence(&g_level.race_course.splits, &g_level.race_course.splits_malformed, split, 1);
 }
 
+/**
+ * @see g_race.h
+ */
 bool G_Race_AddStage(int32_t stage) {
   return G_Race_AddToSequence(&g_level.race_course.stages, &g_level.race_course.stages_malformed, stage, 2);
 }
 
+/**
+ * @see g_race.h
+ */
 void G_Race_AddFinish(void) {
   g_level.race_course.finish_count++;
 }
@@ -204,6 +231,9 @@ static void G_Race_ValidateCourse(void) {
 
 // ---------------------------------------------------------------- the run
 
+/**
+ * @see g_race.h
+ */
 bool G_Race_Debounced(g_client_t *cl, const g_entity_t *ent, float wait) {
 
   if (cl->race_trigger == ent && g_level.time - cl->race_trigger_time < wait * 1000.f) {
@@ -215,6 +245,9 @@ bool G_Race_Debounced(g_client_t *cl, const g_entity_t *ent, float wait) {
   return false;
 }
 
+/**
+ * @see g_race.h
+ */
 bool G_Race_Start(g_client_t *cl) {
 
   if (!G_Race_CanRun(cl)) {
@@ -251,6 +284,9 @@ bool G_Race_Start(g_client_t *cl) {
   return true;
 }
 
+/**
+ * @see g_race.h
+ */
 void G_Race_ArmStart(g_client_t *cl, const g_entity_t *start) {
 
   if (cl->race_start == start) {
@@ -265,6 +301,9 @@ void G_Race_ArmStart(g_client_t *cl, const g_entity_t *start) {
   cl->race_start = start;
 }
 
+/**
+ * @see g_race.h
+ */
 bool G_Race_Checkpoint(g_client_t *cl, uint16_t checkpoint) {
   g_race_run_t *run = &cl->race_run;
 
@@ -362,6 +401,9 @@ bool G_Race_Stage(g_client_t *cl, uint16_t stage, const char *label, const g_ent
   return counted;
 }
 
+/**
+ * @see g_race.h
+ */
 bool G_Race_Finish(g_client_t *cl) {
   g_race_run_t *run = &cl->race_run;
 
@@ -412,6 +454,9 @@ bool G_Race_Finish(g_client_t *cl) {
 
 // ---------------------------------------------------------------- the modes
 
+/**
+ * @brief Moves the client to `mode`, resetting whatever the old mode held.
+ */
 static void G_Race_SetMode(g_client_t *cl, g_race_mode_t mode) {
 
   if (G_Race_Mode(cl) == mode) {
@@ -442,6 +487,9 @@ static void G_Race_SetMode(g_client_t *cl, g_race_mode_t mode) {
   G_ClientRespawn(cl, false);
 }
 
+/**
+ * @brief `mode <race|practice|spectator>`, or with no argument, says which.
+ */
 static void G_Race_Mode_f(g_client_t *cl) {
 
   if (gi.Argc() < 2) {
@@ -537,6 +585,9 @@ static void G_Race_NoClip_f(g_client_t *cl) {
   }
 }
 
+/**
+ * @brief `race`: the course, the client's run and their best, in the console.
+ */
 static void G_Race_Status_f(g_client_t *cl) {
   const g_race_run_t *run = &cl->race_run;
   const g_race_course_t *course = &g_level.race_course;
@@ -585,6 +636,9 @@ static void G_LevelWillSpawn_Race(void) {
   previous.LevelWillSpawn();
 }
 
+/**
+ * @brief The course is validated and published, the records and the raceline loaded, and every client reset for the new level.
+ */
 static void G_ConfigureLevel_Race(void) {
 
   previous.ConfigureLevel();
@@ -611,6 +665,9 @@ static void G_ConfigureLevel_Race(void) {
   });
 }
 
+/**
+ * @brief The race classes first, then whatever common knows.
+ */
 static bool G_InitEntity_Race(g_entity_t *ent) {
 
   if (G_Race_InitEntity(ent)) {
@@ -620,6 +677,9 @@ static bool G_InitEntity_Race(g_entity_t *ent) {
   return previous.InitEntity(ent);
 }
 
+/**
+ * @brief The barriers first, then whatever previous says.
+ */
 static bool G_ClipEntity_Race(const g_entity_t *mover, const g_entity_t *ent) {
 
   if (!G_Race_ClipEntity(mover, ent)) {
@@ -646,6 +706,9 @@ static void G_PrepareSpawn_Race(g_client_t *cl, g_client_spawn_t *spawn) {
   previous.PrepareSpawn(cl, spawn);
 }
 
+/**
+ * @brief A death ends the run; the corpse tosses as usual.
+ */
 static void G_TossInventory_Race(g_client_t *cl) {
 
   G_Race_Reset(cl);
@@ -676,6 +739,9 @@ static bool G_ModifyDamage_Race(g_entity_t *target, g_entity_t *attacker, int32_
   return true;
 }
 
+/**
+ * @brief The grapple is practice equipment: never under a run.
+ */
 static bool G_AllowHook_Race(const g_client_t *cl) {
 
   if (G_Race_Mode(cl) != RACE_MODE_PRACTICE) {
@@ -685,6 +751,9 @@ static bool G_AllowHook_Race(const g_client_t *cl) {
   return previous.AllowHook(cl);
 }
 
+/**
+ * @brief The race commands, deferring the rest.
+ */
 static bool G_HandleClientCommand_Race(g_client_t *cl, const char *cmd) {
 
   if (g_level.intermission_time) {
@@ -799,6 +868,9 @@ static void G_ClientDidMove_Race(g_client_t *cl, const pm_cmd_t *cmd) {
   }
 }
 
+/**
+ * @brief A leaving client's run ends with them.
+ */
 static void G_ClientWillDisconnect_Race(g_client_t *cl) {
 
   G_Race_Reset(cl);
@@ -806,6 +878,9 @@ static void G_ClientWillDisconnect_Race(g_client_t *cl) {
   previous.ClientWillDisconnect(cl);
 }
 
+/**
+ * @brief The race stats: mode, run state, time, checkpoints, flags and runs.
+ */
 static void G_WriteStats_Race(g_client_t *cl) {
 
   previous.WriteStats(cl);
@@ -851,6 +926,9 @@ static void G_WriteScore_Race(const g_client_t *cl, g_score_t *s) {
   }
 }
 
+/**
+ * @see g_race.h
+ */
 void G_Race_Init(void) {
 
   if (installed) {

--- a/src/game/race/g_race_entity.c
+++ b/src/game/race/g_race_entity.c
@@ -65,6 +65,9 @@ static bool G_trigger_race_Accepts(g_entity_t *ent, g_entity_t *other) {
   return !G_Race_Debounced(other->client, ent, ent->wait);
 }
 
+/**
+ * @brief Arms, starts or restarts a run, as the start's mode asks.
+ */
 static void G_trigger_race_start_Touch(g_entity_t *ent, g_entity_t *other, const cm_trace_t *trace) {
 
   if (!G_trigger_race_Accepts(ent, other)) {
@@ -111,6 +114,9 @@ static void G_trigger_race_start(g_entity_t *ent) {
   G_Race_AddStart();
 }
 
+/**
+ * @brief Counts the checkpoint when it is the next one in sequence.
+ */
 static void G_trigger_race_checkpoint_Touch(g_entity_t *ent, g_entity_t *other, const cm_trace_t *trace) {
 
   if (G_trigger_race_Accepts(ent, other) && G_Race_Checkpoint(other->client, ent->count)) {
@@ -145,10 +151,16 @@ static void G_trigger_race_checkpoint(g_entity_t *ent) {
   G_trigger_race_Init(ent, G_trigger_race_checkpoint_Touch);
 }
 
+/**
+ * @brief The trigger's number as its milestones are announced.
+ */
 static const char *G_trigger_race_Label(const g_entity_t *ent) {
   return gi.EntityValue(ent->def, "label")->nullable_string;
 }
 
+/**
+ * @brief Records the split and tells the racer how it compares.
+ */
 static void G_trigger_race_split_Touch(g_entity_t *ent, g_entity_t *other, const cm_trace_t *trace) {
 
   if (G_trigger_race_Accepts(ent, other) && G_Race_Split(other->client, ent->count, G_trigger_race_Label(ent))) {
@@ -183,6 +195,9 @@ static void G_trigger_race_split(g_entity_t *ent) {
   G_trigger_race_Init(ent, G_trigger_race_split_Touch);
 }
 
+/**
+ * @brief Advances the run to the stage and remembers where it restarts.
+ */
 static void G_trigger_race_stage_Touch(g_entity_t *ent, g_entity_t *other, const cm_trace_t *trace) {
 
   if (G_trigger_race_Accepts(ent, other) &&
@@ -223,6 +238,9 @@ static void G_trigger_race_stage(g_entity_t *ent) {
   G_trigger_race_Init(ent, G_trigger_race_stage_Touch);
 }
 
+/**
+ * @see g_race.h
+ */
 void G_Race_ResolveStages(void) {
 
   g_entity_t *stage = NULL;
@@ -242,6 +260,9 @@ void G_Race_ResolveStages(void) {
   }
 }
 
+/**
+ * @brief Ends the run, submits the record, and says how it went.
+ */
 static void G_trigger_race_finish_Touch(g_entity_t *ent, g_entity_t *other, const cm_trace_t *trace) {
 
   if (G_trigger_race_Accepts(ent, other) && G_Race_Finish(other->client)) {
@@ -395,6 +416,9 @@ static bool G_Race_Passes(const g_client_t *cl, const g_entity_t *ent) {
   return offset.x * ent->move_dir.x + offset.y * ent->move_dir.y < 0.f;
 }
 
+/**
+ * @see g_race.h
+ */
 void G_Race_UpdateBarriers(g_client_t *cl) {
   const g_race_course_t *course = &g_level.race_course;
 
@@ -452,6 +476,9 @@ static const struct {
   { "func_race_oneway_wall", G_func_race_oneway_wall },
 };
 
+/**
+ * @see g_race.h
+ */
 bool G_Race_InitEntity(g_entity_t *ent) {
 
   for (size_t i = 0; i < lengthof(g_race_entity_classes); i++) {

--- a/src/game/race/g_race_records.c
+++ b/src/game/race/g_race_records.c
@@ -44,6 +44,9 @@
  * `maps.lst` entry without a name is.
  */
 
+/**
+ * @brief Where this level's records live in the write dir.
+ */
 static const char *G_Race_RecordsPath(void) {
   return va("records/%s.rec", g_level.name);
 }
@@ -70,6 +73,9 @@ static uint32_t G_Race_HashBytes(uint32_t hash, const void *data, size_t length)
   return hash;
 }
 
+/**
+ * @brief An FNV-1a hash of the fields, not the struct: there is padding after movement.
+ */
 static uint32_t G_Race_HashParams(const pm_params_t *params) {
 
   uint32_t hash = 2166136261u;
@@ -102,6 +108,9 @@ static uint16_t G_Race_ParseTimes(const cm_entity_t *def, const char *key, int32
   return count;
 }
 
+/**
+ * @brief Fastest first.
+ */
 static int32_t G_Race_CompareRecords(const void *a, const void *b) {
   const g_race_record_t *ra = a, *rb = b;
 
@@ -112,6 +121,9 @@ static int32_t G_Race_CompareRecords(const void *a, const void *b) {
   return ra->time < rb->time ? -1 : ra->time > rb->time ? 1 : 0;
 }
 
+/**
+ * @brief Keeps the records fastest first within each movement.
+ */
 static void G_Race_SortRecords(void) {
   qsort(g_level.race_records, g_level.race_record_count, sizeof(g_race_record_t), G_Race_CompareRecords);
 }
@@ -140,6 +152,9 @@ static g_race_record_t *G_Race_AddRecord(void) {
   return record;
 }
 
+/**
+ * @brief The client's record under `movement`, or `NULL` for none yet.
+ */
 static g_race_record_t *G_Race_FindRecord(const char *guid, pm_movement_t movement) {
 
   for (size_t i = 0; i < g_level.race_record_count; i++) {
@@ -153,10 +168,16 @@ static g_race_record_t *G_Race_FindRecord(const char *guid, pm_movement_t moveme
   return NULL;
 }
 
+/**
+ * @see g_race.h
+ */
 const g_race_record_t *G_Race_Record(const char *guid, pm_movement_t movement) {
   return G_Race_FindRecord(guid, movement);
 }
 
+/**
+ * @see g_race.h
+ */
 size_t G_Race_Rank(const g_race_record_t *record, size_t *count) {
   size_t rank = 0;
 
@@ -257,6 +278,9 @@ static bool G_Race_ParseRecord(const cm_entity_t *def, int32_t index) {
   return true;
 }
 
+/**
+ * @see g_race.h
+ */
 void G_Race_LoadRecords(void) {
 
   // the level's end freed the last map's, and this may be the same map again
@@ -290,6 +314,9 @@ void G_Race_LoadRecords(void) {
 
 static void G_Race_WriteLine(file_t *file, const char *fmt, ...) __attribute__((format(printf, 2, 3)));
 
+/**
+ * @brief Formats one line into the records file.
+ */
 static void G_Race_WriteLine(file_t *file, const char *fmt, ...) {
   char line[MAX_STRING_CHARS];
 
@@ -301,6 +328,9 @@ static void G_Race_WriteLine(file_t *file, const char *fmt, ...) {
   gi.WriteFile(file, line, 1, Mini(len, (int32_t) sizeof(line) - 1));
 }
 
+/**
+ * @brief Writes a numbered key per time, `key_N` from `first` up, as the loader reads them.
+ */
 static void G_Race_WriteTimes(file_t *file, const char *key, int32_t first, const uint32_t *times, uint16_t count) {
 
   for (uint16_t i = 0; i < count; i++) {
@@ -308,6 +338,9 @@ static void G_Race_WriteTimes(file_t *file, const char *key, int32_t first, cons
   }
 }
 
+/**
+ * @brief Rewrites the level's records file whole, every record it holds.
+ */
 static void G_Race_SaveRecords(void) {
 
   file_t *file = gi.OpenFileWrite(G_Race_RecordsPath());
@@ -339,6 +372,9 @@ static void G_Race_SaveRecords(void) {
   gi.CloseFile(file);
 }
 
+/**
+ * @see g_race.h
+ */
 bool G_Race_SubmitRecord(g_client_t *cl) {
   const g_race_run_t *run = &cl->race_run;
 


### PR DESCRIPTION
The two follow-ups you asked for, plus Copilot's note from #1018. One commit each.

- **Will/Did pairs**: `ClientWillBegin`, `ClientWillChangeUserInfo`, `ClientDidDisconnect`, `FrameWillBegin` - each placed exactly where its name promises (the Did-disconnect fires after the entity is freed but *before* the slot memset, which review caught the first draft getting wrong). `LevelWillSpawn`'s other half is `ConfigureLevel`, so no `LevelDidSpawn` was added - shout if you want the alias anyway.
- **Doxygen**: every function in every file the sweep touched (ac3490a62..HEAD) now has at least a one-line block - ~90 functions across the race module, cgame common, vote, AI nodes and helpers. `@see <header>` where the declaring header already documents it. Reviewer verified a sample against the bodies and caught three docs that claimed more than the code does; fixed.
- **Markdown**: `doc/game-module-hooks.md` tables renamed (`InitEntity`, `AddEntity`, `ClientWillChat`, new pairs) with the "installed by" columns filled in from what vote and race actually install; `.github/subsystems/*.md` no longer describe a `ge->SpawnEntity` export that doesn't exist.

Verified: all modules incl. race build clean; `make check` 20/20; `racetest` loads headlessly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)