### PR TITLE
Show the run's milestones on the HUD, against the bests

### DIFF
--- a/src/cgame/common/cg_module.h
+++ b/src/cgame/common/cg_module.h
@@ -155,14 +155,15 @@ extern ListGameplayModes Cg_ListGameplayModes;
  * @brief Decides whether `ent` clips a trace made on behalf of `mover`, after the
  * client has applied its own skip rules. There is no tail: the chain is `NULL`
  * until a feature installs a link, and the client does not call an empty one.
- * @details Chainable, and the reciprocal of the game's `ClipEntity`: a feature
+ * @details Chainable, and the reciprocal of the game's `ClipEntity`, under a
+ * typedef of its own so that no one translation unit may ever meet both: a feature
  * installs the same rule on both sides, or prediction disagrees with the server.
  * Prediction traces on behalf of `cgi.client->entity`; `mover` is `NULL` for a
  * trace with no entity behind it. An implementation MUST be pure.
  */
-typedef bool (*ClipEntity)(const cl_entity_t *mover, const cl_entity_t *ent);
+typedef bool (*ClipClientEntity)(const cl_entity_t *mover, const cl_entity_t *ent);
 
-extern ClipEntity Cg_ClipEntity;
+extern ClipClientEntity Cg_ClipEntity;
 
 /**
  * @brief Whether the client predicts its own movement this frame. The default

--- a/src/cgame/common/cg_predict.c
+++ b/src/cgame/common/cg_predict.c
@@ -101,7 +101,7 @@ static cm_trace_t Cg_PredictMovement_Trace(const vec3_t start, const vec3_t end,
  * installs a link, and `Cg_Init` exports whatever is installed, so that a
  * client game with nothing to say is never asked.
  */
