### PR TITLE
Null the freed entity before ClientDidDisconnect

### DIFF
--- a/src/game/common/g_client.c
+++ b/src/game/common/g_client.c
@@ -1857,6 +1857,7 @@ void G_ClientDisconnect(g_client_t *cl) {
 
   if (cl->entity) {
     G_FreeEntity(cl->entity);
+    cl->entity = NULL;
   }
 
   G_ClientDidDisconnect(cl);

--- a/src/game/common/g_module.h
+++ b/src/game/common/g_module.h
@@ -458,7 +458,7 @@ extern ClientDidBegin G_ClientDidBegin;
 
 /**
  * @brief The client's user info is about to be applied: `cl->persistent` still
- * holds what it held, and `user_info` what they sent.
+ * holds what it held, and `user_info` what they sent, unvalidated.
  * @details Notification; the tail does nothing.
  */
 typedef void (*ClientWillChangeUserInfo)(g_client_t *cl, const char *user_info);


### PR DESCRIPTION
Copilot's two notes on #1019: `cl->entity` dangled at a freed slot for the length of the `ClientDidDisconnect` hook - it is NULL now, matching the `ClientWillDisconnect` doc's contract for never-spawned clients; and `ClientWillChangeUserInfo`'s doc says its `user_info` is unvalidated, which is the point of a Will hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)