### PR TITLE
Build macOS for Apple Silicon only, in one job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,6 +61,8 @@ jobs:
         cmake --build openal-soft/build -j$(nproc)
         sudo cmake --install openal-soft/build
 
+    # Held at 3.4.12 in step with the macOS pin, so that a release bisects to
+    # the same SDL3 on every platform. See #945.
     - name: Build SDL3
       run: |
         git clone --depth 1 --branch release-3.4.12 https://github.com/libsdl-org/SDL.git SDL3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,10 @@ jobs:
           openal-soft libsndfile physfs \
           curl dylibbundler
 
+    # 3.4.14 regressed SDL_gpu on macOS and the fix is not due until 3.4.18,
+    # so the core library is held at 3.4.12. Homebrew's formula is newer, so
+    # this must run after brew to supersede it. SDL3_image and SDL3_ttf do not
+    # touch SDL_gpu and are left to brew. See #945.
     - name: Pin SDL3
       run: |
         git clone --depth 1 --branch release-3.4.12 https://github.com/libsdl-org/SDL.git SDL3
@@ -269,6 +273,8 @@ jobs:
         cmake --build openal-soft/build -j$(nproc)
         sudo cmake --install openal-soft/build
 
+    # Held at 3.4.12 in step with the macOS pin, so that a release bisects to
+    # the same SDL3 on every platform. See #945.
     - name: Build SDL3
       run: |
         git clone --depth 1 --branch release-3.4.12 https://github.com/libsdl-org/SDL.git SDL3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,21 +29,10 @@ jobs:
 
   build-macos:
     needs: resolve-deps
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - runner: macos-15
-            arch: arm64
-            build: arm64-apple-darwin
-          - runner: macos-15-large
-            arch: x86_64
-            build: x86_64-apple-darwin
-
-    runs-on: ${{ matrix.runner }}
+    runs-on: macos-15
 
     env:
-      HOMEBREW_PREFIX: ${{ matrix.arch == 'arm64' && '/opt/homebrew' || '/usr/local' }}
+      HOMEBREW_PREFIX: /opt/homebrew
 
     steps:
     - name: Install dependencies
@@ -68,7 +57,7 @@ jobs:
       uses: actions/cache@v5
       with:
         path: /usr/local
-        key: macos-deps-${{ matrix.arch }}-sdl3.4.12-${{ needs.resolve-deps.outputs.objectively-sha }}-${{ needs.resolve-deps.outputs.objectivelygpu-sha }}-${{ needs.resolve-deps.outputs.objectivelymvc-sha }}
+        key: macos-deps-arm64-sdl3.4.12-${{ needs.resolve-deps.outputs.objectively-sha }}-${{ needs.resolve-deps.outputs.objectivelygpu-sha }}-${{ needs.resolve-deps.outputs.objectivelymvc-sha }}
 
     - name: Checkout Objectively
       if: steps.cache-deps.outputs.cache-hit != 'true'
@@ -154,55 +143,6 @@ jobs:
       working-directory: quetoo
       run: make -C apple move-resources
 
-    - name: Create archive
-      working-directory: quetoo
-      run: |
-        cd apple/target
-        zip -r ../../quetoo-${{ matrix.build }}.zip Quetoo.app
-
-    - name: Upload artifact
-      uses: actions/upload-artifact@v7
-      with:
-        name: quetoo-${{ matrix.build }}
-        path: quetoo/quetoo-${{ matrix.build }}.zip
-
-  lipo-macos:
-    needs: build-macos
-    runs-on: macos-15
-
-    steps:
-    - name: Download arm64 artifact
-      uses: actions/download-artifact@v8
-      with:
-        name: quetoo-arm64-apple-darwin
-
-    - name: Download x86_64 artifact
-      uses: actions/download-artifact@v8
-      with:
-        name: quetoo-x86_64-apple-darwin
-
-    - name: Create universal binary
-      run: |
-        mkdir arm64 x86_64
-        unzip quetoo-arm64-apple-darwin.zip -d arm64
-        unzip quetoo-x86_64-apple-darwin.zip -d x86_64
-
-        find arm64/Quetoo.app -type f | while read -r f; do
-          if ! file "$f" | grep -q "Mach-O"; then
-            continue
-          fi
-          x86="x86_64/${f#arm64/}"
-          if [ -f "$x86" ]; then
-            lipo -create "$f" "$x86" -output "$f"
-          fi
-        done
-
-    - name: Checkout Quetoo
-      uses: actions/checkout@v6
-      with:
-        path: quetoo
-        fetch-depth: 1
-
     - name: Set up keychain
       env:
         APPLE_CERTIFICATE_P12: ${{ secrets.APPLE_CERTIFICATE_P12 }}
@@ -219,19 +159,23 @@ jobs:
         rm certificate.p12
 
     - name: Sign application
-      run: make -C quetoo/apple sign INSTALL=$(pwd)/arm64/Quetoo.app
+      run: |
+        # codesign refuses a bundle carrying extended attributes, and the build
+        # tree keeps the ones the old unzip round trip discarded
+        xattr -cr quetoo/apple/target/Quetoo.app
+        make -C quetoo/apple sign
 
     - name: Create binary DMG
