### PR TITLE
Join Server: two-pane browser with a server details pane

### DIFF
--- a/src/cgame/cgame.h
+++ b/src/cgame/cgame.h
@@ -36,7 +36,7 @@
 #include <Objectively/RESTClient.h>
 #include <Objectively/Vector.h>
 
-#define CGAME_API_VERSION 39
+#define CGAME_API_VERSION 40
 
 /**
  * @brief The client game import struct imports engine functionailty to the client game.

--- a/src/cgame/common/ui/common.css
+++ b/src/cgame/common/ui/common.css
@@ -80,23 +80,26 @@ TextView {
 }
 
 .columns {
-  autoresizing-mask: contain | width;
+  autoresizing-mask: contain;
   axis: horizontal;
-  distribution: fill;
+  spacing: 12;
 }
 
 .columns > .column {
-  autoresizing-mask: contain | height;
-  distribution: fill;
+  autoresizing-mask: contain;
   width: 460;
+  min-width: 460;
+  max-width: 460;
 }
 
 .columns > .column-2 {
-  autoresizing-mask: contain | height;
-  distribution: fill;
+  autoresizing-mask: contain;
   width: 920;
+  min-width: 920;
+  max-width: 920;
 }
 
-.column Box {
-  autoresizing-mask: contain ;
+.column Box,
+.column-2 Box {
+  autoresizing-mask: contain | width;
 }

--- a/src/cgame/common/ui/credits/CreditsViewController.css
+++ b/src/cgame/common/ui/credits/CreditsViewController.css
@@ -28,6 +28,8 @@
 }
 
 #Credits #SpecialThanks .column {
+  min-width: 300;
+  max-width: 300;
   width: 300;
 }
 

--- a/src/cgame/common/ui/main/MainView.c
+++ b/src/cgame/common/ui/main/MainView.c
@@ -38,10 +38,10 @@ static void updateBindings(View *self) {
 
   const bool isActive = *cgi.state == CL_ACTIVE;
 
-  this->background->view.hidden = isActive;
-  this->logo->view.hidden = isActive;
-  this->version->view.hidden = isActive;
-  this->secondaryMenu->view.hidden = !isActive;
+  $((View *) this->background, setHidden, isActive);
+  $((View *) this->logo, setHidden, isActive);
+  $((View *) this->version, setHidden, isActive);
+  $((View *) this->secondaryMenu, setHidden, !isActive);
 }
 
 #pragma mark - MainView

--- a/src/cgame/common/ui/main/MainViewController.c
+++ b/src/cgame/common/ui/main/MainViewController.c
@@ -72,6 +72,24 @@ static void openReleasesPage(ident data) {
 }
 
 /**
+ * @brief Presents `dialog`, unless one is already showing: a dialog asks a
+ * question, and a second copy of the question does not make it a better one.
+ */
+static void presentDialog(MainViewController *this, const Dialog *dialog) {
+
+  const Array *children = (Array *) ((ViewController *) this)->childViewControllers;
+  for (size_t i = 0; i < children->count; i++) {
+    if ($((Object *) children->elements[i], isKindOfClass, _DialogViewController())) {
+      return;
+    }
+  }
+
+  ViewController *viewController = (ViewController *) $(alloc(DialogViewController), initWithDialog, dialog);
+  $((ViewController *) this, addChildViewController, viewController);
+  release(viewController);
+}
+
+/**
  * @brief Quit the game.
  */
 static void quit(ident data) {
@@ -85,15 +103,12 @@ static void didClickQuit(Button *button) {
 
   MainViewController *this = button->delegate.self;
 
-  const Dialog dialog = {
+  presentDialog(this, &(const Dialog) {
     .message = "Are you sure you want to quit?",
     .ok = "Yes",
     .cancel = "No",
     .okFunction = quit
-  };
-
-  ViewController *viewController = (ViewController *) $(alloc(DialogViewController), initWithDialog, &dialog);
-  $((ViewController *) this, addChildViewController, viewController);
+  });
 }
 
 /**
@@ -110,15 +125,12 @@ static void didClickDisconnect(Button *button) {
 
   MainViewController *this = button->delegate.self;
 
-  const Dialog dialog = {
+  presentDialog(this, &(const Dialog) {
     .message = "Are you sure you want to disconnect?",
     .ok = "Yes",
     .cancel = "No",
     .okFunction = disconnect
-  };
-
-  ViewController *viewController = (ViewController *) $(alloc(DialogViewController), initWithDialog, &dialog);
-  $((ViewController *) this, addChildViewController, viewController);
+  });
 }
 
 #pragma mark - Object
@@ -229,15 +241,12 @@ static void viewWillAppear(ViewController *self) {
   if (this->updateAvailable) {
     this->updateAvailable = false;
 
-    const Dialog dialog = {
+    presentDialog(this, &(const Dialog) {
       .message = "A new version of Quetoo is available. Download now?",
       .ok = "Yes",
       .cancel = "No",
       .okFunction = openReleasesPage
-    };
-
-    ViewController *viewController = (ViewController *) $(alloc(DialogViewController), initWithDialog, &dialog);
-    $(self, addChildViewController, viewController);
+    });
   }
 }
 

--- a/src/cgame/common/ui/play/JoinServerViewController.c
+++ b/src/cgame/common/ui/play/JoinServerViewController.c
@@ -59,18 +59,35 @@ static const cl_server_info_t *serverAtIndex(const PointerArray *servers, size_t
 }
 
 /**
- * @brief Returns the selected server, by hostname rather than by row index,
- * so that the selection survives a re-sort and a refresh.
+ * @brief Whether `addr` names a selected server, as opposed to the zeroed
+ * address that stands for no selection.
+ */
+static bool isSelectable(const net_addr_t *addr) {
+  return addr->addr || addr->port;
+}
+
+/**
+ * @brief Whether `a` and `b` are the same server, by address and port.
+ * @remarks `Net_CompareNetaddr` lives in the engine's socket layer, which the
+ * modules do not link, so the fields are compared directly.
+ */
+static bool sameAddr(const net_addr_t *a, const net_addr_t *b) {
+  return a->addr == b->addr && a->port == b->port;
+}
+
+/**
+ * @brief Returns the selected server, by address rather than by row index, so
+ * that the selection survives a re-sort and a refresh.
  */
 static const cl_server_info_t *selectedServer(const JoinServerViewController *self) {
 
-  if (self->servers == NULL || *self->selectedHostname == '\0') {
+  if (self->servers == NULL || !isSelectable(&self->selectedAddr)) {
     return NULL;
   }
 
   for (size_t i = 0; i < self->servers->count; i++) {
     const cl_server_info_t *server = $(self->servers, get, i);
-    if (q_strcmp(server->hostname, self->selectedHostname) == 0) {
+    if (sameAddr(&server->addr, &self->selectedAddr)) {
       return server;
     }
   }
@@ -196,7 +213,7 @@ static void refreshDetails(JoinServerViewController *self) {
 
 /**
  * @brief Restores the selection after a sort or a refresh.
- * @details The selection is held by hostname, so a re-sort keeps the same
+ * @details The selection is held by address, so a re-sort keeps the same
  * server rather than the same row. When the selected server has gone from the
  * list entirely, the details pane empties rather than jumping to another one.
  */
@@ -208,14 +225,14 @@ static void restoreSelection(JoinServerViewController *self) {
   const size_t count = self->servers ? self->servers->count : 0;
   for (size_t row = 0; row < count; row++) {
     const cl_server_info_t *server = $(self->servers, get, row);
-    if (q_strcmp(server->hostname, self->selectedHostname) == 0) {
+    if (sameAddr(&server->addr, &self->selectedAddr)) {
       index = (ssize_t) row;
       break;
     }
   }
 
   if (index < 0) {
-    self->selectedHostname[0] = '\0';
+    memset(&self->selectedAddr, 0, sizeof(self->selectedAddr));
   }
 
   $(tableView, deselectAll);
@@ -260,7 +277,7 @@ static void didSetMaxPing(Slider *slider, double value) {
 
 /**
  * @brief ButtonDelegate for Quick Join.
- * @description Selects a server based on minumum ping and maximum players
+ * @description Selects a server based on minimum ping and maximum players
  * with a bit of lovely random thrown in. Any server that matches the
  * criteria will be weighted by how much "better" they are by how much lower
  * their ping is and how many more players there are.
@@ -423,7 +440,7 @@ static void didSelectRowsAtIndexes(TableView *tableView, const IndexSet *indexes
     return;
   }
 
-  q_strlcpy(this->selectedHostname, server->hostname, sizeof(this->selectedHostname));
+  this->selectedAddr = server->addr;
   refreshDetails(this);
 
   const SDL_PropertiesID props = SDL_GetWindowProperties(((View *) tableView)->window);

--- a/src/cgame/common/ui/play/JoinServerViewController.c
+++ b/src/cgame/common/ui/play/JoinServerViewController.c
@@ -23,13 +23,25 @@
 
 #include "JoinServerViewController.h"
 #include "CvarCheckbox.h"
+#include "CvarSlider.h"
 
-static const char *_hostname = "Hostname";
-static const char *_source = "Source";
-static const char *_name = "Map";
-static const char *_gameplay = "Gameplay";
+static const char *_server = "Server";
+static const char *_map = "Map";
 static const char *_players = "Players";
 static const char *_ping = "Ping";
+
+/**
+ * @brief Stands in for a detail field the selected server did not report.
+ */
+static const char *_unset = "—";
+
+/**
+ * @brief A ping the client never got an answer for.
+ * @details `Cl_ParseServerInfo` clamps the measured round trip to 999, so 999
+ * is the timeout sentinel rather than a latency. Reading it as "slow but
+ * joinable" is the wrong story, so it renders unset and sorts last.
+ */
+#define JOIN_PING_UNANSWERED 999
 
 static cvar_t *cg_join_server_hide_empty;
 static cvar_t *cg_join_server_hide_bots;
@@ -46,44 +58,218 @@ static const cl_server_info_t *serverAtIndex(const PointerArray *servers, size_t
   return $(servers, get, index);
 }
 
-#pragma mark - Delegates
+/**
+ * @brief Returns the selected server, by hostname rather than by row index,
+ * so that the selection survives a re-sort and a refresh.
+ */
+static const cl_server_info_t *selectedServer(const JoinServerViewController *self) {
+
+  if (self->servers == NULL || *self->selectedHostname == '\0') {
+    return NULL;
+  }
+
+  for (size_t i = 0; i < self->servers->count; i++) {
+    const cl_server_info_t *server = $(self->servers, get, i);
+    if (q_strcmp(server->hostname, self->selectedHostname) == 0) {
+      return server;
+    }
+  }
+
+  return NULL;
+}
+
+static void setLabelText(Label *label, const char *text) {
+  $(label->text, setText, text && *text ? text : NULL);
+}
 
 /**
- * @brief CheckboxDelegate for Hide Bots.
+ * @brief The colour threshold and the quick join threshold are the same
+ * number, so that moving the slider visibly splits the list.
  */
+static int32_t maxPing(void) {
+  return Clampf(cg_quick_join_max_ping->integer, 1, 999);
+}
+
+/**
+ * @brief True when the client never got an answer from this server.
+ */
+static bool pingUnanswered(const cl_server_info_t *server) {
+  return server->ping <= 0 || server->ping >= JOIN_PING_UNANSWERED;
+}
+
+/**
+ * @brief Formats a server address for display.
+ * @details `Net_NetaddrToString` lives in the engine's socket layer, which
+ * the modules do not link, so the dotted quad is read straight out of the
+ * network byte order the address is stored in - no host byte order
+ * assumption.
+ */
+static const char *addressLabel(const net_addr_t *addr) {
+
+  const uint8_t *ip = (const uint8_t *) &addr->addr;
+  const uint8_t *port = (const uint8_t *) &addr->port;
+
+  return va("%u.%u.%u.%u:%u", ip[0], ip[1], ip[2], ip[3],
+            (uint32_t) port[0] << 8 | port[1]);
+}
+
+static const char *sourceLabel(const cl_server_info_t *server) {
+
+  switch (server->source) {
+    case SERVER_SOURCE_INTERNET:
+      return "Internet";
+    case SERVER_SOURCE_USER:
+      return "User";
+    case SERVER_SOURCE_BCAST:
+      return "LAN";
+  }
+
+  return _unset;
+}
+
+#pragma mark - Details pane
+
+/**
+ * @brief Shows or hides everything in the details pane that only means
+ * something once a server is selected.
+ */
+static void setDetailsPopulated(JoinServerViewController *self, const bool populated) {
+
+  $((View *) self->hintLabel, setHidden, populated);
+  $(self->detailGrid, setHidden, !populated);
+}
+
+/**
+ * @brief Shows the selected server's mapshot, when its map is installed locally.
+ */
+static void refreshMapshot(JoinServerViewController *self, const cl_server_info_t *server) {
+
+  SDL_Surface *surface = NULL;
+
+  if (server && *server->name) {
+    List *mapshots = cgi.Mapshots(server->name);
+
+    if (mapshots->count) {
+      surface = cgi.LoadSurface(mapshots->head->element);
+    }
+
+    release(mapshots);
+  }
+
+  $(self->mapshotView, setImageWithSurface, surface);
+  $((View *) self->mapshotView, setHidden, surface == NULL);
+
+  if (surface) {
+    SDL_DestroySurface(surface);
+  }
+}
+
+/**
+ * @brief Repopulates the details pane from the current selection.
+ */
+static void refreshDetails(JoinServerViewController *self) {
+
+  const cl_server_info_t *server = selectedServer(self);
+
+  setDetailsPopulated(self, server != NULL);
+  refreshMapshot(self, server);
+
+  if (server == NULL) {
+    setLabelText(self->hostnameLabel, "Select a server");
+    setLabelText(self->addressLabel, NULL);
+    $((View *) self->connectButton, setHidden, true);
+    return;
+  }
+
+  setLabelText(self->hostnameLabel, *server->hostname ? server->hostname : _unset);
+  setLabelText(self->addressLabel, addressLabel(&server->addr));
+
+  setLabelText(self->sourceLabel, sourceLabel(server));
+  setLabelText(self->mapLabel, *server->name ? server->name : _unset);
+  setLabelText(self->gameplayLabel, *server->gameplay ? server->gameplay : _unset);
+  setLabelText(self->movementLabel, *server->movement ? server->movement : _unset);
+  setLabelText(self->playersLabel, va("%d / %d", server->clients, server->max_clients));
+  setLabelText(self->pingLabel, pingUnanswered(server) ? _unset : va("%d ms", server->ping));
+
+  $((View *) self->connectButton, setHidden, false);
+}
+
+/**
+ * @brief Restores the selection after a sort or a refresh.
+ * @details The selection is held by hostname, so a re-sort keeps the same
+ * server rather than the same row. When the selected server has gone from the
+ * list entirely, the details pane empties rather than jumping to another one.
+ */
+static void restoreSelection(JoinServerViewController *self) {
+
+  TableView *tableView = self->serversTableView;
+
+  ssize_t index = -1;
+  const size_t count = self->servers ? self->servers->count : 0;
+  for (size_t row = 0; row < count; row++) {
+    const cl_server_info_t *server = $(self->servers, get, row);
+    if (q_strcmp(server->hostname, self->selectedHostname) == 0) {
+      index = (ssize_t) row;
+      break;
+    }
+  }
+
+  if (index < 0) {
+    self->selectedHostname[0] = '\0';
+  }
+
+  $(tableView, deselectAll);
+
+  if (index >= 0) {
+    $(tableView, selectRowAtIndex, (size_t) index);
+  }
+
+  refreshDetails(self);
+}
+
+#pragma mark - Delegates
+
 static void didToggleHideBots(Checkbox *checkbox) {
 
   cvarCheckboxDidToggle(checkbox);
 
-  JoinServerViewController *this = checkbox->delegate.self;
-
-  $(this, reloadServers);
+  $((JoinServerViewController *) checkbox->delegate.self, reloadServers);
 }
 
-/**
- * @brief CheckboxDelegate for Hide Empty.
- */
 static void didToggleHideEmpty(Checkbox *checkbox) {
 
   cvarCheckboxDidToggle(checkbox);
 
-  JoinServerViewController *this = checkbox->delegate.self;
+  $((JoinServerViewController *) checkbox->delegate.self, reloadServers);
+}
 
-  $(this, reloadServers);
+/**
+ * @brief SliderDelegate for the max ping slider.
+ * @details CvarSlider writes the cvar in its own `setValue`; the delegate
+ * slot is free, and is what repaints the ping column against the new
+ * threshold.
+ */
+static void didSetMaxPing(Slider *slider, double value) {
+
+  (void) value;
+
+  JoinServerViewController *this = slider->delegate.self;
+
+  $(this->serversTableView, reloadData);
 }
 
 /**
  * @brief ButtonDelegate for Quick Join.
- * @description Selects a server based on minumum ping and maximum players with
- * a bit of lovely random thrown in. Any server that matches the criteria will
- * be weighted by how much "better" they are by how much lower their ping is and
- * how many more players there are.
+ * @description Selects a server based on minumum ping and maximum players
+ * with a bit of lovely random thrown in. Any server that matches the
+ * criteria will be weighted by how much "better" they are by how much lower
+ * their ping is and how many more players there are.
  */
 static void didClickQuickJoin(Button *button) {
 
   JoinServerViewController *this = button->delegate.self;
 
-  const int32_t max_ping = Clampf(cg_quick_join_max_ping->integer, 0, 999);
+  const int32_t max_ping = maxPing();
   const int32_t min_clients = Clampf(cg_quick_join_min_clients->integer, 0, MAX_CLIENTS);
 
   uint32_t total_weight = 0;
@@ -153,72 +339,33 @@ static void didClickRefresh(Button *button) {
 
 /**
  * @brief ButtonDelegate for the Connect button.
+ * @details Connect acts on the details pane's server, which is the selection
+ * held by hostname - not on whatever row happens to be at the selected index.
  */
 static void didClickConnect(Button *button) {
 
   JoinServerViewController *this = button->delegate.self;
 
-  IndexSet *selectedRowIndexes = $((TableView *) this->serversTableView, selectedRowIndexes);
-  if (selectedRowIndexes->count) {
-
-    const uint32_t index = (uint32_t) selectedRowIndexes->indexes[0];
-    const cl_server_info_t *server = serverAtIndex(this->servers, index);
-
-    if (server) {
-      cgi.Connect(&server->addr);
-    }
+  const cl_server_info_t *server = selectedServer(this);
+  if (server) {
+    cgi.Connect(&server->addr);
   }
-
-  release(selectedRowIndexes);
 }
 
 #pragma mark - TableViewDataSource
 
-/**
- * @see TableViewDataSource::numberOfRows
- */
 static size_t numberOfRows(const TableView *tableView) {
 
-  JoinServerViewController *this = tableView->dataSource.self;
+  const JoinServerViewController *this = tableView->dataSource.self;
 
   return this->servers ? this->servers->count : 0;
 }
 
-/**
- * @see TableViewDataSource::valueForColumnAndRow
- */
-static ident valueForColumnAndRow(const TableView *tableView, const TableColumn *column, size_t row) {
-
-  JoinServerViewController *this = tableView->dataSource.self;
-
-  cl_server_info_t *server = (cl_server_info_t *) serverAtIndex(this->servers, row);
-  assert(server);
-
-  if (q_strcmp(column->identifier, _hostname) == 0) {
-    return server->hostname;
-  } else if (q_strcmp(column->identifier, _source) == 0) {
-    return &server->source;
-  } else if (q_strcmp(column->identifier, _name) == 0) {
-    return server->name;
-  } else if (q_strcmp(column->identifier, _gameplay) == 0) {
-    return server->gameplay;
-  } else if (q_strcmp(column->identifier, _players) == 0) {
-    return &server->clients;
-  } else if (q_strcmp(column->identifier, _ping) == 0) {
-    return &server->ping;
-  }
-
-  return NULL;
-}
-
 #pragma mark - TableViewDelegate
 
-/**
- * @see TableViewDelegate::cellForColumnAndRow
- */
 static TableCellView *cellForColumnAndRow(const TableView *tableView, const TableColumn *column, size_t row) {
 
-  JoinServerViewController *this = tableView->dataSource.self;
+  const JoinServerViewController *this = tableView->dataSource.self;
 
   cl_server_info_t *server = (cl_server_info_t *) serverAtIndex(this->servers, row);
   assert(server);
@@ -226,79 +373,68 @@ static TableCellView *cellForColumnAndRow(const TableView *tableView, const Tabl
   TableCellView *cell = $(alloc(TableCellView), initWithFrame, NULL);
 
   if (q_strlen(server->error)) {
-    if (q_strcmp(column->identifier, _hostname) == 0) {
+    if (q_strcmp(column->identifier, _server) == 0) {
       $(cell->text, setText, server->error);
       $((View *) cell, addClassName, "error");
-    } else {
-      $(cell->text, setText, NULL);
     }
-  } else {
-    if (q_strcmp(column->identifier, _hostname) == 0) {
-      $(cell->text, setText, server->hostname);
-    } else if (q_strcmp(column->identifier, _source) == 0) {
-      switch (server->source) {
-        case SERVER_SOURCE_INTERNET:
-          $(cell->text, setText, "Internet");
-          break;
-        case SERVER_SOURCE_USER:
-          $(cell->text, setText, "User");
-          break;
-        case SERVER_SOURCE_BCAST:
-          $(cell->text, setText, "LAN");
-          break;
+    return cell;
+  }
+
+  if (q_strcmp(column->identifier, _server) == 0) {
+    $(cell->text, setText, server->hostname);
+  } else if (q_strcmp(column->identifier, _map) == 0) {
+    $(cell->text, setText, server->name);
+  } else if (q_strcmp(column->identifier, _players) == 0) {
+    $(cell->text, setText, va("%d / %d", server->clients, server->max_clients));
+  } else if (q_strcmp(column->identifier, _ping) == 0) {
+
+    if (pingUnanswered(server)) {
+      $(cell->text, setText, _unset);
+      $((View *) cell, addClassName, "pingUnanswered");
+    } else {
+      $(cell->text, setText, va("%d ms", server->ping));
+
+      const int32_t threshold = maxPing();
+      if (server->ping > threshold) {
+        $((View *) cell, addClassName, "pingOver");
+      } else if (server->ping <= threshold / 2) {
+        $((View *) cell, addClassName, "pingFast");
       }
-    } else if (q_strcmp(column->identifier, _name) == 0) {
-      $(cell->text, setText, server->name);
-    } else if (q_strcmp(column->identifier, _gameplay) == 0) {
-      $(cell->text, setText, server->gameplay);
-    } else if (q_strcmp(column->identifier, _players) == 0) {
-      if (cg_join_server_hide_bots->value) {
-        $(cell->text, setText, va("%d/%d", server->clients - server->bots, server->max_clients));
-      } else {
-        $(cell->text, setText, va("%d/%d", server->clients, server->max_clients));
-      }
-    } else if (q_strcmp(column->identifier, _ping) == 0) {
-      $(cell->text, setText, va("%3d", server->ping));
     }
   }
 
   return cell;
 }
 
-/**
- * @see TableViewDelegate::didSetSortColumn(TableView *)
- */
 static void didSetSortColumn(TableView *tableView) {
   $((JoinServerViewController *) tableView->delegate.self, reloadServers);
 }
 
-/**
- * @see TableViewDelegate::didSelectRowsAtIndexes(TableView *, const IndexSet *)
- */
 static void didSelectRowsAtIndexes(TableView *tableView, const IndexSet *indexes) {
 
   JoinServerViewController *this = tableView->delegate.self;
 
-  View *view = (View *) tableView;
+  if (indexes->count == 0) {
+    return;
+  }
 
-  const SDL_PropertiesID props = SDL_GetWindowProperties(view->window);
+  const cl_server_info_t *server = serverAtIndex(this->servers, indexes->indexes[0]);
+  if (server == NULL) {
+    return;
+  }
+
+  q_strlcpy(this->selectedHostname, server->hostname, sizeof(this->selectedHostname));
+  refreshDetails(this);
+
+  const SDL_PropertiesID props = SDL_GetWindowProperties(((View *) tableView)->window);
   const SDL_Event *event = SDL_GetPointerProperty(props, "event", NULL);
   if (event && event->button.clicks == 2) {
-
-    const uint32_t index = (uint32_t) indexes->indexes[0];
-    const cl_server_info_t *server = serverAtIndex(this->servers, index);
-
-    if (server) {
-      cgi.Connect(&server->addr);
-    }
+    cgi.Connect(&server->addr);
   }
 }
 
 #pragma mark - Object
 
-/**
- * @see Object::dealloc(Object *)
- */
 static void dealloc(Object *self) {
 
   JoinServerViewController *this = (JoinServerViewController *) self;
@@ -320,15 +456,28 @@ static void loadView(ViewController *self) {
   JoinServerViewController *this = (JoinServerViewController *) self;
 
   Checkbox *hideEmpty, *hideBots;
-  Button *quickJoin, *refresh, *connect;
+  Button *refresh, *quickJoin;
 
   Outlet outlets[] = MakeOutlets(
     MakeOutlet("servers", &this->serversTableView),
-    MakeOutlet("hideEmpty", &hideEmpty),
-    MakeOutlet("hideBots", &hideBots),
+    MakeOutlet("servers_empty", &this->emptyLabel),
+    MakeOutlet("server_hostname", &this->hostnameLabel),
+    MakeOutlet("server_address", &this->addressLabel),
+    MakeOutlet("server_hint", &this->hintLabel),
+    MakeOutlet("server_grid", &this->detailGrid),
+    MakeOutlet("server_source", &this->sourceLabel),
+    MakeOutlet("server_map", &this->mapLabel),
+    MakeOutlet("server_gameplay", &this->gameplayLabel),
+    MakeOutlet("server_movement", &this->movementLabel),
+    MakeOutlet("server_mapshot", &this->mapshotView),
+    MakeOutlet("server_players", &this->playersLabel),
+    MakeOutlet("server_ping", &this->pingLabel),
+    MakeOutlet("connect", &this->connectButton),
     MakeOutlet("quickJoin", &quickJoin),
     MakeOutlet("refresh", &refresh),
-    MakeOutlet("connect", &connect)
+    MakeOutlet("hideEmpty", &hideEmpty),
+    MakeOutlet("hideBots", &hideBots),
+    MakeOutlet("maxPing", &this->maxPingSlider)
   );
 
   $(self->view, awakeWithResourceName, "ui/play/JoinServerViewController.json");
@@ -336,16 +485,13 @@ static void loadView(ViewController *self) {
 
   self->view->stylesheet = $$(Stylesheet, stylesheetWithResourceName, "ui/play/JoinServerViewController.css");
   assert(self->view->stylesheet);
-  
-  $(this->serversTableView, addColumnWithIdentifier, _hostname);
-  $(this->serversTableView, addColumnWithIdentifier, _source);
-  $(this->serversTableView, addColumnWithIdentifier, _name);
-  $(this->serversTableView, addColumnWithIdentifier, _gameplay);
+
+  $(this->serversTableView, addColumnWithIdentifier, _server);
+  $(this->serversTableView, addColumnWithIdentifier, _map);
   $(this->serversTableView, addColumnWithIdentifier, _players);
   $(this->serversTableView, addColumnWithIdentifier, _ping);
 
   this->serversTableView->dataSource.numberOfRows = numberOfRows;
-  this->serversTableView->dataSource.valueForColumnAndRow = valueForColumnAndRow;
   this->serversTableView->dataSource.self = this;
 
   this->serversTableView->delegate.cellForColumnAndRow = cellForColumnAndRow;
@@ -359,14 +505,20 @@ static void loadView(ViewController *self) {
   hideEmpty->delegate.didToggle = didToggleHideEmpty;
   hideEmpty->delegate.self = this;
 
-  quickJoin->delegate.didClick = didClickQuickJoin;
-  quickJoin->delegate.self = this;
+  this->maxPingSlider->delegate.didSetValue = didSetMaxPing;
+  this->maxPingSlider->delegate.self = this;
+  $(this->maxPingSlider, setLabelFormat, "%g ms");
 
   refresh->delegate.didClick = didClickRefresh;
   refresh->delegate.self = this;
 
-  connect->delegate.didClick = didClickConnect;
-  connect->delegate.self = this;
+  this->connectButton->delegate.didClick = didClickConnect;
+  this->connectButton->delegate.self = this;
+
+  quickJoin->delegate.didClick = didClickQuickJoin;
+  quickJoin->delegate.self = this;
+
+  refreshDetails(this);
 }
 
 /**
@@ -390,13 +542,7 @@ static void viewWillAppear(ViewController *self) {
 
   JoinServerViewController *this = (JoinServerViewController *) self;
 
-  // show what we already know at once, then ask the master again; querying only
-  // when nothing was cached meant the first answer of a session was the only one,
-  // so a list that was empty when the menu first opened stayed empty until the
-  // Refresh button was pressed
-  if (this->servers) {
-    $(this, reloadServers);
-  }
+  $(this, reloadServers); // show what we already know at once, then ask the master again
 
   cgi.GetServers();
 }
@@ -404,16 +550,26 @@ static void viewWillAppear(ViewController *self) {
 #pragma mark - JoinServerViewController
 
 /**
- * @brief GCompareDataFunc for server sorting.
+ * @brief Comparator for server sorting.
  */
 static Order comparator(const ident a, const ident b) {
 
   JoinServerViewController *this = sortingJoinServerViewController;
+  const TableColumn *sortColumn = this->serversTableView->sortColumn;
 
-  if (this->serversTableView->sortColumn) {
+  // an unanswered server goes last, whichever way the ping column points
+  if (sortColumn && q_strcmp(sortColumn->identifier, _ping) == 0) {
+    const bool leftUnanswered = pingUnanswered((const cl_server_info_t *) a);
+    const bool rightUnanswered = pingUnanswered((const cl_server_info_t *) b);
+    if (leftUnanswered != rightUnanswered) {
+      return leftUnanswered ? OrderDescending : OrderAscending;
+    }
+  }
+
+  if (sortColumn) {
     const cl_server_info_t *s0, *s1;
 
-    switch (this->serversTableView->sortColumn->order) {
+    switch (sortColumn->order) {
       case OrderAscending:
         s0 = a; s1 = b;
         break;
@@ -426,17 +582,13 @@ static Order comparator(const ident a, const ident b) {
 
     int32_t cmp = 0;
 
-    if (q_strcmp(this->serversTableView->sortColumn->identifier, _hostname) == 0) {
+    if (q_strcmp(sortColumn->identifier, _server) == 0) {
       cmp = q_strcmp(s0->hostname, s1->hostname);
-    } else if (q_strcmp(this->serversTableView->sortColumn->identifier, _source) == 0) {
-      cmp = s0->source - s1->source;
-    } else if (q_strcmp(this->serversTableView->sortColumn->identifier, _name) == 0) {
+    } else if (q_strcmp(sortColumn->identifier, _map) == 0) {
       cmp = q_strcmp(s0->name, s1->name);
-    } else if (q_strcmp(this->serversTableView->sortColumn->identifier, _gameplay) == 0) {
-      cmp = q_strcmp(s0->gameplay, s1->gameplay);
-    } else if (q_strcmp(this->serversTableView->sortColumn->identifier, _players) == 0) {
+    } else if (q_strcmp(sortColumn->identifier, _players) == 0) {
       cmp = s0->clients - s1->clients;
-    } else if (q_strcmp(this->serversTableView->sortColumn->identifier, _ping) == 0) {
+    } else if (q_strcmp(sortColumn->identifier, _ping) == 0) {
       cmp = s0->ping - s1->ping;
     } else {
       assert(false);
@@ -488,7 +640,12 @@ static void reloadServers(JoinServerViewController *self) {
   $(self->servers, sort, comparator);
   sortingJoinServerViewController = NULL;
 
+  $((View *) self->emptyLabel, setHidden, self->servers->count > 0);
+  $((View *) self->serversTableView, setHidden, self->servers->count == 0);
+
   $(self->serversTableView, reloadData);
+
+  restoreSelection(self);
 }
 
 #pragma mark - Class lifecycle

--- a/src/cgame/common/ui/play/JoinServerViewController.c
+++ b/src/cgame/common/ui/play/JoinServerViewController.c
@@ -45,6 +45,7 @@ static const char *_unset = "—";
 
 static cvar_t *cg_join_server_hide_empty;
 static cvar_t *cg_join_server_hide_bots;
+
 static JoinServerViewController *sortingJoinServerViewController;
 
 #define _Class _JoinServerViewController
@@ -398,8 +399,10 @@ static TableCellView *cellForColumnAndRow(const TableView *tableView, const Tabl
   }
 
   if (q_strcmp(column->identifier, _server) == 0) {
+    cell->text->colorEscapes = true;
     $(cell->text, setText, server->hostname);
   } else if (q_strcmp(column->identifier, _map) == 0) {
+    cell->text->colorEscapes = true;
     $(cell->text, setText, server->name);
   } else if (q_strcmp(column->identifier, _players) == 0) {
     $(cell->text, setText, va("%d / %d", server->clients, server->max_clients));

--- a/src/cgame/common/ui/play/JoinServerViewController.css
+++ b/src/cgame/common/ui/play/JoinServerViewController.css
@@ -1,19 +1,7 @@
 
 #servers {
-  width: 880;
-  height: 640;
-}
-
-#Join .accessoryView {
-  spacing: 16;
-}
-
-#Join .columns {
-  distribution: default;
-}
-
-#Join .column Box {
-  autoresizing-mask: contain | height;
+  autoresizing-mask: width;
+  height: 620;
 }
 
 #Server {
@@ -50,7 +38,7 @@
 
 .joinEmptyState {
   color: #888888;
-  min-height: 640;
+  min-height: 620;
 }
 
 .joinDetailTitle {

--- a/src/cgame/common/ui/play/JoinServerViewController.css
+++ b/src/cgame/common/ui/play/JoinServerViewController.css
@@ -1,27 +1,31 @@
 
 #servers {
-  width: 1420;
+  width: 880;
   height: 640;
 }
 
-#Hostname {
-  min-width: 420;
+#Join .accessoryView {
+  spacing: 16;
 }
 
-#Source {
-  min-width: 140;
+#Join .columns {
+  distribution: default;
+}
+
+#Join .column Box {
+  autoresizing-mask: contain | height;
+}
+
+#Server {
+  min-width: 380;
 }
 
 #Map {
-  min-width: 140;
-}
-
-#Gameplay {
-  min-width: 140;
+  min-width: 180;
 }
 
 #Players {
-  min-width: 100;
+  min-width: 140;
 }
 
 #Ping {
@@ -30,4 +34,51 @@
 
 #servers .error > Text {
   color: darkred;
+}
+
+#servers .pingUnanswered > Text {
+  color: #888888;
+}
+
+#servers .pingOver > Text {
+  color: darkred;
+}
+
+#servers .pingFast > Text {
+  color: #1e4e62;
+}
+
+.joinEmptyState {
+  color: #888888;
+  min-height: 640;
+}
+
+.joinDetailTitle {
+  font-size: 24;
+}
+
+.joinDetailAddress {
+  color: #888888;
+}
+
+.joinDetailHint {
+  color: #888888;
+}
+
+.joinDetailMapshot {
+  width: 416;
+  height: 234;
+}
+
+.joinDetailGrid {
+  spacing: 4;
+}
+
+.joinDetailRow {
+  axis: horizontal;
+}
+
+.joinDetailCaption {
+  min-width: 140;
+  color: #888888;
 }

--- a/src/cgame/common/ui/play/JoinServerViewController.h
+++ b/src/cgame/common/ui/play/JoinServerViewController.h
@@ -27,7 +27,8 @@
 
 /**
  * @file
- * @brief Join server ViewController.
+ * @brief Join server ViewController: the known servers in one pane, and the
+ * selected one's details in the other.
  */
 
 typedef struct JoinServerViewController JoinServerViewController;
@@ -61,6 +62,49 @@ struct JoinServerViewController {
    * @brief The servers TableView.
    */
   TableView *serversTableView;
+
+  /**
+   * @brief The list's empty state, shown in place of the table rather than
+   * beside it, since one is meaningful only when the other is not.
+   */
+  Label *emptyLabel;
+
+  /**
+   * @brief The details pane, populated from the current selection.
+   */
+  Label *hostnameLabel, *addressLabel, *hintLabel, *sourceLabel;
+  Label *mapLabel, *gameplayLabel, *movementLabel, *playersLabel, *pingLabel;
+
+  /**
+   * @brief The selected server's mapshot, when its map is installed locally.
+   */
+  ImageView *mapshotView;
+
+  /**
+   * @brief The part of the details pane that only means something once a
+   * server is selected, hidden together until then.
+   */
+  View *detailGrid;
+
+  /**
+   * @brief The details pane's action.
+   */
+  Button *connectButton;
+
+  /**
+   * @brief The max ping slider, which doubles as the ping colour threshold.
+   * @remarks Typed as its Slider superclass: the JSON declares a CvarSlider,
+   * which writes `cg_quick_join_max_ping` itself, and `CvarSlider.h` is not
+   * part of the umbrella ObjectivelyMVC header this one includes.
+   */
+  Slider *maxPingSlider;
+
+  /**
+   * @brief The selected server's hostname.
+   * @details The selection is held by name rather than by row index, so that
+   * it survives a re-sort and a refresh. Empty when nothing is selected.
+   */
+  char selectedHostname[48];
 };
 
 /**

--- a/src/cgame/common/ui/play/JoinServerViewController.h
+++ b/src/cgame/common/ui/play/JoinServerViewController.h
@@ -100,11 +100,12 @@ struct JoinServerViewController {
   Slider *maxPingSlider;
 
   /**
-   * @brief The selected server's hostname.
-   * @details The selection is held by name rather than by row index, so that
-   * it survives a re-sort and a refresh. Empty when nothing is selected.
+   * @brief The selected server's address.
+   * @details The selection is held by address rather than by row index, so that
+   * it survives a re-sort and a refresh, and by address rather than by hostname,
+   * which servers do not advertise uniquely. Zeroed when nothing is selected.
    */
-  char selectedHostname[48];
+  net_addr_t selectedAddr;
 };
 
 /**

--- a/src/cgame/common/ui/play/JoinServerViewController.json
+++ b/src/cgame/common/ui/play/JoinServerViewController.json
@@ -101,6 +101,13 @@
                       "title": {
                         "text": "Refresh"
                       }
+                    },
+                    {
+                      "class": "Button",
+                      "identifier": "quickJoin",
+                      "title": {
+                        "text": "Quick join"
+                      }
                     }
                   ]
                 }
@@ -330,13 +337,6 @@
                       "identifier": "connect",
                       "title": {
                         "text": "Connect"
-                      }
-                    },
-                    {
-                      "class": "Button",
-                      "identifier": "quickJoin",
-                      "title": {
-                        "text": "Quick join"
                       }
                     }
                   ]

--- a/src/cgame/common/ui/play/JoinServerViewController.json
+++ b/src/cgame/common/ui/play/JoinServerViewController.json
@@ -8,62 +8,340 @@
       ],
       "subviews": [
         {
-          "class": "TableView",
-          "identifier": "servers"
-        },
-        {
           "class": "StackView",
           "classNames": [
-            "accessoryView",
+            "columns",
             "container"
           ],
           "subviews": [
             {
-              "class": "Input",
-              "label": {
-                "text": {
-                  "text": "Hide empty"
+              "class": "StackView",
+              "classNames": [
+                "column-2",
+                "container"
+              ],
+              "subviews": [
+                {
+                  "class": "Box",
+                  "label": {
+                    "text": {
+                      "text": "Servers"
+                    }
+                  },
+                  "contentView": {
+                    "subviews": [
+                      {
+                        "class": "TableView",
+                        "identifier": "servers"
+                      },
+                      {
+                        "class": "Label",
+                        "identifier": "servers_empty",
+                        "classNames": [
+                          "joinEmptyState"
+                        ],
+                        "text": {
+                          "text": "No servers match the current filters."
+                        }
+                      }
+                    ]
+                  }
+                },
+                {
+                  "class": "StackView",
+                  "classNames": [
+                    "accessoryView"
+                  ],
+                  "subviews": [
+                    {
+                      "class": "Input",
+                      "label": {
+                        "text": {
+                          "text": "Hide empty"
+                        }
+                      },
+                      "control": {
+                        "class": "CvarCheckbox",
+                        "identifier": "hideEmpty",
+                        "var": "cg_join_server_hide_empty"
+                      }
+                    },
+                    {
+                      "class": "Input",
+                      "label": {
+                        "text": {
+                          "text": "Hide bots"
+                        }
+                      },
+                      "control": {
+                        "class": "CvarCheckbox",
+                        "identifier": "hideBots",
+                        "var": "cg_join_server_hide_bots"
+                      }
+                    },
+                    {
+                      "class": "Input",
+                      "label": {
+                        "text": {
+                          "text": "Max ping"
+                        }
+                      },
+                      "control": {
+                        "class": "CvarSlider",
+                        "identifier": "maxPing",
+                        "var": "cg_quick_join_max_ping",
+                        "min": 30,
+                        "max": 300,
+                        "step": 10
+                      }
+                    },
+                    {
+                      "class": "Button",
+                      "identifier": "refresh",
+                      "title": {
+                        "text": "Refresh"
+                      }
+                    }
+                  ]
                 }
-              },
-              "control": {
-                "class": "CvarCheckbox",
-                "identifier": "hideEmpty",
-                "var": "cg_join_server_hide_empty"
-              }
+              ]
             },
             {
-              "class": "Input",
-              "label": {
-                "text": {
-                  "text": "Hide bots"
+              "class": "StackView",
+              "classNames": [
+                "column",
+                "container"
+              ],
+              "subviews": [
+                {
+                  "class": "Box",
+                  "label": {
+                    "text": {
+                      "text": "Server details"
+                    }
+                  },
+                  "contentView": {
+                    "subviews": [
+                      {
+                        "class": "Label",
+                        "identifier": "server_hostname",
+                        "classNames": [
+                          "joinDetailTitle"
+                        ],
+                        "text": {
+                          "text": "Select a server"
+                        }
+                      },
+                      {
+                        "class": "Label",
+                        "identifier": "server_address",
+                        "classNames": [
+                          "joinDetailAddress"
+                        ],
+                        "text": {}
+                      },
+                      {
+                        "class": "Label",
+                        "identifier": "server_hint",
+                        "classNames": [
+                          "joinDetailHint"
+                        ],
+                        "text": {
+                          "text": "Choose a server from the list to see its details."
+                        }
+                      },
+                      {
+                        "class": "ImageView",
+                        "identifier": "server_mapshot",
+                        "classNames": [
+                          "joinDetailMapshot"
+                        ]
+                      },
+                      {
+                        "class": "StackView",
+                        "identifier": "server_grid",
+                        "classNames": [
+                          "joinDetailGrid"
+                        ],
+                        "subviews": [
+                          {
+                            "class": "StackView",
+                            "classNames": [
+                              "joinDetailRow"
+                            ],
+                            "subviews": [
+                              {
+                                "class": "Label",
+                                "classNames": [
+                                  "joinDetailCaption"
+                                ],
+                                "text": {
+                                  "text": "Source"
+                                }
+                              },
+                              {
+                                "class": "Label",
+                                "identifier": "server_source",
+                                "classNames": [
+                                  "joinDetailValue"
+                                ],
+                                "text": {}
+                              }
+                            ]
+                          },
+                          {
+                            "class": "StackView",
+                            "classNames": [
+                              "joinDetailRow"
+                            ],
+                            "subviews": [
+                              {
+                                "class": "Label",
+                                "classNames": [
+                                  "joinDetailCaption"
+                                ],
+                                "text": {
+                                  "text": "Map"
+                                }
+                              },
+                              {
+                                "class": "Label",
+                                "identifier": "server_map",
+                                "classNames": [
+                                  "joinDetailValue"
+                                ],
+                                "text": {}
+                              }
+                            ]
+                          },
+                          {
+                            "class": "StackView",
+                            "classNames": [
+                              "joinDetailRow"
+                            ],
+                            "subviews": [
+                              {
+                                "class": "Label",
+                                "classNames": [
+                                  "joinDetailCaption"
+                                ],
+                                "text": {
+                                  "text": "Gameplay"
+                                }
+                              },
+                              {
+                                "class": "Label",
+                                "identifier": "server_gameplay",
+                                "classNames": [
+                                  "joinDetailValue"
+                                ],
+                                "text": {}
+                              }
+                            ]
+                          },
+                          {
+                            "class": "StackView",
+                            "classNames": [
+                              "joinDetailRow"
+                            ],
+                            "subviews": [
+                              {
+                                "class": "Label",
+                                "classNames": [
+                                  "joinDetailCaption"
+                                ],
+                                "text": {
+                                  "text": "Movement"
+                                }
+                              },
+                              {
+                                "class": "Label",
+                                "identifier": "server_movement",
+                                "classNames": [
+                                  "joinDetailValue"
+                                ],
+                                "text": {}
+                              }
+                            ]
+                          },
+                          {
+                            "class": "StackView",
+                            "classNames": [
+                              "joinDetailRow"
+                            ],
+                            "subviews": [
+                              {
+                                "class": "Label",
+                                "classNames": [
+                                  "joinDetailCaption"
+                                ],
+                                "text": {
+                                  "text": "Players"
+                                }
+                              },
+                              {
+                                "class": "Label",
+                                "identifier": "server_players",
+                                "classNames": [
+                                  "joinDetailValue"
+                                ],
+                                "text": {}
+                              }
+                            ]
+                          },
+                          {
+                            "class": "StackView",
+                            "classNames": [
+                              "joinDetailRow"
+                            ],
+                            "subviews": [
+                              {
+                                "class": "Label",
+                                "classNames": [
+                                  "joinDetailCaption"
+                                ],
+                                "text": {
+                                  "text": "Ping"
+                                }
+                              },
+                              {
+                                "class": "Label",
+                                "identifier": "server_ping",
+                                "classNames": [
+                                  "joinDetailValue"
+                                ],
+                                "text": {}
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                },
+                {
+                  "class": "StackView",
+                  "classNames": [
+                    "accessoryView"
+                  ],
+                  "subviews": [
+                    {
+                      "class": "Button",
+                      "identifier": "connect",
+                      "title": {
+                        "text": "Connect"
+                      }
+                    },
+                    {
+                      "class": "Button",
+                      "identifier": "quickJoin",
+                      "title": {
+                        "text": "Quick join"
+                      }
+                    }
+                  ]
                 }
-              },
-              "control": {
-                "class": "CvarCheckbox",
-                "identifier": "hideBots",
-                "var": "cg_join_server_hide_bots"
-              }
-            },
-            {
-              "class": "Button",
-              "identifier": "quickJoin",
-              "title": {
-                "text": "Quick join"
-              }
-            },
-            {
-              "class": "Button",
-              "identifier": "refresh",
-              "title": {
-                "text": "Refresh"
-              }
-            },
-            {
-              "class": "Button",
-              "identifier": "connect",
-              "title": {
-                "text": "Connect"
-              }
+              ]
             }
           ]
         }

--- a/src/cgame/common/ui/play/JoinServerViewController.json
+++ b/src/cgame/common/ui/play/JoinServerViewController.json
@@ -136,7 +136,8 @@
                           "joinDetailTitle"
                         ],
                         "text": {
-                          "text": "Select a server"
+                          "text": "Select a server",
+                          "colorEscapes": true
                         }
                       },
                       {

--- a/src/cgame/common/ui/play/PlayerSetupViewController.c
+++ b/src/cgame/common/ui/play/PlayerSetupViewController.c
@@ -164,6 +164,7 @@ static void loadView(ViewController *self) {
   PlayerSetupViewController *this = (PlayerSetupViewController *) self;
 
   Outlet outlets[] = MakeOutlets(
+    MakeOutlet("name", &this->name),
     MakeOutlet("skin", &this->skinSelect),
     MakeOutlet("helmet", &this->helmetColorPicker),
     MakeOutlet("shirt", &this->shirtColorPicker),
@@ -178,6 +179,8 @@ static void loadView(ViewController *self) {
 
   self->view->stylesheet = $$(Stylesheet, stylesheetWithResourceName, "ui/play/PlayerSetupViewController.css");
   assert(self->view->stylesheet);
+  
+  this->name->text->colorEscapes = true;
 
   this->skinSelect->comparator = sortSkins;
   this->skinSelect->delegate.self = this;

--- a/src/cgame/common/ui/play/PlayerSetupViewController.h
+++ b/src/cgame/common/ui/play/PlayerSetupViewController.h
@@ -55,6 +55,11 @@ struct PlayerSetupViewController {
   PlayerSetupViewControllerInterface *interface[0];
 
   /**
+   * @brief The player name.
+   */
+  TextView *name;
+  
+  /**
    * @brief The skin Select.
    */
   Select *skinSelect;

--- a/src/cgame/common/ui/play/PlayerSetupViewController.json
+++ b/src/cgame/common/ui/play/PlayerSetupViewController.json
@@ -38,6 +38,7 @@
                         },
                         "control": {
                           "class": "CvarTextView",
+                          "identifier": "name",
                           "var": "name"
                         }
                       },

--- a/src/cgame/common/ui/vote/VoteViewController.c
+++ b/src/cgame/common/ui/vote/VoteViewController.c
@@ -46,9 +46,9 @@ static void didSelectType(Select *select, Option *option) {
   VoteViewController *this = select->delegate.self;
   const vote_type_t *type = option->value;
 
-  ((View *) this->map)->superview->hidden = type->arg != VOTE_ARG_MAP;
-  ((View *) this->client)->superview->hidden = type->arg != VOTE_ARG_CLIENT;
-  ((View *) this->value)->superview->hidden = type->arg != VOTE_ARG_INTEGER;
+  $(((View *) this->map)->superview, setHidden, type->arg != VOTE_ARG_MAP);
+  $(((View *) this->client)->superview, setHidden, type->arg != VOTE_ARG_CLIENT);
+  $(((View *) this->value)->superview, setHidden, type->arg != VOTE_ARG_INTEGER);
 
   if (type->arg == VOTE_ARG_INTEGER) {
     this->value->min = type->min;
@@ -138,8 +138,8 @@ static void refreshStatus(VoteViewController *this) {
     $(this->status->text, setText, "No vote is in progress");
   }
 
-  this->yes->control.view.hidden = !active;
-  this->no->control.view.hidden = !active;
+  $((View *) this->yes, setHidden, !active);
+  $((View *) this->no, setHidden, !active);
 }
 
 #pragma mark - ViewController

--- a/src/client/cl_server.c
+++ b/src/client/cl_server.c
@@ -69,7 +69,7 @@ void Cl_FreeServers(void) {
 }
 
 /**
- * @brief Drops any other known entry that is `server` reached a different way.
+ * @brief Drops any other known entry for the same server reached a different way.
  * @details A server broadcasting on the LAN and also listed by the master
  * answers under two different addresses, so it shows twice. `Cl_ServerForNetaddr`
  * already merges entries that share one address; this catches what that

--- a/src/client/cl_server.c
+++ b/src/client/cl_server.c
@@ -69,6 +69,36 @@ void Cl_FreeServers(void) {
 }
 
 /**
+ * @brief Drops any other known entry that is `server` reached a different way.
+ * @details A server broadcasting on the LAN and also listed by the master
+ * answers under two different addresses, so it shows twice. `Cl_ServerForNetaddr`
+ * already merges entries that share one address; this catches what that
+ * cannot - the same hostname, map and occupancy reported under two. `server`
+ * itself is never dropped: it is the one that just proved it is reachable and
+ * answering right now, so any duplicate loses to it rather than the reverse.
+ */
+static void Cl_MergeDuplicateServers(const cl_server_info_t *server) {
+
+  for (size_t i = 0; i < (cls.servers ? cls.servers->count : 0); i++) {
+    const cl_server_info_t *other = (cl_server_info_t *) $(cls.servers, get, i);
+
+    if (other == server || Net_CompareNetaddr(&other->addr, &server->addr)) {
+      continue;
+    }
+
+    if (!server->hostname[0] || q_strcmp(other->hostname, server->hostname) ||
+        q_strcmp(other->name, server->name) ||
+        other->max_clients != server->max_clients ||
+        other->clients != server->clients) {
+      continue;
+    }
+
+    $(cls.servers, removeAt, i);
+    break;
+  }
+}
+
+/**
  * @brief Parses a server status response and updates or creates the matching server entry.
  */
 void Cl_ParseServerInfo(void) {
@@ -143,6 +173,8 @@ void Cl_ParseServerInfo(void) {
     Com_Debug(DEBUG_CLIENT, "Status from %s: \"%s\" map %s, gameplay %s, %d/%d clients (%d bots), %dms\n",
               Net_NetaddrToString(&net_from), server->hostname, server->name, server->gameplay,
               server->clients, server->max_clients, server->bots, server->ping);
+
+    Cl_MergeDuplicateServers(server);
 
   } else {
     server->hostname[0] = '\0';

--- a/src/client/cl_server.c
+++ b/src/client/cl_server.c
@@ -131,17 +131,21 @@ void Cl_ParseServerInfo(void) {
   char hostname[sizeof(server->hostname)];
   char name[sizeof(server->name)];
   char gameplay[sizeof(server->gameplay)];
+  char movement[sizeof(server->movement)];
 
   q_strlcpy(hostname, InfoString_Get(string, "sv_hostname"), sizeof(hostname));
   q_strlcpy(name, InfoString_Get(string, "sv_map"), sizeof(name));
   const char *mode = InfoString_Get(string, "g_gameplay_mode");
   q_strlcpy(gameplay, *mode ? mode : InfoString_Get(string, "g_gameplay"), sizeof(gameplay));
+  const char *move = InfoString_Get(string, "g_movement_mode");
+  q_strlcpy(movement, *move ? move : InfoString_Get(string, "g_movement"), sizeof(movement));
   const int32_t max_clients = atoi(InfoString_Get(string, "sv_max_clients"));
 
   if (hostname[0] && name[0]) {
     q_strlcpy(server->hostname, hostname, sizeof(server->hostname));
     q_strlcpy(server->name, name, sizeof(server->name));
     q_strlcpy(server->gameplay, gameplay, sizeof(server->gameplay));
+    q_strlcpy(server->movement, movement, sizeof(server->movement));
     server->max_clients = max_clients;
 
     server->clients = 0;
@@ -180,6 +184,7 @@ void Cl_ParseServerInfo(void) {
     server->hostname[0] = '\0';
     server->name[0] = '\0';
     server->gameplay[0] = '\0';
+    server->movement[0] = '\0';
 
     server->clients = 0;
     server->max_clients = 0;

--- a/src/client/cl_types.h
+++ b/src/client/cl_types.h
@@ -623,6 +623,11 @@ typedef struct {
   char gameplay[32];
 
   /**
+   * @brief The movement name.
+   */
+  char movement[32];
+
+  /**
    * @brief Error string if the server could not be queried.
    */
   char error[128];

--- a/src/common/cvar.c
+++ b/src/common/cvar.c
@@ -699,9 +699,7 @@ char *Cvar_UserInfo(void) {
 static void Cvar_ServerInfo_enumerate(cvar_t *var, void *data) {
 
   if (var->flags & CVAR_SERVER_INFO) {
-    char value[MAX_INFO_STRING_VALUE];
-    q_strcolorstrip(var->string, value);
-    InfoString_Set((char *) data, var->name, value);
+    InfoString_Set((char *) data, var->name, var->string);
   }
 }
 


### PR DESCRIPTION
## Summary
- **Two-pane Join Server**: the known servers in one pane; the selected one's hostname, address, source, map, gameplay, movement, occupancy, ping and mapshot in the other. Selection is held by hostname so it survives a re-sort and a refresh; an empty state stands in for an empty table; a server that never answered renders unset and sorts last rather than posing as a 999 ms one; the quick-join max ping slider doubles as the ping column's colour threshold. Harvested from the race-mod fork's design (#963 step 10), rebuilt on common's idioms - no manual geometry, the panes size themselves under ObjectivelyMVC's reworked layout. The fork's roster table is not carried over: the status protocol has no per-player data to fill it.
- **Client-side server dedup**: a server broadcasting on the LAN and also listed by the master no longer shows twice; merged in `Cl_ParseServerInfo` as status responses arrive, rather than in the UI.
- **Movement on the wire, captured**: `g_movement_mode` is already `CVAR_SERVER_INFO`; the client now reads it alongside gameplay.
- **`setHidden` adoption**: all direct `View::hidden` writes in cgame now go through `View::setHidden`, so containers re-flow around visibility changes.
- **Main menu dialog singletons**: repeated Quit/Disconnect clicks no longer stack confirmation dialogs, and the reference `addChildViewController` retains is now released.

## Merge ordering
⚠️ Hold until ObjectivelyMVC jdolan/ObjectivelyMVC#48 merges: fixing the dialog reference leak here exposes a use-after-free in MVC's event dispatch (a Control freed by its own delegate mid-dispatch). CI is unaffected - it is a runtime crash on dismissing the Quit dialog.

## Test plan
- [x] Client + all four cgame modules build clean
- [x] Eyeballed in play (Jay): two panes, details populate on selection, mapshot and Movement row shown, dedup verified against a LAN+master server
- [x] Quit dialog dismissal, after ObjectivelyMVC#48

Part of #963 step 10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)