-ClipEntity Cg_ClipEntity = NULL;
+ClipClientEntity Cg_ClipEntity = NULL;
 
 /**
  * @brief Run recent movement commands through the player movement code locally, storing the

--- a/src/cgame/race/cg_race.c
+++ b/src/cgame/race/cg_race.c
@@ -45,7 +45,7 @@ static struct {
   AddEntity AddEntity;
   ClientInfo ClientInfo;
   EntityEffects EntityEffects;
-  ClipEntity ClipEntity;
+  ClipClientEntity ClipEntity;
 } previous;
 
 static cg_client_info_t cg_race_ghost;

--- a/src/cgame/race/cg_race.c
+++ b/src/cgame/race/cg_race.c
@@ -90,13 +90,29 @@ static bool Cg_ParseConfigString_Race(int32_t index) {
 }
 
 /**
- * @brief The barriers that pass this client, which the server sends every frame.
- * More than fit are read and dropped, so that the message stays in step.
+ * @brief The barriers that pass this client, sent every frame - more than fit
+ * are read and dropped, so that the message stays in step - and the run's
+ * milestones, sent as they are passed.
  */
 static bool Cg_ParseServerCommand_Race(int32_t cmd) {
 
-  if (cmd != SV_CMD_RACE_BARRIERS) {
+  if (cmd != SV_CMD_RACE_BARRIERS && cmd != SV_CMD_RACE_MILESTONE) {
     return previous.ParseServerCommand(cmd);
+  }
+
+  if (cmd == SV_CMD_RACE_MILESTONE) {
+    const g_race_milestone_t kind = cgi.ReadByte();
+    const uint16_t number = cgi.ReadByte();
+
+    char label[MAX_QPATH];
+    q_strlcpy(label, cgi.ReadString(), sizeof(label));
+
+    const uint32_t time = cgi.ReadLong();
+    const int32_t vs_best = cgi.ReadLong();
+    const int32_t vs_record = cgi.ReadLong();
+
+    Cg_Race_Milestone(kind, number, label, time, vs_best, vs_record);
+    return true;
   }
 
   const int32_t count = cgi.ReadByte();

--- a/src/cgame/race/cg_race.h
+++ b/src/cgame/race/cg_race.h
@@ -46,6 +46,13 @@ uint32_t Cg_Race_Time(const player_state_t *ps);
 const char *Cg_Race_FormatTime(uint32_t ms);
 
 /**
+ * @brief Keeps the run's latest milestone for the HUD to show a while:
+ * what was passed, the time, and how it compares against this racer's best
+ * and the course record, `RACE_MILESTONE_NO_DELTA` for no comparison.
+ */
+void Cg_Race_Milestone(g_race_milestone_t kind, uint16_t number, const char *label, uint32_t time, int32_t vs_best, int32_t vs_record);
+
+/**
  * @brief The scoreboard, arranged for racing. Installed over `DrawScores` by
  * `Cg_Race_Init`, not chained.
  */

--- a/src/cgame/race/cg_race_hud.c
+++ b/src/cgame/race/cg_race_hud.c
@@ -40,8 +40,6 @@
 // with every frame at a high frame rate
 #define RACE_HUD_SPEED_LERP .2f
 
-static float cg_race_speed;
-
 /**
  * @see cg_race.h
  */
@@ -56,6 +54,45 @@ static void Cg_Race_DrawCentered(int32_t y, const char *string, const color_t co
   cgi.Draw2DString((cgi.context->w - cgi.StringWidth(string)) / 2, y, string, color);
 }
 
+// how long a milestone stays on the HUD
+#define RACE_HUD_MILESTONE_MILLIS 3000
+
+static struct {
+  char name[MAX_QPATH];
+  uint32_t time;
+  int32_t vs_best, vs_record;
+  uint32_t shown; // when it went up, in unclamped client time; 0 for none
+} cg_race_milestone;
+
+/**
+ * @see cg_race.h
+ */
+void Cg_Race_Milestone(g_race_milestone_t kind, uint16_t number, const char *label, uint32_t time, int32_t vs_best, int32_t vs_record) {
+
+  if (label && *label) {
+    q_strlcpy(cg_race_milestone.name, label, sizeof(cg_race_milestone.name));
+  } else {
+    const char *kinds[] = { "Checkpoint", "Split", "Stage" };
+    q_snprintf(cg_race_milestone.name, sizeof(cg_race_milestone.name), "%s %u", kinds[kind % 3], number);
+  }
+
+  cg_race_milestone.time = time;
+  cg_race_milestone.vs_best = vs_best;
+  cg_race_milestone.vs_record = vs_record;
+  cg_race_milestone.shown = cgi.client->unclamped_time;
+}
+
+/**
+ * @brief A comparison, signed, colored by which way it went.
+ */
+static void Cg_Race_DrawDelta(int32_t y, int32_t delta, const char *against) {
+  const char *string = va("%s%s  %s", delta < 0 ? "-" : "+", Cg_Race_FormatTime(abs(delta)), against);
+
+  Cg_Race_DrawCentered(y, string, delta > 0 ? color_red : color_green);
+}
+
+static float cg_race_speed;
+
 /**
  * @brief The time, colored by what will become of it, and the checkpoints
  * reached out of the course's.
@@ -64,6 +101,7 @@ static void Cg_Race_DrawRun(const player_state_t *ps) {
 
   const g_race_run_state_t state = ps->stats[STAT_RACE_RUN];
   if (state == RACE_RUN_IDLE) {
+    cg_race_milestone.shown = 0;
     return;
   }
 
@@ -88,6 +126,25 @@ static void Cg_Race_DrawRun(const player_state_t *ps) {
   if (checkpoints) {
     cgi.BindFont("small", NULL, &ch);
     Cg_Race_DrawCentered(y, va("%d / %u", ps->stats[STAT_RACE_CHECKPOINTS], checkpoints), color_white);
+    y += ch;
+  }
+
+  // the latest milestone, and how it compares, for a moment
+  if (cg_race_milestone.shown && cgi.client->unclamped_time - cg_race_milestone.shown < RACE_HUD_MILESTONE_MILLIS) {
+    cgi.BindFont("small", NULL, &ch);
+
+    Cg_Race_DrawCentered(y, va("%s  %s", cg_race_milestone.name, Cg_Race_FormatTime(cg_race_milestone.time)), color_white);
+    y += ch;
+
+    if (cg_race_milestone.vs_best != RACE_MILESTONE_NO_DELTA &&
+        cg_race_milestone.vs_best != cg_race_milestone.vs_record) {
+      Cg_Race_DrawDelta(y, cg_race_milestone.vs_best, "best");
+      y += ch;
+    }
+
+    if (cg_race_milestone.vs_record != RACE_MILESTONE_NO_DELTA) {
+      Cg_Race_DrawDelta(y, cg_race_milestone.vs_record, "record");
+    }
   }
 
   cgi.BindFont(NULL, NULL, NULL);

--- a/src/game/race/g_race.c
+++ b/src/game/race/g_race.c
@@ -302,6 +302,60 @@ void G_Race_ArmStart(g_client_t *cl, const g_entity_t *start) {
 }
 
 /**
+ * @brief How `time` compares to `record` at this milestone, or no answer when
+ * the record never got this far.
+ */
+static int32_t G_Race_Delta(const g_race_record_t *record, g_race_milestone_t kind, uint16_t number, uint32_t time) {
+
+  if (!record) {
+    return RACE_MILESTONE_NO_DELTA;
+  }
+
+  uint32_t reference;
+
+  switch (kind) {
+    case RACE_MILESTONE_CHECKPOINT:
+      if (record->checkpoint_count < number) {
+        return RACE_MILESTONE_NO_DELTA;
+      }
+      reference = record->checkpoint_times[number - 1];
+      break;
+    case RACE_MILESTONE_SPLIT:
+      if (record->split_count < number) {
+        return RACE_MILESTONE_NO_DELTA;
+      }
+      reference = record->split_times[number - 1];
+      break;
+    default:
+      if (record->stage_count < number - 1) {
+        return RACE_MILESTONE_NO_DELTA;
+      }
+      reference = record->stage_times[number - 2];
+      break;
+  }
+
+  return (int32_t) time - (int32_t) reference;
+}
+
+/**
+ * @brief Tells the racer what they just passed and how it compares, for the
+ * HUD to show: against their own best, and against the course record.
+ */
+static void G_Race_Milestone(g_client_t *cl, g_race_milestone_t kind, uint16_t number, const char *label, uint32_t time) {
+
+  const pm_movement_t movement = cl->race_run.movement;
+
+  gi.WriteByte(SV_CMD_RACE_MILESTONE);
+  gi.WriteByte(kind);
+  gi.WriteByte(number);
+  gi.WriteString(label ?: "");
+  gi.WriteLong(time);
+  gi.WriteLong(G_Race_Delta(G_Race_Record(cl->persistent.guid, movement), kind, number, time));
+  gi.WriteLong(G_Race_Delta(G_Race_BestRecord(movement), kind, number, time));
+  gi.Unicast(cl, true);
+}
+
+/**
  * @see g_race.h
  */
 bool G_Race_Checkpoint(g_client_t *cl, uint16_t checkpoint) {
@@ -324,7 +378,7 @@ bool G_Race_Checkpoint(g_client_t *cl, uint16_t checkpoint) {
 
   run->checkpoint_times[run->checkpoint_count++] = g_level.time - run->start_time;
 
-  G_Race_CenterPrint(cl, "Checkpoint %u  %s", checkpoint, G_Race_FormatTime(run->checkpoint_times[checkpoint - 1]));
+  G_Race_Milestone(cl, RACE_MILESTONE_CHECKPOINT, checkpoint, NULL, run->checkpoint_times[checkpoint - 1]);
 
   G_MulticastSound(&(const g_play_sound_t) {
     .index = g_media.sounds.teleport,
@@ -350,12 +404,11 @@ bool G_Race_Split(g_client_t *cl, uint16_t split, const char *label) {
   }
 
   const uint32_t time = g_level.time - run->start_time;
-  const uint32_t previous = run->split_count ? run->split_times[run->split_count - 1] : 0;
 
   run->split_times[run->split_count++] = time;
 
-  G_Race_CenterPrint(cl, "%s  %s  (+%s)", label && *label ? label : va("Split %u", split),
-                     G_Race_FormatTime(time), G_Race_FormatTime(time - previous));
+  G_Race_Milestone(cl, RACE_MILESTONE_SPLIT, split, label, time);
+
   return true;
 }
 
@@ -377,7 +430,7 @@ bool G_Race_Stage(g_client_t *cl, uint16_t stage, const char *label, const g_ent
     run->stage_times[stage - 2] = g_level.time - run->start_time;
     run->stage = stage;
 
-    G_Race_CenterPrint(cl, "%s  %s", name, G_Race_FormatTime(run->stage_times[stage - 2]));
+    G_Race_Milestone(cl, RACE_MILESTONE_STAGE, stage, label, run->stage_times[stage - 2]);
     counted = true;
   }
 

--- a/src/game/race/g_race.h
+++ b/src/game/race/g_race.h
@@ -141,6 +141,11 @@ const g_race_record_t *G_Race_Record(const char *guid, pm_movement_t movement);
 size_t G_Race_Rank(const g_race_record_t *record, size_t *count);
 
 /**
+ * @brief The course record under `movement`, or `NULL` for none yet.
+ */
+const g_race_record_t *G_Race_BestRecord(pm_movement_t movement);
+
+/**
  * @brief Finds each stage's `restart_target` once every entity has spawned,
  * and spoils the stages if any is missing. Called from `ConfigureLevel`.
  */

--- a/src/game/race/g_race_records.c
+++ b/src/game/race/g_race_records.c
@@ -171,6 +171,20 @@ static g_race_record_t *G_Race_FindRecord(const char *guid, pm_movement_t moveme
 /**
  * @see g_race.h
  */
+const g_race_record_t *G_Race_BestRecord(pm_movement_t movement) {
+
+  for (size_t i = 0; i < g_level.race_record_count; i++) {
+    if (g_level.race_records[i].movement == movement) {
+      return &g_level.race_records[i];
+    }
+  }
+
+  return NULL;
+}
+
+/**
+ * @see g_race.h
+ */
 const g_race_record_t *G_Race_Record(const char *guid, pm_movement_t movement) {
   return G_Race_FindRecord(guid, movement);
 }
@@ -378,13 +392,7 @@ static void G_Race_SaveRecords(void) {
 bool G_Race_SubmitRecord(g_client_t *cl) {
   const g_race_run_t *run = &cl->race_run;
 
-  const g_race_record_t *best = NULL;
-  for (size_t i = 0; i < g_level.race_record_count; i++) {
-    if (g_level.race_records[i].movement == run->movement) {
-      best = &g_level.race_records[i];
-      break;
-    }
-  }
+  const g_race_record_t *best = G_Race_BestRecord(run->movement);
 
   g_race_record_t *record = G_Race_FindRecord(cl->persistent.guid, run->movement);
 

--- a/src/game/race/g_types.h
+++ b/src/game/race/g_types.h
@@ -60,6 +60,7 @@ typedef enum {
   SV_CMD_SCORES,
   SV_CMD_SNAP_ANGLES,
   SV_CMD_RACE_BARRIERS, // [byte] count, [short] entity...: the barriers that pass this client
+  SV_CMD_RACE_MILESTONE, // [byte] kind, [byte] number, [string] label, [long] time, [long] vs best, [long] vs record
 } g_sv_packet_cmd_t;
 
 /**
@@ -140,6 +141,19 @@ _Static_assert(STAT_RACE_RUNS < MAX_STATS, "the race stats must fit the stat arr
 
 // how many func_race_* brushes a level may have
 #define RACE_MAX_BARRIERS 32
+
+/**
+ * @brief What a run just passed, reported to its racer as `SV_CMD_RACE_MILESTONE`
+ * with the time and how it compares: against their own best, and against the
+ * course record. A comparison with nothing to compare to is `RACE_MILESTONE_NO_DELTA`.
+ */
+typedef enum {
+  RACE_MILESTONE_CHECKPOINT,
+  RACE_MILESTONE_SPLIT,
+  RACE_MILESTONE_STAGE,
+} g_race_milestone_t;
+
+#define RACE_MILESTONE_NO_DELTA INT32_MIN
 
 // how many of a map's records CS_RACE_RECORDS carries, and the board shows
 #define RACE_RECORDS_SHOWN 15


### PR DESCRIPTION
Step 7d of #963, and the `ClipEntity` typedef collision fix (item 6), one commit each.

- **Milestones**: `G_Race_Checkpoint`/`Split`/`Stage` send `SV_CMD_RACE_MILESTONE [kind][number][label][time][vs best][vs record]` (unicast reliable) instead of centre-printing. Deltas come from the racer's own PB and the course record (`G_Race_BestRecord`, extracted from `G_Race_SubmitRecord`); `RACE_MILESTONE_NO_DELTA` for no reference. The HUD draws the latest for 3 s under the run timer: name and time, then the signed comparisons - green faster, red slower - with the "best" row folded away when it equals the "record" row. A run going idle clears it.
- Behaviour deliberately dropped: the split centre print's `(+delta vs previous split)`; comparisons are now against references, not the run itself.
- **`ClipClientEntity`**: the cgame's clip typedef no longer collides with the game's `ClipEntity`; hooks keep their names, no ABI change.

Verified: full build (race included, now via `make`) clean; `make check` 20/20; `racetest` loads headlessly. Read-only review applied (index math against both record formats verified; zero-delta sign; stale milestone across runs). Wants a lap: run `racetest` twice - the second run should show deltas at each checkpoint once a record exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)