-      run: make -C quetoo/apple dmg INSTALL=$(pwd)/arm64/Quetoo.app \
-             SNAPSHOT=$(pwd)/quetoo-universal-apple-darwin.dmg
+      run: make -C quetoo/apple dmg \
+             SNAPSHOT=$(pwd)/quetoo-arm64-apple-darwin.dmg
 
     - name: Notarize binary DMG
       env:
         APPLE_ID: ${{ secrets.APPLE_ID }}
         APPLE_APP_PASSWORD: ${{ secrets.APPLE_APP_PASSWORD }}
         APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-      run: make -C quetoo/apple notarize INSTALL=$(pwd)/arm64/Quetoo.app \
-             SNAPSHOT=$(pwd)/quetoo-universal-apple-darwin.dmg
+      run: make -C quetoo/apple notarize \
+             SNAPSHOT=$(pwd)/quetoo-arm64-apple-darwin.dmg
 
     - name: Checkout quetoo-data
       uses: actions/checkout@v6
@@ -242,41 +186,41 @@ jobs:
         sparse-checkout: target
 
     - name: Bundle game data
-      run: make -C quetoo/apple bundle-data INSTALL=$(pwd)/arm64/Quetoo.app \
+      run: make -C quetoo/apple bundle-data \
              QUETOO_DATA_DIR=$(pwd)/quetoo-data
 
     - name: Re-sign bundle
       run: |
         security unlock-keychain -p "$KEYCHAIN_PASSWORD" build.keychain
-        make -C quetoo/apple bundle-sign INSTALL=$(pwd)/arm64/Quetoo.app
+        make -C quetoo/apple bundle-sign
 
     - name: Create bundle DMG
-      run: make -C quetoo/apple bundle-dmg INSTALL=$(pwd)/arm64/Quetoo.app \
-             BUNDLE_SNAPSHOT=$(pwd)/quetoo-bundle-universal-apple-darwin.dmg
+      run: make -C quetoo/apple bundle-dmg \
+             BUNDLE_SNAPSHOT=$(pwd)/quetoo-bundle-arm64-apple-darwin.dmg
 
     - name: Notarize bundle DMG
       env:
         APPLE_ID: ${{ secrets.APPLE_ID }}
         APPLE_APP_PASSWORD: ${{ secrets.APPLE_APP_PASSWORD }}
         APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-      run: make -C quetoo/apple bundle-notarize INSTALL=$(pwd)/arm64/Quetoo.app \
-             BUNDLE_SNAPSHOT=$(pwd)/quetoo-bundle-universal-apple-darwin.dmg
+      run: make -C quetoo/apple bundle-notarize \
+             BUNDLE_SNAPSHOT=$(pwd)/quetoo-bundle-arm64-apple-darwin.dmg
 
     - name: Tear down keychain
       if: always()
-      run: security delete-keychain build.keychain
+      run: security delete-keychain build.keychain || true
 
     - name: Upload binary DMG artifact
       uses: actions/upload-artifact@v7
       with:
-        name: quetoo-universal-apple-darwin
-        path: quetoo-universal-apple-darwin.dmg
+        name: quetoo-arm64-apple-darwin
+        path: quetoo-arm64-apple-darwin.dmg
 
     - name: Upload bundle artifact
       uses: actions/upload-artifact@v7
       with:
-        name: quetoo-bundle-universal-apple-darwin
-        path: quetoo-bundle-universal-apple-darwin.dmg
+        name: quetoo-bundle-arm64-apple-darwin
+        path: quetoo-bundle-arm64-apple-darwin.dmg
 
   build-linux:
     needs: resolve-deps
@@ -567,7 +511,7 @@ jobs:
         path: quetoo/quetoo-x86_64-pc-windows.zip
 
   release:
-    needs: [lipo-macos, build-linux, build-windows]
+    needs: [build-macos, build-linux, build-windows]
     runs-on: ubuntu-latest
 
     steps:
@@ -667,10 +611,10 @@ jobs:
 
         ## ![macOS](https://img.shields.io/badge/-%20-A2AAAD?style=flat-square&logo=apple&logoColor=white) macOS
 
-        | Type | Link |
+        | Type | Apple Silicon |
         |---|---|
-        | Full Install | [quetoo-bundle-universal-apple-darwin.dmg](https://github.com/${{ github.repository }}/releases/download/$VERSION/quetoo-bundle-universal-apple-darwin.dmg) |
-        | Binaries Only | [quetoo-universal-apple-darwin.dmg](https://github.com/${{ github.repository }}/releases/download/$VERSION/quetoo-universal-apple-darwin.dmg) |
+        | Full Install | [quetoo-bundle-arm64-apple-darwin.dmg](https://github.com/${{ github.repository }}/releases/download/$VERSION/quetoo-bundle-arm64-apple-darwin.dmg) |
+        | Binaries Only | [quetoo-arm64-apple-darwin.dmg](https://github.com/${{ github.repository }}/releases/download/$VERSION/quetoo-arm64-apple-darwin.dmg) |
 
         ## ![Linux](https://img.shields.io/badge/-%20-FCC624?style=flat-square&logo=linux&logoColor=black) Linux
 
@@ -695,11 +639,11 @@ jobs:
         )
 
         assets=(
-          quetoo-bundle-universal-apple-darwin/quetoo-bundle-universal-apple-darwin.dmg
+          quetoo-bundle-arm64-apple-darwin/quetoo-bundle-arm64-apple-darwin.dmg
           quetoo-bundle-x86_64-pc-linux.tar.gz
           quetoo-bundle-aarch64-pc-linux.tar.gz
           quetoo-bundle-x86_64-pc-windows.zip
-          quetoo-universal-apple-darwin/quetoo-universal-apple-darwin.dmg
+          quetoo-arm64-apple-darwin/quetoo-arm64-apple-darwin.dmg
           quetoo-x86_64-pc-linux-archive/quetoo-x86_64-pc-linux.tar.gz
           quetoo-x86_64-pc-linux-deb/quetoo-client-x86_64-pc-linux.deb
           quetoo-x86_64-pc-linux-deb/quetoo-server-x86_64-pc-linux.deb
@@ -728,7 +672,7 @@ jobs:
     - name: Download macOS bundle
       uses: actions/download-artifact@v8
       with:
-        name: quetoo-bundle-universal-apple-darwin
+        name: quetoo-bundle-arm64-apple-darwin
         path: itch/mac
 
     - name: Download Linux x86_64 bundle
@@ -755,6 +699,6 @@ jobs:
         BUTLER_API_KEY: ${{ secrets.BUTLER_API_KEY }}
         VERSION: ${{ github.event.inputs.version || github.ref_name }}
       run: |
-        ./butler push itch/mac/quetoo-bundle-universal-apple-darwin.dmg    wickedoldgames/quetoo:mac     --userversion $VERSION
+        ./butler push itch/mac/quetoo-bundle-arm64-apple-darwin.dmg        wickedoldgames/quetoo:mac     --userversion $VERSION
         ./butler push itch/linux/quetoo-bundle-x86_64-pc-linux.tar.gz      wickedoldgames/quetoo:linux   --userversion $VERSION
         ./butler push itch/windows/quetoo-bundle-x86_64-pc-windows.zip     wickedoldgames/quetoo:windows --userversion $VERSION


### PR DESCRIPTION
Retires the Intel macOS build and folds the two macOS jobs into one.

### Why now

This is what broke the v1.0.86 release. Homebrew dropped Intel x86_64 support in September 2026 and says so in that run's own log. With no bottles left, installing `curl` had to rebuild `openssl@3` from source, its post-install step failed, and Homebrew reports a failed post-install as a non-zero exit, which killed the step under `bash -e`. Every package the build needed had actually installed. The prior release fifteen hours earlier passed with an identical workflow file, and nothing in the repo had changed.

It will keep failing. Apple dropped Intel in macOS 27, Homebrew has dropped it, and GitHub retires the runners in 2027.

### What changed

With one architecture there is nothing to `lipo`, so the second job folds into the first. That job was named for the `lipo`, but `lipo` was one step out of a dozen; the signing, notarizing, data bundling and re-signing all survive, now on a single runner with no artifact round trip.

Release assets are renamed for what they are:

| Before | After |
|---|---|
| `quetoo-universal-apple-darwin.dmg` | `quetoo-arm64-apple-darwin.dmg` |
| `quetoo-bundle-universal-apple-darwin.dmg` | `quetoo-bundle-arm64-apple-darwin.dmg` |

The release notes, the asset upload and the itch push follow, and the notes table now names Apple Silicon so nobody downloads it expecting Intel. Nothing in the engine referenced the old names; the in-game updater only fetches game data.

Signing now runs against the build tree rather than an unzipped artifact, which incidentally stops it signing a zip's lossy view of the bundle. `xattr -cr` runs first, because the unzip used to discard extended attributes that `codesign` rejects.

The Intel path is not kept in the tree. It is recoverable from this commit if it is ever wanted.

### Worth knowing

`configure.ac` sets `host_cpu` to `arm64` unconditionally on Apple, so the retired Intel leg was already stamping its own build string `arm64-apple-darwin`. That build was partly broken before this change.

### One trade-off

The old split meant a notarization flake could be retried by re-running just the second job, reusing the uploaded bundle. Now a notary hiccup discards the whole job. The dependency cache absorbs most of a re-run, but not the pinned SDL3 build. Easy to split back out if it proves annoying in practice.

### Not addressed here

- Existing Intel installs still poll the S3 build number, so they will report an update forever with no Intel DMG to fetch. The updater only downloads game data, so nothing breaks, but the nag is permanent.
- The dependency cache key names the pinned SDL3 version while SDL3 installs outside the cached path, so bumping SDL needlessly invalidates the cache and the from-source SDL3 build is never cached. Pre-existing, and worth its own change given it is pure cost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)