### PR TITLE
Refactor HUD visibility management and menu tab sizing

### DIFF
--- a/Quetoo.xcodeproj/xcshareddata/xcschemes/quetoo-all.xcscheme
+++ b/Quetoo.xcodeproj/xcshareddata/xcschemes/quetoo-all.xcscheme
@@ -150,7 +150,7 @@
          </CommandLineArgument>
          <CommandLineArgument
             argument = "+map edge"
-            isEnabled = "YES">
+            isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
             argument = "+set sv_map_list maps-jdolan.lst"

--- a/configure.ac
+++ b/configure.ac
@@ -177,7 +177,7 @@ dnl ------------------------
 dnl Check for ObjectivelyMVC
 dnl ------------------------
 
-PKG_CHECK_MODULES([OBJECTIVELYMVC], [ObjectivelyMVC >= 2.4.7])
+PKG_CHECK_MODULES([OBJECTIVELYMVC], [ObjectivelyMVC >= 2.5.0])
 
 dnl ------------------------------------------------
 dnl Check for offline shader cross-compilation tools

--- a/src/cgame/cgame.h
+++ b/src/cgame/cgame.h
@@ -37,7 +37,7 @@
 #include <Objectively/RESTClient.h>
 #include <Objectively/Vector.h>
 
-#define CGAME_API_VERSION 44
+#define CGAME_API_VERSION 45
 
 /**
  * @brief The client game import struct imports engine functionailty to the client game.
@@ -182,6 +182,14 @@ typedef struct cg_import_s {
    */
 
   /**
+   * @brief Stat the given filename.
+   * @param path The file path (e.g. `"maps/torn.bsp"`).
+   * @param out The return value. Pass @c NULL to simply check if the file exists.
+   * @return True if the @c stat was successful, false otherwise.
+   */
+  bool (*StatFile)(const char *path, fs_stat_t *out);
+
+  /**
    * @brief Opens the specified file for reading.
    * @param path The file path (e.g. `"maps/torn.bsp"`).
    */
@@ -249,12 +257,6 @@ typedef struct cg_import_s {
    * @param data User data.
    */
   void (*EnumerateFiles)(const char *pattern, Fs_Enumerator enumerator, void *data);
-
-  /**
-   * @brief Check if a file exists or not.
-   * @return True if the specified filename exists on the search path.
-   */
-  bool (*FileExists)(const char *path);
 
   /**
    * @}

--- a/src/cgame/common/cg_client.c
+++ b/src/cgame/common/cg_client.c
@@ -376,7 +376,7 @@ static void Cg_PreloadClientModel(const char *path, void *data) {
   name++;
 
   // Only preload actual player model directories (must have upper.md3)
-  if (!cgi.FileExists(va("%s/upper.md3", path))) {
+  if (!cgi.StatFile(va("%s/upper.md3", path), NULL)) {
     return;
   }
 

--- a/src/cgame/common/cg_ctf.c
+++ b/src/cgame/common/cg_ctf.c
@@ -63,7 +63,7 @@ static void updateBindings(View *self, ident data) {
     }
   }
 
-  $(self, setHidden, flag == ITEM_NONE);
+  $(self, setVisibility, flag == ITEM_NONE ? ViewVisibilityHidden : ViewVisibilityVisible);
 
   if (flag == ITEM_NONE) {
     return;

--- a/src/cgame/common/ui/CvarSelect.c
+++ b/src/cgame/common/ui/CvarSelect.c
@@ -77,51 +77,35 @@ static void updateBindings(View *self, ident data) {
 #pragma mark - Select
 
 /**
- * @see Select::selectOptionWithValue(Select *, ident)
+ * @see Select::selectOption(Select *, Option *)
+ * @remarks The variable is written here, rather than from a SelectDelegate, because the
+ * delegate is the consumer's: a controller that wants to be told of a selection would
+ * otherwise replace the only thing that stores it.
  */
-static void selectOptionWithValue(Select *self, ident value) {
+static void selectOption(Select *self, Option *option) {
+
+  super(Select, self, selectOption, option);
 
   const CvarSelect *this = (CvarSelect *) self;
-  if (this->var) {
 
-    Option *option = $(self, optionWithValue, value);
-    if (option) {
+  if (option) {
+    if (this->var) {
       if (this->expectsStringValue) {
-        const char *string = option->value ?: option->title->text;
-        cgi.SetCvarString(this->var->name, string);
+        cgi.SetCvarString(this->var->name, option->value ?: option->title->text);
+      } else if (this->expectsFloatValue) {
+        cgi.SetCvarValue(this->var->name, (float) (intptr_t) option->value);
       } else {
         cgi.SetCvarInteger(this->var->name, (int32_t) (intptr_t) option->value);
       }
+    } else {
+      String *desc = $((Object *) this, description);
+      Cg_Warn("%s: null cvar\n", desc->chars);
+      release(desc);
     }
   }
-
-  super(Select, self, selectOptionWithValue, value);
 }
 
 #pragma mark - CvarSelect
-
-/**
- * @brief Default SelectDelegate for CvarSelect.
- */
-static void didSelectOption(Select *select, Option *option) {
-
-  CvarSelect *this = (CvarSelect *) select;
-
-  if (this->var) {
-    if (this->expectsStringValue) {
-      const char *string = option->value ?: option->title->text;
-      cgi.SetCvarString(this->var->name, string);
-    } else if (this->expectsFloatValue) {
-      cgi.SetCvarValue(this->var->name, (float) (intptr_t) option->value);
-    } else {
-      cgi.SetCvarInteger(this->var->name, (int32_t) (intptr_t) option->value);
-    }
-  } else {
-    String *desc = $((Object *) this, description);
-    Cg_Warn("%s: null cvar\n", desc->chars);
-    release(desc);
-  }
-}
 
 /**
  * @fn CvarSelect *CvarSelect::initWithVariable(CvarSelect *self, cvar_t *var)
@@ -133,9 +117,6 @@ static CvarSelect *initWithVariable(CvarSelect *self, cvar_t *var) {
   self = (CvarSelect *) super(Select, self, initWithFrame, NULL);
   if (self) {
     self->var = var;
-
-    self->select.delegate.self = self;
-    self->select.delegate.didSelectOption = didSelectOption;
   }
 
   return self;
@@ -161,7 +142,7 @@ static void initialize(Class *clazz) {
   ((ViewInterface *) clazz->interface)->init = init;
   ((ViewInterface *) clazz->interface)->updateBindings = updateBindings;
 
-  ((SelectInterface *) clazz->interface)->selectOptionWithValue = selectOptionWithValue;
+  ((SelectInterface *) clazz->interface)->selectOption = selectOption;
 
   ((CvarSelectInterface *) clazz->interface)->initWithVariable = initWithVariable;
   ((CvarSelectInterface *) clazz->interface)->initWithVariableName = initWithVariableName;

--- a/src/cgame/common/ui/DialogViewController.css
+++ b/src/cgame/common/ui/DialogViewController.css
@@ -18,5 +18,5 @@
 }
 
 #dialog > Panel .accessoryView {
-  hidden: false;
+  visibility: visible;
 }

--- a/src/cgame/common/ui/common.css
+++ b/src/cgame/common/ui/common.css
@@ -43,15 +43,11 @@ Panel > .resizeHandle {
   border-radius: 12;
 }
 
-/*
- * A tab page is a ViewController's root View, which is `fill`, and a `fill` child measures as
- * nothing to a `contain` parent -- so the page view is given the size the pages fill.
- */
+/* Every menu takes the same width, whatever the widest thing on its page is */
 
 Panel.menu .tabPageView {
   autoresizing-mask: contain;
   min-width: 1440;
-  min-height: 720;
 }
 
 Select {

--- a/src/cgame/common/ui/common.css
+++ b/src/cgame/common/ui/common.css
@@ -45,8 +45,7 @@ Panel > .resizeHandle {
 
 Panel.menu .tabPageView {
   autoresizing-mask: contain;
-  width: 1440;
-  /*height: 720;*/
+  min-width: 1440;
 }
 
 Select {
@@ -111,14 +110,12 @@ TextView {
 
 .columns > .column {
   autoresizing-mask: contain;
-  width: 460;
   min-width: 460;
   max-width: 460;
 }
 
 .columns > .column-2 {
   autoresizing-mask: contain;
-  width: 920;
   min-width: 920;
   max-width: 920;
 }
@@ -126,4 +123,122 @@ TextView {
 .column Box,
 .column-2 Box {
   autoresizing-mask: contain | width;
+}
+
+/*
+ * The defaults the view classes used to assign in C. A styled property is owned by the
+ * cascade, so a class that needs one arranged a certain way declares it here, at the lowest
+ * specificity it can, and leaves a HUD variant or a controller stylesheet free to override.
+ */
+
+ChatView {
+  autoresizing-mask: contain;
+  axis: vertical;
+}
+
+CrosshairView {
+  autoresizing-mask: contain;
+}
+
+DiagnosticsView {
+  autoresizing-mask: contain;
+}
+
+MapListCollectionItemView Text {
+  alignment: bottom-center;
+}
+
+NavEditView {
+  autoresizing-mask: contain;
+}
+
+PickupView {
+  axis: horizontal;
+}
+
+PowerupView {
+  axis: horizontal;
+  spacing: 32;
+}
+
+PickupView > Text {
+  alignment: middle;
+}
+
+StatView {
+  axis: horizontal;
+  spacing: 5;
+}
+
+StatView > .labels {
+  axis: vertical;
+}
+
+WeaponBarView {
+  axis: vertical;
+}
+
+WeaponBarView > StackView {
+  autoresizing-mask: contain;
+  axis: horizontal;
+  spacing: 4;
+}
+
+WeaponBarView .slot {
+  autoresizing-mask: contain;
+}
+
+/*
+ * The HUD and the scoreboard fill the window, and a variant that ships only a stylesheet of
+ * its own still gets that; #hud is the root identifier every variant's JSON must use.
+ */
+
+#hud {
+  autoresizing-mask: fill;
+}
+
+BlendView > ImageView {
+  autoresizing-mask: fill;
+}
+
+ScoreboardView {
+  autoresizing-mask: fill;
+}
+
+ScoreboardView > .header {
+  axis: horizontal;
+}
+
+ScoreboardView > .columns {
+  axis: horizontal;
+}
+
+ScoreboardView .column {
+  axis: vertical;
+}
+
+ScoreboardView .fields .caption {
+  alignment: middle-right;
+}
+
+ScoreView > .fill {
+  alignment: internal;
+}
+
+ScoreView > .ping {
+  alignment: top-right;
+}
+
+ScoreView > .aside {
+  alignment: right;
+}
+
+/* A row laid out as fields is a table row: the values and the ping line up on their centres */
+
+ScoreView.fields .field {
+  alignment: middle-right;
+}
+
+ScoreView.fields > .ping {
+  alignment: middle-right;
 }

--- a/src/cgame/common/ui/common.css
+++ b/src/cgame/common/ui/common.css
@@ -43,9 +43,15 @@ Panel > .resizeHandle {
   border-radius: 12;
 }
 
+/*
+ * A tab page is a ViewController's root View, which is `fill`, and a `fill` child measures as
+ * nothing to a `contain` parent -- so the page view is given the size the pages fill.
+ */
+
 Panel.menu .tabPageView {
   autoresizing-mask: contain;
   min-width: 1440;
+  min-height: 720;
 }
 
 Select {

--- a/src/cgame/common/ui/controls/ResponseServiceViewController.c
+++ b/src/cgame/common/ui/controls/ResponseServiceViewController.c
@@ -28,7 +28,7 @@
 #pragma mark - Crosshair selection
 
 /**
- * @brief Fs_Enumerator for crosshair selection.
+ * @brief @c Fs_Enumerator for crosshair selection.
  */
 static void enumerateCrosshairs(const char *path, void *data) {
   char name[MAX_QPATH];
@@ -53,7 +53,7 @@ static Order sortAlphabetical(const ident a, const ident b) {
 }
 
 /**
- * @brief SelectDelegate callback for crosshair selection.
+ * @brief @c SelectDelegate callback for crosshair selection.
  */
 static void didSelectCrosshair(Select *select, Option *option) {
 
@@ -64,7 +64,7 @@ static void didSelectCrosshair(Select *select, Option *option) {
 }
 
 /**
- * @brief HueColorPickerDelegate callback for crosshair color selection.
+ * @brief @c HueColorPickerDelegate callback for crosshair color selection.
  */
 static void didPickCrosshairColor(HueColorPicker *hueColorPicker, double hue, double saturation, double value) {
 
@@ -85,7 +85,7 @@ static void didPickCrosshairColor(HueColorPicker *hueColorPicker, double hue, do
 }
 
 /**
- * @brief SliderDelegate callback for crosshair scale.
+ * @brief @c SliderDelegate callback for crosshair scale.
  */
 static void didSetCrosshairScale(Slider *slider, double value) {
 
@@ -95,7 +95,7 @@ static void didSetCrosshairScale(Slider *slider, double value) {
 }
 
 /**
- * @brief SliderDelegate callback for crosshair opcaity.
+ * @brief @c SliderDelegate callback for crosshair opcaity.
  */
 static void didSetCrosshairAlpha(Slider *slider, double value) {
 
@@ -105,7 +105,7 @@ static void didSetCrosshairAlpha(Slider *slider, double value) {
 }
 
 /**
- * @brief SelectDelegate callback for crosshair health style.
+ * @brief @c SelectDelegate callback for crosshair health style.
  */
 static void didSelectCrosshairHealth(Select *select, Option *option) {
 
@@ -115,7 +115,7 @@ static void didSelectCrosshairHealth(Select *select, Option *option) {
 }
 
 /**
- * @brief TextViewDelegate callback for binding keys.
+ * @brief @c TextViewDelegate callback for binding keys.
  */
 static void didBindKey(TextView *textView) {
 
@@ -125,7 +125,7 @@ static void didBindKey(TextView *textView) {
 }
 
 /**
- * @brief ViewEnumerator for setting the TextViewDelegate.
+ * @brief @c ViewEnumerator for setting the TextViewDelegate.
  */
 static void setDelegate(View *view, ident data) {
 
@@ -133,6 +133,32 @@ static void setDelegate(View *view, ident data) {
     .self = data,
     .didEndEditing = didBindKey
   };
+}
+
+/**
+ * @brief @c Fs_Enumerator for HUD selection.
+ */
+static void enumerateHuds(const char *path, void *data) {
+
+  Select *select = data;
+
+  fs_stat_t stat;
+  if (cgi.StatFile(path, &stat)) {
+
+    if (stat.type == FS_DIRECTORY) {
+
+      const char *name = Basename(path);
+
+      for (size_t i = 0; i < select->options->count; i++) {
+        Option *option = $(select->options, objectAtIndex, i);
+        if (!q_strcmp(option->title->text, name)) {
+          return;
+        }
+      }
+
+      $(select, addOption, name, NULL);
+    }
+  }
 }
 
 #pragma mark - ViewController
@@ -152,12 +178,13 @@ static void loadView(ViewController *self) {
   Slider *crosshairAlpha;
 
   Outlet outlets[] = MakeOutlets(
-    MakeOutlet("crosshair", &this->crosshair),
+    MakeOutlet("crosshairSelect", &this->crosshair),
     MakeOutlet("crosshairColor", &this->crosshairColorPicker),
     MakeOutlet("crosshairAlpha", &crosshairAlpha),
     MakeOutlet("crosshairScale", &crosshairScale),
     MakeOutlet("crosshairHealth", &this->crosshairHealth),
-    MakeOutlet("crosshairView", &this->crosshairView)
+    MakeOutlet("crosshairView", &this->crosshairView),
+    MakeOutlet("hudSelect", &this->hud)
   );
 
   $(self->view, resolve, outlets);
@@ -169,7 +196,7 @@ static void loadView(ViewController *self) {
 
   this->crosshair->comparator = sortAlphabetical;
 
-  $(this->crosshair, addOption, "", (ident) 0);
+  $(this->crosshair, addOption, "None", (ident) 0);
   cgi.EnumerateFiles("pics/ch*", enumerateCrosshairs, this->crosshair);
 
   this->crosshair->delegate.self = this;
@@ -194,6 +221,9 @@ static void loadView(ViewController *self) {
 
   this->crosshairColorPicker->delegate.self = this;
   this->crosshairColorPicker->delegate.didPickColor = didPickCrosshairColor;
+
+  this->hud->comparator = sortAlphabetical;
+  cgi.EnumerateFiles("ui/hud/*", enumerateHuds, this->hud);
 }
 
 /**

--- a/src/cgame/common/ui/controls/ResponseServiceViewController.c
+++ b/src/cgame/common/ui/controls/ResponseServiceViewController.c
@@ -96,7 +96,7 @@ static void didSetCrosshairScale(Slider *slider, double value) {
 }
 
 /**
- * @brief @c SliderDelegate callback for crosshair opcaity.
+ * @brief @c SliderDelegate callback for crosshair opacity.
  */
 static void didSetCrosshairAlpha(Slider *slider, double value) {
 

--- a/src/cgame/common/ui/controls/ResponseServiceViewController.c
+++ b/src/cgame/common/ui/controls/ResponseServiceViewController.c
@@ -73,7 +73,8 @@ static void didPickCrosshairColor(HueColorPicker *hueColorPicker, double hue, do
   if (hue < 1.0) {
     cgi.SetCvarString(cg_draw_crosshair_color->name, "default");
 
-    hueColorPicker->colorView->backgroundColor = Colors.Charcoal;
+    $(hueColorPicker->colorView->style, addColorAttribute, "background-color", &Colors.Charcoal);
+    $(hueColorPicker->colorView, invalidateStyle);
 
     $(hueColorPicker->hueSlider->label, setText, "");
   } else {

--- a/src/cgame/common/ui/controls/ResponseServiceViewController.h
+++ b/src/cgame/common/ui/controls/ResponseServiceViewController.h
@@ -74,6 +74,11 @@ struct ResponseServiceViewController {
    * @brief The CrosshairPreviewView.
    */
   CrosshairPreviewView *crosshairView;
+
+  /**
+   * @brief The HUD Select.
+   */
+  Select *hud;
 };
 
 /**

--- a/src/cgame/common/ui/controls/ResponseServiceViewController.json
+++ b/src/cgame/common/ui/controls/ResponseServiceViewController.json
@@ -169,7 +169,7 @@
                         },
                         "control": {
                           "class": "CvarSelect",
-                          "identifier": "crosshair",
+                          "identifier": "crosshairSelect",
                           "var": "cg_draw_crosshair"
                         }
                       },
@@ -261,6 +261,32 @@
                 "container"
               ],
               "subviews": [
+                {
+                  "class": "Box",
+                  "label": {
+                    "text": {
+                      "text": "HUD"
+                    }
+                  },
+                  "contentView": {
+                    "subviews": [
+                      {
+                        "class": "Input",
+                        "label": {
+                          "text": {
+                            "text": "HUD"
+                          }
+                        },
+                        "control": {
+                          "class": "CvarSelect",
+                          "identifier": "hudSelect",
+                          "var": "cg_hud",
+                          "expectsStringValue": true
+                        }
+                      }
+                    ]
+                  }
+                },
                 {
                   "class": "Box",
                   "label": {

--- a/src/cgame/common/ui/editor/EditorViewController.json
+++ b/src/cgame/common/ui/editor/EditorViewController.json
@@ -5,7 +5,7 @@
   ],
   "accessoryView": {
     "style": {
-      "hidden": false
+      "visibility": "visible"
     },
     "subviews": [
       {

--- a/src/cgame/common/ui/editor/EntityViewController.c
+++ b/src/cgame/common/ui/editor/EntityViewController.c
@@ -158,7 +158,9 @@ static void loadView(ViewController *self) {
  */
 static void cycleCandidate(EntityViewController *self, int32_t dir) {
 
-  if (self->numCandidates < 2 || ((ViewController *) self)->view->hidden) {
+  const View *view = ((ViewController *) self)->view;
+
+  if (self->numCandidates < 2 || view->visibility == ViewVisibilityHidden) {
     return;
   }
 

--- a/src/cgame/common/ui/hud/BlendView.c
+++ b/src/cgame/common/ui/hud/BlendView.c
@@ -124,8 +124,6 @@ static View *init(View *self) {
       this->flashes[i] = $(alloc(ImageView), initWithFrame, NULL);
       assert(this->flashes[i]);
 
-      this->flashes[i]->view.autoresizingMask = ViewAutoresizingFill;
-
       $(self, addSubview, (View *) this->flashes[i]);
     }
   }
@@ -163,7 +161,12 @@ static void updateBindings(View *self, ident data) {
     return;
   }
 
-  self->backgroundColor = liquidTint();
+  const SDL_Color tint = liquidTint();
+
+  if (memcmp(&tint, &self->backgroundColor, sizeof(tint))) {
+    $(self->style, addColorAttribute, "background-color", &tint);
+    $(self, invalidateStyle);
+  }
 
   const int16_t pickup = ps->stats[STAT_PICKUP] & ~STAT_TOGGLE_BIT;
   if (pickup && pickup != cg_hud_state.blend.pickup) {

--- a/src/cgame/common/ui/hud/BlendView.c
+++ b/src/cgame/common/ui/hud/BlendView.c
@@ -157,7 +157,7 @@ static void updateBindings(View *self, ident data) {
 
   const player_state_t *ps = &((const cl_frame_t *) data)->ps;
 
-  $(self, setHidden, !cg_draw_blend->value);
+  $(self, setVisibility, cg_draw_blend->value ? ViewVisibilityVisible : ViewVisibilityHidden);
 
   if (!cg_draw_blend->value) {
     return;
@@ -186,7 +186,8 @@ static void updateBindings(View *self, ident data) {
   for (size_t i = 0; i < BlendViewTotal; i++) {
     const float alpha = Clampf01(alphas[i]);
 
-    $((View *) this->flashes[i], setHidden, alpha <= 0.f);
+    $((View *) this->flashes[i], setVisibility,
+      alpha <= 0.f ? ViewVisibilityHidden : ViewVisibilityVisible);
     this->flashes[i]->color.a = (Uint8) (alpha * 255);
   }
 }

--- a/src/cgame/common/ui/hud/ChatView.c
+++ b/src/cgame/common/ui/hud/ChatView.c
@@ -79,9 +79,6 @@ static View *init(View *self) {
   if (self) {
     ChatView *this = (ChatView *) self;
 
-    this->stackView.axis = StackViewAxisVertical;
-    self->autoresizingMask = ViewAutoresizingContain;
-
     this->history = (ConsoleText *) $((View *) alloc(ConsoleText), init);
     assert(this->history);
 

--- a/src/cgame/common/ui/hud/ChatView.c
+++ b/src/cgame/common/ui/hud/ChatView.c
@@ -95,7 +95,7 @@ static View *init(View *self) {
     this->input->delegate.self = this;
     this->input->delegate.didEndEditing = didEndEditing;
 
-    $((View *) this->input, setHidden, true);
+    $((View *) this->input, setVisibility, ViewVisibilityHidden);
 
     $(self, addSubview, (View *) this->input);
   }
@@ -144,11 +144,12 @@ static void updateBindings(View *self, ident data) {
 
   this->typing = typing;
 
-  $((View *) this->input, setHidden, !typing);
+  $((View *) this->input, setVisibility, typing ? ViewVisibilityVisible : ViewVisibilityHidden);
 
   const size_t lines = Clampf(cg_chat_lines->integer, 0, CHAT_MAX_LINES);
 
-  $((View *) this->history, setHidden, lines == 0);
+  $((View *) this->history, setVisibility,
+    lines == 0 ? ViewVisibilityHidden : ViewVisibilityVisible);
 
   if (data && lines && self->superview) {
     const uint32_t now = (uint32_t) SDL_GetTicks();

--- a/src/cgame/common/ui/hud/CounterView.c
+++ b/src/cgame/common/ui/hud/CounterView.c
@@ -110,8 +110,6 @@ static CounterView *initWithCaption(CounterView *self, const char *caption, int3
   if (self) {
     self->stat = stat;
 
-    self->stackView.axis = StackViewAxisVertical;
-
     self->caption = $(alloc(Text), initWithText, caption, NULL);
     assert(self->caption);
 

--- a/src/cgame/common/ui/hud/CrosshairView.c
+++ b/src/cgame/common/ui/hud/CrosshairView.c
@@ -135,8 +135,6 @@ static View *init(View *self) {
     assert(this->imageView);
 
     $(self, addSubview, (View *) this->imageView);
-
-    self->autoresizingMask = ViewAutoresizingContain;
   }
 
   return self;

--- a/src/cgame/common/ui/hud/CrosshairView.c
+++ b/src/cgame/common/ui/hud/CrosshairView.c
@@ -237,7 +237,7 @@ static void updateBindings(View *self, ident data) {
 
   const bool shown = this->imageView->image && visible(ps);
 
-  $(self, setHidden, !shown);
+  $(self, setVisibility, shown ? ViewVisibilityVisible : ViewVisibilityHidden);
 
   if (!shown) {
     return;

--- a/src/cgame/common/ui/hud/DiagnosticsView.c
+++ b/src/cgame/common/ui/hud/DiagnosticsView.c
@@ -157,7 +157,7 @@ static View *init(View *self) {
     table->delegate.cellForColumnAndRow = cellForColumnAndRow;
     table->delegate.self = this;
 
-    $((View *) table->headerView, setHidden, true);
+    $((View *) table->headerView, setVisibility, ViewVisibilityHidden);
   }
 
   return self;
@@ -170,14 +170,15 @@ static void updateBindings(View *self, ident data) {
 
   DiagnosticsView *this = (DiagnosticsView *) self;
 
-  $(self, setHidden, !cg_draw_diagnostics->integer);
+  $(self, setVisibility,
+    cg_draw_diagnostics->integer ? ViewVisibilityVisible : ViewVisibilityHidden);
 
   if (data) {
     cl_client_t *cl = cgi.client;
 
     const uint32_t now = (uint32_t) SDL_GetTicks();
 
-    if (self->hidden) {
+    if (self->visibility == ViewVisibilityHidden) {
       cl->packets = 0;
       this->frames = 0;
       this->time = now;

--- a/src/cgame/common/ui/hud/DiagnosticsView.c
+++ b/src/cgame/common/ui/hud/DiagnosticsView.c
@@ -146,8 +146,6 @@ static View *init(View *self) {
     DiagnosticsView *this = (DiagnosticsView *) self;
     TableView *table = (TableView *) self;
 
-    self->autoresizingMask = ViewAutoresizingContain;
-
     $(table, addColumnWithIdentifier, _name);
     $(table, addColumnWithIdentifier, _value);
 

--- a/src/cgame/common/ui/hud/FpsView.c
+++ b/src/cgame/common/ui/hud/FpsView.c
@@ -42,7 +42,7 @@ static void updateBindings(View *self, ident data) {
 
   FpsView *this = (FpsView *) self;
 
-  $(self, setHidden, !cg_draw_fps->integer);
+  $(self, setVisibility, cg_draw_fps->integer ? ViewVisibilityVisible : ViewVisibilityHidden);
 
   if (data) {
     this->frames++;

--- a/src/cgame/common/ui/hud/HudViewController.c
+++ b/src/cgame/common/ui/hud/HudViewController.c
@@ -175,6 +175,27 @@ static const char *hudResource(const char *hud, const char *file) {
 }
 
 /**
+ * @brief Warns when `hud` ships no file of its own, which is what a misspelled `cg_hud` looks
+ * like: every file falls back to the default, and the fallback is otherwise silent.
+ */
+static void checkHud(const char *hud) {
+
+  if (!q_strcmp(hud, HUD_DEFAULT)) {
+    return;
+  }
+
+  const char *files[] = { "hud.json", "hud.css", "scoreboard.json", "scoreboard.css" };
+
+  for (size_t i = 0; i < lengthof(files); i++) {
+    if (cgi.StatFile(va("ui/hud/%s/%s", hud, files[i]), NULL)) {
+      return;
+    }
+  }
+
+  Cg_Warn("No ui/hud/%s, using the %s HUD\n", hud, HUD_DEFAULT);
+}
+
+/**
  * @brief Loads the hud's View and Stylesheet, or `NULL` if either is missing.
  */
 static View *loadHud(const char *hud) {
@@ -228,6 +249,8 @@ static ScoreboardView *loadScoreboard(const char *hud) {
  * @memberof HudViewController
  */
 static void reload(HudViewController *self) {
+
+  checkHud(cg_hud->string);
 
   if (self->hud) {
     $((View *) self->hud, removeFromSuperview);

--- a/src/cgame/common/ui/hud/HudViewController.c
+++ b/src/cgame/common/ui/hud/HudViewController.c
@@ -94,7 +94,7 @@ static void loadView(ViewController *self) {
   View *view = $(alloc(View), initWithFrame, NULL);
   assert(view);
 
-  view->autoresizingMask = ViewAutoresizingFill;
+  $(view->style, addEnumAttribute, "autoresizing-mask", ViewAutoresizingNames, ViewAutoresizingFill);
 
   $(self, setView, view);
   release(view);
@@ -220,8 +220,6 @@ static ScoreboardView *loadScoreboard(const char *hud) {
     Cg_Warn("Failed to load %s\n", css);
   }
 
-  scoreboard->autoresizingMask = ViewAutoresizingFill;
-
   return (ScoreboardView *) scoreboard;
 }
 
@@ -256,8 +254,6 @@ static void reload(HudViewController *self) {
     Cg_Warn("No HUD\n");
     return;
   }
-
-  hud->autoresizingMask = ViewAutoresizingFill;
 
   // beneath the notify lines, the chat, the scoreboard and the nav edit
   $(self->viewController.view, addSubview, hud);

--- a/src/cgame/common/ui/hud/HudViewController.c
+++ b/src/cgame/common/ui/hud/HudViewController.c
@@ -29,7 +29,7 @@
 
 #define _Class _HudViewController
 
-#define HUD_DEFAULT_VARIANT "default"
+#define HUD_DEFAULT "default"
 
 HudViewController *cg_hud_view_controller;
 
@@ -135,9 +135,6 @@ static AtlasImage *image(HudViewController *self, const char *name) {
     return NULL;
   }
 
-  // Registered by resource name, so a controller re-created on a module switch finds the
-  // image the last one added rather than adding it again; a name with a slash can never be
-  // typed as an :icon: escape, so these stay out of the way of the emoji
   AtlasImage *image = $(theme, icon, name);
   if (image) {
     return image;
@@ -164,46 +161,25 @@ static AtlasImage *image(HudViewController *self, const char *name) {
 }
 
 /**
- * @brief The name of `file` in `variant`, if the variant provides it, else in the default
- * variant. A variant overrides only the files it ships; the rest it inherits.
+ * @brief The name of `file` in `hud`, if the hud provides it, else in the default
+ * hud. A hud overrides only the files it ships; the rest it inherits.
  */
-static const char *variantResource(const char *variant, const char *file) {
+static const char *hudResource(const char *hud, const char *file) {
 
-  const char *name = va("ui/hud/%s/%s", variant, file);
-  if (cgi.FileExists(name)) {
+  const char *name = va("ui/hud/%s/%s", hud, file);
+  if (cgi.StatFile(name, NULL)) {
     return name;
   }
 
-  return va("ui/hud/%s/%s", HUD_DEFAULT_VARIANT, file);
+  return va("ui/hud/%s/%s", HUD_DEFAULT, file);
 }
 
 /**
- * @brief Warns when `variant` ships no file of its own, which is what a misspelled `cg_hud`
- * looks like: every file resolves to the default variant, and the fallback is otherwise silent.
+ * @brief Loads the hud's View and Stylesheet, or `NULL` if either is missing.
  */
-static void checkVariant(const char *variant) {
+static View *loadHud(const char *hud) {
 
-  if (!q_strcmp(variant, HUD_DEFAULT_VARIANT)) {
-    return;
-  }
-
-  const char *files[] = { "hud.json", "hud.css", "scoreboard.json", "scoreboard.css" };
-
-  for (size_t i = 0; i < lengthof(files); i++) {
-    if (cgi.FileExists(va("ui/hud/%s/%s", variant, files[i]))) {
-      return;
-    }
-  }
-
-  Cg_Debug("No ui/hud/%s, using the %s HUD\n", variant, HUD_DEFAULT_VARIANT);
-}
-
-/**
- * @brief Loads the variant's View and Stylesheet, or `NULL` if either is missing.
- */
-static View *loadVariant(const char *variant) {
-
-  const char *json = variantResource(variant, "hud.json");
+  const char *json = hudResource(hud, "hud.json");
 
   View *view = $$(View, viewWithResourceName, json, NULL);
   if (view == NULL) {
@@ -211,7 +187,7 @@ static View *loadVariant(const char *variant) {
     return NULL;
   }
 
-  const char *css = variantResource(variant, "hud.css");
+  const char *css = hudResource(hud, "hud.css");
 
   view->stylesheet = $$(Stylesheet, stylesheetWithResourceName, css);
   if (view->stylesheet == NULL) {
@@ -224,11 +200,11 @@ static View *loadVariant(const char *variant) {
 }
 
 /**
- * @brief Loads the variant's scoreboard, which a module MAY name a ScoreboardView subclass in.
+ * @brief Loads the hud's scoreboard, which a module MAY name a ScoreboardView subclass in.
  */
-static ScoreboardView *loadScoreboard(const char *variant) {
+static ScoreboardView *loadScoreboard(const char *hud) {
 
-  const char *json = variantResource(variant, "scoreboard.json");
+  const char *json = hudResource(hud, "scoreboard.json");
 
   View *scoreboard = $$(View, viewWithResourceName, json, NULL);
   if (scoreboard == NULL || !$((Object *) scoreboard, isKindOfClass, _ScoreboardView())) {
@@ -237,7 +213,7 @@ static ScoreboardView *loadScoreboard(const char *variant) {
     scoreboard = $((View *) alloc(ScoreboardView), init);
   }
 
-  const char *css = variantResource(variant, "scoreboard.css");
+  const char *css = hudResource(hud, "scoreboard.css");
 
   scoreboard->stylesheet = $$(Stylesheet, stylesheetWithResourceName, css);
   if (scoreboard->stylesheet == NULL) {
@@ -255,15 +231,13 @@ static ScoreboardView *loadScoreboard(const char *variant) {
  */
 static void reload(HudViewController *self) {
 
-  checkVariant(cg_hud->string);
-
   if (self->hud) {
-    $(self->hud, removeFromSuperview);
+    $((View *) self->hud, removeFromSuperview);
     self->hud = release(self->hud);
   }
 
-  // The scoreboard belongs to the variant, but shows through the intermission and with the
-  // HUD off, so it is swapped before the variant and survives a variant that fails to load
+  // The scoreboard belongs to the hud, but shows through the intermission and with the
+  // HUD off, so it is swapped before the hud and survives a hud that fails to load
   if (self->scoreboard) {
     $((View *) self->scoreboard, removeFromSuperview);
     self->scoreboard = release(self->scoreboard);
@@ -272,10 +246,10 @@ static void reload(HudViewController *self) {
   self->scoreboard = loadScoreboard(cg_hud->string);
   $(self->viewController.view, addSubview, (View *) self->scoreboard);
 
-  View *hud = loadVariant(cg_hud->string);
-  if (hud == NULL && q_strcmp(cg_hud->string, HUD_DEFAULT_VARIANT)) {
-    Cg_Warn("Falling back to the %s HUD\n", HUD_DEFAULT_VARIANT);
-    hud = loadVariant(HUD_DEFAULT_VARIANT);
+  View *hud = loadHud(cg_hud->string);
+  if (hud == NULL && q_strcmp(cg_hud->string, HUD_DEFAULT)) {
+    Cg_Warn("Falling back to the %s HUD\n", HUD_DEFAULT);
+    hud = loadHud(HUD_DEFAULT);
   }
 
   if (hud == NULL) {
@@ -293,7 +267,7 @@ static void reload(HudViewController *self) {
   $(self->viewController.view, bringSubviewToFront, (View *) self->navEdit);
   self->hud = hud;
 
-  // The diagnostics join the variant's layout so that its stylesheet and inset apply to them
+  // The diagnostics join the hud's layout so that its stylesheet and inset apply to them
   View *layout = $(hud, descendantWithIdentifier, "layout") ?: hud;
   $(layout, addSubview, (View *) self->diagnostics);
 

--- a/src/cgame/common/ui/hud/HudViewController.c
+++ b/src/cgame/common/ui/hud/HudViewController.c
@@ -289,7 +289,8 @@ static void hideForEditor(View *view, ident data) {
   }
 
   const bool crosshair = $((Object *) view, isKindOfClass, _CrosshairView());
-  $(view, setHidden, editor->value && !crosshair);
+  $(view, setVisibility,
+    editor->value && !crosshair ? ViewVisibilityHidden : ViewVisibilityVisible);
 }
 
 /**
@@ -345,7 +346,8 @@ static void updateWithFrame(HudViewController *self, const cl_frame_t *frame) {
   // Only what shows takes the frame, since some elements trace the world to fill themselves in.
   const bool scores = ps->stats[STAT_SCORES] && !cg_state.nav_edit;
 
-  $((View *) self->scoreboard, setHidden, !scores);
+  $((View *) self->scoreboard, setVisibility,
+    scores ? ViewVisibilityVisible : ViewVisibilityHidden);
 
   if (scores) {
     $((View *) self->scoreboard, updateBindings, (ident) frame);
@@ -354,7 +356,7 @@ static void updateWithFrame(HudViewController *self, const cl_frame_t *frame) {
   const bool hidden = !cg_draw_hud->integer || !ps->stats[STAT_TIME] || cg_state.nav_edit;
 
   if (self->hud) {
-    $(self->hud, setHidden, hidden);
+    $(self->hud, setVisibility, hidden ? ViewVisibilityHidden : ViewVisibilityVisible);
 
     if (!hidden) {
       $(self->hud, enumerateSubviews, hideForEditor, NULL);

--- a/src/cgame/common/ui/hud/HudViewController.h
+++ b/src/cgame/common/ui/hud/HudViewController.h
@@ -43,7 +43,7 @@ typedef struct HudViewController HudViewController;
 typedef struct HudViewControllerInterface HudViewControllerInterface;
 
 /**
- * @brief The HUD: the variant's View tree beneath the scoreboard, the notify lines, the chat
+ * @brief The HUD: the hud's View tree beneath the scoreboard, the notify lines, the chat
  * and the nav edit card, all fed the frame each Cg_UpdateScreen.
  * @extends ViewController
  */
@@ -62,18 +62,24 @@ struct HudViewController {
 
   /**
    * @brief Whether the Theme's icon atlas has HUD images added since it was last compiled,
-   * which happens only when a variant asks for one HudViewController::warm did not.
+   * which happens only when a hud asks for one HudViewController::warm did not.
    */
   bool atlasDirty;
 
   /**
-   * @brief The diagnostics table, added to each variant's layout and shown while
+   * @brief The chat tail View.
+   */
+  ChatView *chat;
+
+  /**
+   * @brief The diagnostics table, added to each hud's layout and shown while
    * `cg_draw_diagnostics` is set.
    */
   DiagnosticsView *diagnostics;
 
   /**
-   * @brief The View loaded from the variant's JSON, a subview of `view`.
+   * @brief The primary HUD View shown when active in-game.
+   * @details This is the View responsible for rendering vitals, inventory, map time, etc.
    */
   View *hud;
 
@@ -88,16 +94,12 @@ struct HudViewController {
   NavEditView *navEdit;
 
   /**
-   * @brief The notify lines and the chat, siblings of `hud` so that they outlive it through the
-   * intermission and with the HUD off, as the scoreboard does.
+   * @brief The console notifications View, a sibling of `hud`.
    */
   NotifyView *notify;
-  ChatView *chat;
 
   /**
-   * @brief The scoreboard, a subview of `view` above `hud`. It belongs to the variant, but
-   * shows through the intermission and with the HUD off, so it outlives a variant that
-   * fails to load.
+   * @brief The scoreboard, a sibling of `hud`.
    */
   ScoreboardView *scoreboard;
 };
@@ -126,10 +128,10 @@ struct HudViewControllerInterface {
 
   /**
    * @fn void HudViewController::reload(HudViewController *self)
-   * @brief Loads the variant named by `cg_hud`, and its scoreboard. Each file is read from
-   * `ui/hud/<variant>`, or from `ui/hud/default` when the variant does not ship it, so a
-   * variant overrides only what it changes. A module arranging its HUD differently ships its
-   * own `ui/hud/<variant>/hud.json` in its game directory.
+   * @brief Loads the hud named by `cg_hud`, and its scoreboard. Each file is read from
+   * `ui/hud/<hud>`, or from `ui/hud/default` when the hud does not ship it, so a
+   * hud overrides only what it changes. A module arranging its HUD differently ships its
+   * own `ui/hud/<hud>/hud.json` in its game directory.
    * @param self The HudViewController.
    * @memberof HudViewController
    */
@@ -138,7 +140,7 @@ struct HudViewControllerInterface {
   /**
    * @fn void HudViewController::updateWithFrame(HudViewController *self, const cl_frame_t *frame)
    * @brief Resolves visibility, hands `frame` to the View hierarchy, and compiles the Theme's
-   * icon atlas if a variant added to it. Called once per frame, before the client draws.
+   * icon atlas if a hud added to it. Called once per frame, before the client draws.
    * @param self The HudViewController.
    * @param frame The frame.
    * @memberof HudViewController

--- a/src/cgame/common/ui/hud/NavEditView.c
+++ b/src/cgame/common/ui/hud/NavEditView.c
@@ -50,8 +50,6 @@ static View *init(View *self) {
   if (self) {
     NavEditView *this = (NavEditView *) self;
 
-    self->autoresizingMask = ViewAutoresizingContain;
-
     $(self->style, addRectangleAttribute, "padding", &MakeRect(8, 16, 8, 16));
     $(self->style, addColorAttribute, "background-color", &(const SDL_Color) { 0, 0, 0, 166 });
     $(self->style, addIntegerAttribute, "border-radius", 4);

--- a/src/cgame/common/ui/hud/NavEditView.c
+++ b/src/cgame/common/ui/hud/NavEditView.c
@@ -93,7 +93,7 @@ static void updateBindings(View *self, ident data) {
 
   const bool shown = cg_state.nav_edit == 1;
 
-  $(self, setHidden, !shown);
+  $(self, setVisibility, shown ? ViewVisibilityVisible : ViewVisibilityHidden);
 
   if (!shown) {
     return;

--- a/src/cgame/common/ui/hud/NotifyView.c
+++ b/src/cgame/common/ui/hud/NotifyView.c
@@ -52,7 +52,7 @@ static void updateBindings(View *self, ident data) {
   const size_t lines = Clampf(cg_notify_lines->integer, 0, NOTIFY_MAX_LINES);
   const bool hidden = lines == 0 || cgi.GetKeyDest() != KEY_GAME;
 
-  $(self, setHidden, hidden);
+  $(self, setVisibility, hidden ? ViewVisibilityHidden : ViewVisibilityVisible);
 
   if (data && !hidden && self->superview) {
     const uint32_t now = (uint32_t) SDL_GetTicks();

--- a/src/cgame/common/ui/hud/OverlayText.c
+++ b/src/cgame/common/ui/hud/OverlayText.c
@@ -47,7 +47,7 @@ static void updateBindings(View *self, ident data) {
 
   const char *text = $((OverlayText *) self, textForFrame, data);
 
-  $(self, setHidden, text == NULL);
+  $(self, setVisibility, text == NULL ? ViewVisibilityHidden : ViewVisibilityVisible);
 
   if (text) {
     $((Text *) self, setText, text);

--- a/src/cgame/common/ui/hud/PickupView.c
+++ b/src/cgame/common/ui/hud/PickupView.c
@@ -54,8 +54,6 @@ static View *init(View *self) {
 
     this->item = ITEM_NONE;
 
-    this->stackView.axis = StackViewAxisHorizontal;
-
     this->icon = $(alloc(ImageView), initWithFrame, &MakeRect(0, 0, HUD_PIC_HEIGHT, HUD_PIC_HEIGHT));
     assert(this->icon);
 
@@ -63,8 +61,6 @@ static View *init(View *self) {
 
     this->name = $(alloc(Text), initWithText, NULL, NULL);
     assert(this->name);
-
-    this->name->view.alignment = ViewAlignmentMiddle;
 
     $(self, addSubview, (View *) this->name);
   }

--- a/src/cgame/common/ui/hud/PickupView.c
+++ b/src/cgame/common/ui/hud/PickupView.c
@@ -90,7 +90,7 @@ static void updateBindings(View *self, ident data) {
   const int16_t pickup = ps->stats[STAT_PICKUP] & ~STAT_TOGGLE_BIT;
   const bool valid = pickup > ITEM_NONE && pickup < ITEM_TOTAL;
 
-  $(self, setHidden, !valid);
+  $(self, setVisibility, valid ? ViewVisibilityVisible : ViewVisibilityHidden);
 
   if (valid && pickup != (int16_t) this->item) {
     this->item = pickup;

--- a/src/cgame/common/ui/hud/PingView.c
+++ b/src/cgame/common/ui/hud/PingView.c
@@ -44,7 +44,7 @@ static void updateBindings(View *self, ident data) {
 
   PingView *this = (PingView *) self;
 
-  $(self, setHidden, !cg_draw_ping->integer);
+  $(self, setVisibility, cg_draw_ping->integer ? ViewVisibilityVisible : ViewVisibilityHidden);
 
   if (data) {
     const cl_client_t *cl = cgi.client;

--- a/src/cgame/common/ui/hud/PowerupView.c
+++ b/src/cgame/common/ui/hud/PowerupView.c
@@ -120,7 +120,8 @@ static void update(PowerupView *self, g_item_tag_t item, int16_t value) {
 
   const bool valid = item > ITEM_NONE && item < ITEM_TOTAL;
 
-  $((View *) self, setHidden, value == 0 || !valid);
+  $((View *) self, setVisibility,
+    value == 0 || !valid ? ViewVisibilityHidden : ViewVisibilityVisible);
 
   if (value == 0 || !valid) {
     return;

--- a/src/cgame/common/ui/hud/PowerupView.c
+++ b/src/cgame/common/ui/hud/PowerupView.c
@@ -137,7 +137,13 @@ static void update(PowerupView *self, g_item_tag_t item, int16_t value) {
   if (value < 0) {
     $(self->value, setText, NULL);
   } else {
-    self->value->color = value < HUD_POWERUP_LOW ? Colors.Red : Colors.White;
+    const SDL_Color color = value < HUD_POWERUP_LOW ? Colors.Red : Colors.White;
+
+    if (memcmp(&color, &self->value->color, sizeof(color))) {
+      $(self->value->view.style, addColorAttribute, "color", &color);
+      $((View *) self->value, invalidateStyle);
+    }
+
     $(self->value, setTextWithFormat, "%d", value);
   }
 }
@@ -152,9 +158,6 @@ static PowerupView *initWithPowerup(PowerupView *self, PowerupViewPowerup poweru
   if (self) {
     self->powerup = powerup;
     self->item = ITEM_NONE;
-
-    self->stackView.axis = StackViewAxisHorizontal;
-    self->stackView.spacing = HUD_PIC_HEIGHT / 2;
 
     self->icon = $(alloc(ImageView), initWithFrame, &MakeRect(0, 0, HUD_PIC_HEIGHT, HUD_PIC_HEIGHT));
     assert(self->icon);

--- a/src/cgame/common/ui/hud/ScoreView.c
+++ b/src/cgame/common/ui/hud/ScoreView.c
@@ -92,7 +92,7 @@ static ScoreView *initWithScore(ScoreView *self, const g_score_t *score, int32_t
     self->badge = $(alloc(ImageView), initWithFrame, &MakeRect(1, 1, SCORES_ICON_WIDTH * 0.3f, SCORES_ICON_WIDTH * 0.3f));
     assert(self->badge);
 
-    $((View *) self->badge, setHidden, true);
+    $((View *) self->badge, setVisibility, ViewVisibilityHidden);
     $((View *) self, addSubview, (View *) self->badge);
 
     const int32_t x = SCORES_ICON_WIDTH;
@@ -139,8 +139,8 @@ static void setFields(ScoreView *self, const ScoreField *fields, const char **va
   assert(fields);
   assert(values);
 
-  $((View *) self->detail, setHidden, true);
-  $((View *) self->aside, setHidden, true);
+  $((View *) self->detail, setVisibility, ViewVisibilityHidden);
+  $((View *) self->aside, setVisibility, ViewVisibilityHidden);
 
   const int32_t height = self->view.frame.h;
 
@@ -185,8 +185,10 @@ static void setDetails(ScoreView *self, const char *detail, const char *aside) {
   $(self->detail, setText, detail);
   $(self->aside, setText, aside);
 
-  $((View *) self->detail, setHidden, detail == NULL);
-  $((View *) self->aside, setHidden, aside == NULL);
+  $((View *) self->detail, setVisibility,
+    detail == NULL ? ViewVisibilityHidden : ViewVisibilityVisible);
+  $((View *) self->aside, setVisibility,
+    aside == NULL ? ViewVisibilityHidden : ViewVisibilityVisible);
 }
 
 #pragma mark - Class lifecycle

--- a/src/cgame/common/ui/hud/ScoreView.c
+++ b/src/cgame/common/ui/hud/ScoreView.c
@@ -75,7 +75,7 @@ static ScoreView *initWithScore(ScoreView *self, const g_score_t *score, int32_t
 
     // a row is its width, whatever its children reach: the ping is aligned rather than
     // placed, so a size derived from the children alone falls short of the columns
-    self->view.minSize.w = width;
+    $(self->view.style, addIntegerAttribute, "min-width", width);
 
     const cg_client_info_t *info = &cg_state.clients[score->client];
 
@@ -101,8 +101,6 @@ static ScoreView *initWithScore(ScoreView *self, const g_score_t *score, int32_t
     self->fill = $(alloc(View), initWithFrame, &MakeRect(x, 0, fw, SCORES_ROW_HEIGHT - 1));
     assert(self->fill);
 
-    self->fill->alignment = ViewAlignmentInternal;
-
     $((View *) self->fill, addClassName, "fill");
     $((View *) self, addSubview, self->fill);
 
@@ -111,20 +109,20 @@ static ScoreView *initWithScore(ScoreView *self, const g_score_t *score, int32_t
       c.a = score->client == cgi.client->frame.ps.client ? .3f : .15f;
 
       const color32_t rgba = Color_Color32(c);
-      self->fill->backgroundColor = (SDL_Color) { rgba.r, rgba.g, rgba.b, rgba.a };
+      const SDL_Color fill = { rgba.r, rgba.g, rgba.b, rgba.a };
+
+      $(self->fill->style, addColorAttribute, "background-color", &fill);
     }
 
     self->name = addText(self, &MakeRect(x, 0, fw, 0), "name");
     $(self->name, setText, info->name);
 
     self->ping = addText(self, &MakeRect(x, 0, fw, 0), "ping");
-    self->ping->view.alignment = ViewAlignmentTopRight;
     $(self->ping, setTextWithFormat, "%dms", score->ping);
 
     self->detail = addText(self, &MakeRect(x, 16, fw, 0), "detail");
 
     self->aside = addText(self, &MakeRect(x, 16, fw, 0), "aside");
-    self->aside->view.alignment = ViewAlignmentRight;
   }
 
   return self;
@@ -138,6 +136,8 @@ static void setFields(ScoreView *self, const ScoreField *fields, const char **va
 
   assert(fields);
   assert(values);
+
+  $((View *) self, addClassName, "fields");
 
   $((View *) self->detail, setVisibility, ViewVisibilityHidden);
   $((View *) self->aside, setVisibility, ViewVisibilityHidden);
@@ -161,8 +161,6 @@ static void setFields(ScoreView *self, const ScoreField *fields, const char **va
     Text *value = $(alloc(Text), initWithText, values[i - 1], NULL);
     assert(value);
 
-    value->view.alignment = ViewAlignmentMiddleRight;
-
     $((View *) value, addClassName, "field");
     $(column, addSubview, (View *) value);
     release(value);
@@ -173,7 +171,6 @@ static void setFields(ScoreView *self, const ScoreField *fields, const char **va
 
   // the prose lines are gone, so the name and the ping take the middle of the row
   self->name->view.frame.y = (height - self->name->view.frame.h) / 2;
-  self->ping->view.alignment = ViewAlignmentMiddleRight;
 }
 
 /**

--- a/src/cgame/common/ui/hud/ScoreboardView.c
+++ b/src/cgame/common/ui/hud/ScoreboardView.c
@@ -68,7 +68,7 @@ static void configureBadge(ScoreView *row, const g_score_t *score) {
 #if defined(G_CTF)
   if (score->flags & SCORE_CTF_FLAG) {
     $(row->badge, setImage, (Image *) Cg_HudImage(va("pics/flag%d", score->team)));
-    $((View *) row->badge, setHidden, false);
+    $((View *) row->badge, setVisibility, ViewVisibilityVisible);
   }
 #endif
 }

--- a/src/cgame/common/ui/hud/ScoreboardView.c
+++ b/src/cgame/common/ui/hud/ScoreboardView.c
@@ -127,8 +127,6 @@ static View *tableHeader(ScoreboardView *self) {
     Text *caption = $(alloc(Text), initWithText, f[i - 1].caption, NULL);
     assert(caption);
 
-    caption->view.alignment = ViewAlignmentMiddleRight;
-
     $((View *) caption, addClassName, "caption");
     $(column, addSubview, (View *) caption);
     release(caption);
@@ -187,14 +185,12 @@ static View *init(View *self) {
     this->header = $(alloc(StackView), initWithFrame, NULL);
     assert(this->header);
 
-    this->header->axis = StackViewAxisHorizontal;
     $((View *) this->header, addClassName, "header");
     $(self, addSubview, (View *) this->header);
 
     this->columns = $(alloc(StackView), initWithFrame, NULL);
     assert(this->columns);
 
-    this->columns->axis = StackViewAxisHorizontal;
     $((View *) this->columns, addClassName, "columns");
     $(self, addSubview, (View *) this->columns);
   }
@@ -257,7 +253,6 @@ static StackView *addColumn(ScoreboardView *self) {
   StackView *column = $(alloc(StackView), initWithFrame, NULL);
   assert(column);
 
-  column->axis = StackViewAxisVertical;
   $((View *) column, addClassName, "column");
 
   $((View *) self->columns, addSubview, (View *) column);
@@ -420,7 +415,6 @@ static void rebuild(ScoreboardView *self) {
       const color32_t rgba = Color_Color32(cg_state.teams[t].color);
       const SDL_Color color = { rgba.r, rgba.g, rgba.b, 255 };
 
-      total->color = color;
       $(total->view.style, addColorAttribute, "color", &color);
 
       $((View *) self->header, addSubview, (View *) total);

--- a/src/cgame/common/ui/hud/StatView.c
+++ b/src/cgame/common/ui/hud/StatView.c
@@ -106,7 +106,8 @@ static void awakeWithDictionary(View *self, const Dictionary *dictionary) {
     free(caption);
   }
 
-  $((View *) this->caption, setHidden, this->caption->text == NULL);
+  $((View *) this->caption, setVisibility,
+    this->caption->text == NULL ? ViewVisibilityHidden : ViewVisibilityVisible);
 }
 
 /**
@@ -162,7 +163,7 @@ static void updateBindings(View *self, ident data) {
       break;
   }
 
-  $(self, setHidden, value <= 0);
+  $(self, setVisibility, value <= 0 ? ViewVisibilityHidden : ViewVisibilityVisible);
 
   if (value <= 0) {
     return;
@@ -217,7 +218,7 @@ static StatView *initWithStat(StatView *self, StatViewStat stat) {
     assert(self->caption);
 
     $((View *) self->caption, addClassName, "caption");
-    $((View *) self->caption, setHidden, true);
+    $((View *) self->caption, setVisibility, ViewVisibilityHidden);
     $((View *) self->labels, addSubview, (View *) self->caption);
 
     self->value = $(alloc(Text), initWithText, NULL, NULL);

--- a/src/cgame/common/ui/hud/StatView.c
+++ b/src/cgame/common/ui/hud/StatView.c
@@ -181,7 +181,11 @@ static void updateBindings(View *self, ident data) {
     color = Colors.Yellow;
   }
 
-  this->value->color = color;
+  if (memcmp(&color, &this->value->color, sizeof(color))) {
+    $(this->value->view.style, addColorAttribute, "color", &color);
+    $((View *) this->value, invalidateStyle);
+  }
+
   $(this->value, setTextWithFormat, "%d", value);
 
   this->icon->color.a = (Uint8) (pulse * 255);
@@ -204,13 +208,9 @@ static StatView *initWithStat(StatView *self, StatViewStat stat) {
   if (self) {
     self->stat = stat;
 
-    self->stackView.axis = StackViewAxisHorizontal;
-    self->stackView.spacing = 5;
-
     self->labels = $(alloc(StackView), initWithFrame, NULL);
     assert(self->labels);
 
-    self->labels->axis = StackViewAxisVertical;
     $((View *) self->labels, addClassName, "labels");
     $((View *) self, addSubview, (View *) self->labels);
 

--- a/src/cgame/common/ui/hud/TeamBannerView.c
+++ b/src/cgame/common/ui/hud/TeamBannerView.c
@@ -54,7 +54,12 @@ static void updateBindings(View *self, ident data) {
 
   if (valid) {
     const color32_t color = Color_Color32(ColorHSVA(cg_state.teams[team].hue, 1.f, 1.f, .14f));
-    self->backgroundColor = (SDL_Color) { color.r, color.g, color.b, color.a };
+    const SDL_Color background = { color.r, color.g, color.b, color.a };
+
+    if (memcmp(&background, &self->backgroundColor, sizeof(background))) {
+      $(self->style, addColorAttribute, "background-color", &background);
+      $(self, invalidateStyle);
+    }
   }
 }
 

--- a/src/cgame/common/ui/hud/TeamBannerView.c
+++ b/src/cgame/common/ui/hud/TeamBannerView.c
@@ -50,7 +50,7 @@ static void updateBindings(View *self, ident data) {
   const int16_t team = ps->stats[STAT_TEAM];
   const bool valid = team >= 0 && team < MAX_TEAMS;
 
-  $(self, setHidden, !valid);
+  $(self, setVisibility, valid ? ViewVisibilityVisible : ViewVisibilityHidden);
 
   if (valid) {
     const color32_t color = Color_Color32(ColorHSVA(cg_state.teams[team].hue, 1.f, 1.f, .14f));

--- a/src/cgame/common/ui/hud/WeaponBarView.c
+++ b/src/cgame/common/ui/hud/WeaponBarView.c
@@ -149,7 +149,7 @@ static void updateBindings(View *self, ident data) {
   float alpha;
   const bool visible = Cg_UpdateSelectWeapon(ps, &alpha);
 
-  $(self, setHidden, !visible);
+  $(self, setVisibility, visible ? ViewVisibilityVisible : ViewVisibilityHidden);
 
   if (!visible) {
     return;

--- a/src/cgame/common/ui/hud/WeaponBarView.c
+++ b/src/cgame/common/ui/hud/WeaponBarView.c
@@ -26,8 +26,6 @@
 
 #define _Class _WeaponBarView
 
-#define WEAPON_BAR_SPACING 4
-
 #pragma mark - Object
 
 /**
@@ -54,8 +52,6 @@ static View *init(View *self) {
   if (self) {
     WeaponBarView *this = (WeaponBarView *) self;
 
-    this->stackView.axis = StackViewAxisVertical;
-
     this->name = $(alloc(Text), initWithText, NULL, NULL);
     assert(this->name);
 
@@ -63,10 +59,6 @@ static View *init(View *self) {
 
     this->slots = $(alloc(StackView), initWithFrame, NULL);
     assert(this->slots);
-
-    this->slots->axis = StackViewAxisHorizontal;
-    this->slots->spacing = WEAPON_BAR_SPACING;
-    this->slots->view.autoresizingMask = ViewAutoresizingContain;
 
     $(self, addSubview, (View *) this->slots);
   }
@@ -86,7 +78,6 @@ static void rebuild(WeaponBarView *self) {
       View *slot = $(alloc(View), initWithFrame, NULL);
       assert(slot);
 
-      slot->autoresizingMask = ViewAutoresizingContain;
       $(slot, addClassName, "slot");
 
       ImageView *icon = $(alloc(ImageView), initWithFrame, &MakeRect(0, 0, HUD_PIC_HEIGHT, HUD_PIC_HEIGHT));

--- a/src/cgame/common/ui/main/LoadingViewController.c
+++ b/src/cgame/common/ui/main/LoadingViewController.c
@@ -142,7 +142,8 @@ static void setProgress(LoadingViewController *self, const cl_loading_t loading)
 
     const char *server = resolveServerName();
     $(self->serverName->text, setText, server);
-    $((View *) self->serverName, setHidden, *server == '\0');
+    $((View *) self->serverName, setVisibility,
+      *server == '\0' ? ViewVisibilityHidden : ViewVisibilityVisible);
   }
 }
 

--- a/src/cgame/common/ui/main/MainView.c
+++ b/src/cgame/common/ui/main/MainView.c
@@ -38,10 +38,12 @@ static void updateBindings(View *self, ident data) {
 
   const bool isActive = *cgi.state == CL_ACTIVE;
 
-  $((View *) this->background, setHidden, isActive);
-  $((View *) this->logo, setHidden, isActive);
-  $((View *) this->version, setHidden, isActive);
-  $((View *) this->secondaryMenu, setHidden, !isActive);
+  $((View *) this->background, setVisibility,
+    isActive ? ViewVisibilityHidden : ViewVisibilityVisible);
+  $((View *) this->logo, setVisibility, isActive ? ViewVisibilityHidden : ViewVisibilityVisible);
+  $((View *) this->version, setVisibility, isActive ? ViewVisibilityHidden : ViewVisibilityVisible);
+  $((View *) this->secondaryMenu, setVisibility,
+    isActive ? ViewVisibilityVisible : ViewVisibilityHidden);
 }
 
 #pragma mark - MainView

--- a/src/cgame/common/ui/play/JoinServerViewController.c
+++ b/src/cgame/common/ui/play/JoinServerViewController.c
@@ -153,8 +153,9 @@ static const char *sourceLabel(const cl_server_info_t *server) {
  */
 static void setDetailsPopulated(JoinServerViewController *self, const bool populated) {
 
-  $((View *) self->hintLabel, setHidden, populated);
-  $(self->detailGrid, setHidden, !populated);
+  $((View *) self->hintLabel, setVisibility,
+    populated ? ViewVisibilityHidden : ViewVisibilityVisible);
+  $(self->detailGrid, setVisibility, populated ? ViewVisibilityVisible : ViewVisibilityHidden);
 }
 
 /**
@@ -175,7 +176,8 @@ static void refreshMapshot(JoinServerViewController *self, const cl_server_info_
   }
 
   $(self->mapshotView, setImageWithSurface, surface);
-  $((View *) self->mapshotView, setHidden, surface == NULL);
+  $((View *) self->mapshotView, setVisibility,
+    surface == NULL ? ViewVisibilityHidden : ViewVisibilityVisible);
 
   if (surface) {
     SDL_DestroySurface(surface);
@@ -195,7 +197,7 @@ static void refreshDetails(JoinServerViewController *self) {
   if (server == NULL) {
     setLabelText(self->hostnameLabel, "Select a server");
     setLabelText(self->addressLabel, NULL);
-    $((View *) self->connectButton, setHidden, true);
+    $((View *) self->connectButton, setVisibility, ViewVisibilityHidden);
     return;
   }
 
@@ -209,7 +211,7 @@ static void refreshDetails(JoinServerViewController *self) {
   setLabelText(self->playersLabel, va("%d / %d", server->clients, server->max_clients));
   setLabelText(self->pingLabel, pingUnanswered(server) ? _unset : va("%d ms", server->ping));
 
-  $((View *) self->connectButton, setHidden, false);
+  $((View *) self->connectButton, setVisibility, ViewVisibilityVisible);
 }
 
 /**
@@ -658,8 +660,10 @@ static void reloadServers(JoinServerViewController *self) {
   $(self->servers, sort, comparator);
   sortingJoinServerViewController = NULL;
 
-  $((View *) self->emptyLabel, setHidden, self->servers->count > 0);
-  $((View *) self->serversTableView, setHidden, self->servers->count == 0);
+  $((View *) self->emptyLabel, setVisibility,
+    self->servers->count > 0 ? ViewVisibilityHidden : ViewVisibilityVisible);
+  $((View *) self->serversTableView, setVisibility,
+    self->servers->count == 0 ? ViewVisibilityHidden : ViewVisibilityVisible);
 
   $(self->serversTableView, reloadData);
 

--- a/src/cgame/common/ui/play/MapListCollectionItemView.c
+++ b/src/cgame/common/ui/play/MapListCollectionItemView.c
@@ -34,12 +34,7 @@
  */
 static MapListCollectionItemView *initWithFrame(MapListCollectionItemView *self, const SDL_Rect *frame) {
 
-  self = (MapListCollectionItemView *) super(CollectionItemView, self, initWithFrame, frame);
-  if (self) {
-    self->collectionItemView.text->view.alignment = ViewAlignmentBottomCenter;
-  }
-
-  return self;
+  return (MapListCollectionItemView *) super(CollectionItemView, self, initWithFrame, frame);
 }
 
 /**

--- a/src/cgame/common/ui/play/MapListCollectionView.c
+++ b/src/cgame/common/ui/play/MapListCollectionView.c
@@ -29,6 +29,13 @@
 #define _Class _MapListCollectionView
 
 /**
+ * @brief The mapshot surfaces are scaled once, on the loading thread, so they take a fixed
+ * resolution rather than the item size, which the cascade owns and which that thread may not read.
+ */
+#define MAPSHOT_WIDTH  420
+#define MAPSHOT_HEIGHT 236
+
+/**
  * @brief PointerArray destroy function for MapListItemInfo.
  */
 static void freeMapListItemInfo(void *p) {
@@ -191,7 +198,7 @@ static void enumerateMaps(const char *path, void *data) {
 
         SDL_Surface *surf = mapshot ? cgi.LoadSurface(mapshot) : NULL;
         if (surf) {
-          info->mapshot = SDL_CreateSurface(this->collectionView.itemSize.w, this->collectionView.itemSize.h, SDL_PIXELFORMAT_RGB24);
+          info->mapshot = SDL_CreateSurface(MAPSHOT_WIDTH, MAPSHOT_HEIGHT, SDL_PIXELFORMAT_RGB24);
           SDL_BlitSurfaceScaled(surf, NULL, info->mapshot, NULL, SDL_SCALEMODE_LINEAR);
         } else {
           info->mapshot = NULL;
@@ -284,8 +291,6 @@ static MapListCollectionView *initWithFrame(MapListCollectionView *self, const S
     self->collectionView.dataSource.numberOfItems = numberOfItems;
     self->collectionView.dataSource.objectForItemAtIndexPath = objectForItemAtIndexPath;
     self->collectionView.delegate.itemForObjectAtIndexPath = itemForObjectAtIndexPath;
-
-    self->collectionView.itemSize = MakeSize(420, 236);
   }
 
   return self;

--- a/src/cgame/common/ui/play/PlayerSetupViewController.c
+++ b/src/cgame/common/ui/play/PlayerSetupViewController.c
@@ -111,7 +111,8 @@ static void didPickEffectColor(HueColorPicker *hueColorPicker, double hue, doubl
   if (hue < 0.0) {
     cgi.SetCvarString(cg_color->name, "default");
 
-    this->effectsColorPicker->colorView->backgroundColor = Colors.Charcoal;
+    $(this->effectsColorPicker->colorView->style, addColorAttribute, "background-color", &Colors.Charcoal);
+    $(this->effectsColorPicker->colorView, invalidateStyle);
 
     $(this->effectsColorPicker->hueSlider->label, setText, "");
   } else {
@@ -139,7 +140,8 @@ static void didPickPlayerColor(HSVColorPicker *hsvColorPicker, double hue, doubl
   if (hue < 0.0) {
     cgi.SetCvarString(var->name, "default");
 
-    hsvColorPicker->colorView->backgroundColor = Colors.Charcoal;
+    $(hsvColorPicker->colorView->style, addColorAttribute, "background-color", &Colors.Charcoal);
+    $(hsvColorPicker->colorView, invalidateStyle);
 
     $(hsvColorPicker->hueSlider->label, setText, "");
   } else {

--- a/src/cgame/common/ui/teams/TeamsViewController.json
+++ b/src/cgame/common/ui/teams/TeamsViewController.json
@@ -14,7 +14,7 @@
   },
   "accessoryView": {
     "style": {
-      "hidden": false
+      "visibility": "visible"
   },
   "subviews": [
       {

--- a/src/cgame/common/ui/vote/VoteViewController.c
+++ b/src/cgame/common/ui/vote/VoteViewController.c
@@ -46,9 +46,12 @@ static void didSelectType(Select *select, Option *option) {
   VoteViewController *this = select->delegate.self;
   const vote_type_t *type = option->value;
 
-  $(((View *) this->map)->superview, setHidden, type->arg != VOTE_ARG_MAP);
-  $(((View *) this->client)->superview, setHidden, type->arg != VOTE_ARG_CLIENT);
-  $(((View *) this->value)->superview, setHidden, type->arg != VOTE_ARG_INTEGER);
+  $(((View *) this->map)->superview, setVisibility,
+    type->arg != VOTE_ARG_MAP ? ViewVisibilityHidden : ViewVisibilityVisible);
+  $(((View *) this->client)->superview, setVisibility,
+    type->arg != VOTE_ARG_CLIENT ? ViewVisibilityHidden : ViewVisibilityVisible);
+  $(((View *) this->value)->superview, setVisibility,
+    type->arg != VOTE_ARG_INTEGER ? ViewVisibilityHidden : ViewVisibilityVisible);
 
   if (type->arg == VOTE_ARG_INTEGER) {
     this->value->min = type->min;
@@ -138,8 +141,8 @@ static void refreshStatus(VoteViewController *this) {
     $(this->status->text, setText, "No vote is in progress");
   }
 
-  $((View *) this->yes, setHidden, !active);
-  $((View *) this->no, setHidden, !active);
+  $((View *) this->yes, setVisibility, active ? ViewVisibilityVisible : ViewVisibilityHidden);
+  $((View *) this->no, setVisibility, active ? ViewVisibilityVisible : ViewVisibilityHidden);
 }
 
 #pragma mark - ViewController

--- a/src/cgame/common/ui/vote/VoteViewController.json
+++ b/src/cgame/common/ui/vote/VoteViewController.json
@@ -107,7 +107,7 @@
   },
   "accessoryView": {
     "style": {
-      "hidden": false
+      "visibility": "visible"
     },
     "subviews": [
       {

--- a/src/client/cl_cgame.c
+++ b/src/client/cl_cgame.c
@@ -197,6 +197,7 @@ void Cl_InitCgame(void) {
     import.restClient = client;
   }
 
+  import.StatFile = Fs_Stat;
   import.OpenFile = Fs_OpenRead;
   import.SeekFile = Fs_Seek;
   import.ReadFile = Fs_Read;
@@ -206,7 +207,6 @@ void Cl_InitCgame(void) {
   import.LoadFile = Fs_Load;
   import.FreeFile = Fs_Free;
   import.EnumerateFiles = Fs_Enumerate;
-  import.FileExists = Fs_Exists;
 
   import.AddCvar = Cvar_Add;
   import.GetCvar = Cvar_Get;

--- a/src/client/ui/ConsoleView.c
+++ b/src/client/ui/ConsoleView.c
@@ -55,8 +55,7 @@ static Text *addText(View *view, ViewAlignment alignment) {
   Text *text = $(alloc(Text), initWithText, NULL, NULL);
   assert(text);
 
-  text->view.alignment = alignment;
-
+  $(text->view.style, addEnumAttribute, "alignment", ViewAlignmentNames, alignment);
   $(text->view.style, addCharactersAttribute, "font-family", DEFAULT_MONOSPACE_FONT_FAMILY);
   $(text->view.style, addIntegerAttribute, "font-size", CONSOLE_FONT_SIZE);
 
@@ -74,15 +73,16 @@ static View *init(View *self) {
   if (self) {
     ConsoleView *this = (ConsoleView *) self;
 
-    self->autoresizingMask = ViewAutoresizingWidth;
-    self->clipsSubviews = true;
+    $(self->style, addEnumAttribute, "autoresizing-mask", ViewAutoresizingNames, ViewAutoresizingWidth);
+    $(self->style, addBoolAttribute, "clips-subviews", true);
 
     Image *conback = $$(Image, imageWithResourceName, "ui/conback.png");
     if (conback) {
       this->background = $(alloc(ImageView), initWithImage, conback);
       assert(this->background);
 
-      this->background->view.alignment = ViewAlignmentInternal;
+      $(this->background->view.style, addEnumAttribute, "alignment", ViewAlignmentNames,
+        ViewAlignmentInternal);
 
       $(self, addSubview, (View *) this->background);
       release(conback);
@@ -217,15 +217,13 @@ static void update(ConsoleView *self, int32_t height) {
     }
   } else if (view->backgroundColor.a != alpha) {
     const SDL_Color color = { 0, 0, 0, alpha };
-    view->backgroundColor = color;
     $(view->style, addColorAttribute, "background-color", &color);
+    $(view, invalidateStyle);
   }
 
   if (view->padding.bottom != ch.h) {
-    const SDL_Rect padding = MakeRect(0, 1, ch.h, 1);
-    view->padding = MakePadding(0, 1, ch.h, 1);
-    $(view->style, addRectangleAttribute, "padding", &padding);
-    $(view, setNeedsLayout);
+    $(view->style, addRectangleAttribute, "padding", &MakeRect(0, 1, ch.h, 1));
+    $(view, invalidateStyle);
   }
 
   tail(&cl_console, cl_console.height, self->buffer);

--- a/src/client/ui/ConsoleViewController.c
+++ b/src/client/ui/ConsoleViewController.c
@@ -49,7 +49,8 @@ static void loadView(ViewController *self) {
 
   super(ViewController, self, loadView);
 
-  self->view->pointerEvents = false;
+  $(self->view->style, addEnumAttribute, "pointer-events", ViewPointerEventsNames,
+    ViewPointerEventsNone);
 
   ConsoleViewController *this = (ConsoleViewController *) self;
 

--- a/src/client/ui/ConsoleViewController.c
+++ b/src/client/ui/ConsoleViewController.c
@@ -71,7 +71,7 @@ static void update(ConsoleViewController *self) {
 
   const bool console = cls.key_state.dest == KEY_CONSOLE && cls.state != CL_LOADING;
 
-  $(view, setHidden, !console);
+  $(view, setVisibility, console ? ViewVisibilityVisible : ViewVisibilityHidden);
 
   if (console) {
     const int32_t height = self->viewController.view->frame.h;

--- a/src/client/ui/ui_main.c
+++ b/src/client/ui/ui_main.c
@@ -300,7 +300,8 @@ void Ui_Init(void) {
 
   hudLayer = $(alloc(ViewController), init);
   $(rootViewController, addChildViewController, hudLayer);
-  hudLayer->view->pointerEvents = false;
+  $(hudLayer->view->style, addEnumAttribute, "pointer-events", ViewPointerEventsNames,
+    ViewPointerEventsNone);
 
   navigationViewController = $(alloc(NavigationViewController), init);
   $(rootViewController, addChildViewController, (ViewController *) navigationViewController);

--- a/src/client/ui/ui_main.c
+++ b/src/client/ui/ui_main.c
@@ -189,8 +189,9 @@ void Ui_Draw(void) {
   const bool hud = cls.state == CL_ACTIVE && dest != KEY_UI;
   const bool menus = dest == KEY_UI || cls.state == CL_LOADING || (cls.state != CL_ACTIVE && dest != KEY_CONSOLE);
 
-  $(hudLayer->view, setHidden, !hud);
-  $(navigationViewController->viewController.view, setHidden, !menus);
+  $(hudLayer->view, setVisibility, hud ? ViewVisibilityVisible : ViewVisibilityHidden);
+  $(navigationViewController->viewController.view, setVisibility,
+    menus ? ViewVisibilityVisible : ViewVisibilityHidden);
 
   $(consoleViewController, update);
 

--- a/src/common/filesystem.c
+++ b/src/common/filesystem.c
@@ -172,7 +172,7 @@ bool Fs_Eof(file_t *file) {
  * @return True if the specified filename exists on the search path.
  */
 bool Fs_Exists(const char *filename) {
-  return PHYSFS_exists(filename) ? true : false;
+  return Fs_Stat(filename, NULL);
 }
 
 /**
@@ -180,6 +180,36 @@ bool Fs_Exists(const char *filename) {
  */
 bool Fs_Flush(file_t *file) {
   return PHYSFS_flush((PHYSFS_File *) file) ? true : false;
+}
+
+/**
+ * @brief Performs a @c stat on the given filename.
+ * @param filename The filename.
+ * @param out The @c fs_stat_t.
+ * @return True if the @c stat was successful, false otherwise.
+ */
+bool Fs_Stat(const char *filename, fs_stat_t *out) {
+
+  PHYSFS_Stat s;
+  if (PHYSFS_stat(filename, &s)) {
+    if (out) {
+      out->type = (fs_file_type_t) s.filetype;
+      out->size = s.filesize;
+      out->created = s.createtime;
+      out->modified = s.modtime;
+      out->accessed = s.accesstime;
+    }
+    return true;
+  } else {
+    if (out) {
+      out->type = FS_UNKNOWN;
+      out->size = -1;
+      out->created = -1;
+      out->modified = -1;
+      out->accessed = -1;
+    }
+    return false;
+  }
 }
 
 /**

--- a/src/common/filesystem.h
+++ b/src/common/filesystem.h
@@ -23,6 +23,28 @@
 
 #include "common.h"
 
+/**
+ * @brief The @c Fs_Stat file types.
+ */
+typedef enum {
+  FS_UNKNOWN = -1,
+  FS_REGULAR,
+  FS_DIRECTORY,
+  FS_SYMLINK,
+  FS_OTHER,
+} fs_file_type_t;
+
+/**
+ * @brief The @c Fs_Stat return type.
+ */
+typedef struct {
+  fs_file_type_t type;
+  int64_t size;
+  int64_t created;
+  int64_t modified;
+  int64_t accessed;
+} fs_stat_t;
+
 const char *Fs_BaseDir(void);
 const char *Fs_BinDir(void);
 const char *Fs_LibDir(void);
@@ -32,6 +54,7 @@ bool Fs_Delete(const char *filename);
 bool Fs_Eof(file_t *file);
 bool Fs_Exists(const char *filename);
 bool Fs_Flush(file_t *file);
+bool Fs_Stat(const char *filename, fs_stat_t *out);
 const char *Fs_LastError(void);
 bool Fs_Mkdir(const char *dir);
 file_t *Fs_OpenAppend(const char *filename);


### PR DESCRIPTION
This pull request introduces several improvements and refactorings related to file handling, UI consistency, and HUD selection in the client game codebase. The most significant changes include replacing the file existence check with a more robust file stat function, updating the UI and code to support HUD selection, and standardizing UI property usage and naming for clarity and maintainability.

**File handling improvements:**

* Added a new `StatFile` function to the `cg_import_s` struct in `cgame.h`, replacing the previous `FileExists` function for more robust file and directory checks. Updated all relevant usages to use `StatFile` instead of `FileExists`. (`src/cgame/cgame.h`, `src/cgame/common/cg_client.c`, [[1]](diffhunk://#diff-58de0d93f0a39ba59bc9a688f6e02832dfbe837b1ba32fe6245ea2fc2cea7df9R184-R191) [[2]](diffhunk://#diff-58de0d93f0a39ba59bc9a688f6e02832dfbe837b1ba32fe6245ea2fc2cea7df9L253-L258) [[3]](diffhunk://#diff-a6b26e728faa81028673e1c3f4efc75e7314afb64f74a5eb6d751168815a9a9aL379-R379)
* Updated the `OBJECTIVELYMVC` dependency to require version 2.5.0 or higher in `configure.ac`. (`configure.ac`, [configure.acL180-R180](diffhunk://#diff-49473dca262eeab3b4a43002adb08b4db31020d190caaad1594b47f1d5daa810L180-R180))
* Increased the `CGAME_API_VERSION` from 44 to 45 to reflect API changes. (`src/cgame/cgame.h`, [src/cgame/cgame.hL40-R40](diffhunk://#diff-58de0d93f0a39ba59bc9a688f6e02832dfbe837b1ba32fe6245ea2fc2cea7df9L40-R40))

**HUD selection feature:**

* Added support for selecting HUDs in the UI: introduced a new HUD select control in the JSON layout, corresponding struct member, and logic to enumerate available HUDs using the new `StatFile` function. (`src/cgame/common/ui/controls/ResponseServiceViewController.c`, `src/cgame/common/ui/controls/ResponseServiceViewController.h`, `src/cgame/common/ui/controls/ResponseServiceViewController.json`, [[1]](diffhunk://#diff-49bc1ea1e8575c6f7bec022d8afcc06b61d0bd6e81b8d9df8492f88183055aebR139-R164) [[2]](diffhunk://#diff-8d038724706a2cecdb2638a1d35adea4ec6bad0a281e02dab3cea6baa218dc78R77-R81) [[3]](diffhunk://#diff-03393f958cce8d21f14482f2868e5b352c83c74f6e3f5b9562e9441b93e8bcb3R264-R289)

**UI and UX consistency:**

* Updated UI element identifiers for clarity (e.g., renamed `crosshair` to `crosshairSelect` in code and JSON). (`src/cgame/common/ui/controls/ResponseServiceViewController.c`, `src/cgame/common/ui/controls/ResponseServiceViewController.json`, [[1]](diffhunk://#diff-49bc1ea1e8575c6f7bec022d8afcc06b61d0bd6e81b8d9df8492f88183055aebL155-R188) [[2]](diffhunk://#diff-03393f958cce8d21f14482f2868e5b352c83c74f6e3f5b9562e9441b93e8bcb3L172-R172)
* Standardized the use of visibility properties in CSS and UI code, replacing deprecated or inconsistent usage (e.g., `hidden` to `visibility`, and `setHidden` to `setVisibility`). (`src/cgame/common/ui/DialogViewController.css`, `src/cgame/common/cg_ctf.c`, [[1]](diffhunk://#diff-304bb7c39cf251bcb3e865737ea9aa28f558250295370e1b4e7cba2cb10e78eaL21-R21) [[2]](diffhunk://#diff-4f1087241e7ef936de1cf050c15cae0a954f508371dff955b44ca616e4329ccbL66-R66)
* Added and updated default style rules for various UI components to improve maintainability and ensure consistent layouts across the HUD and scoreboard. (`src/cgame/common/ui/common.css`, [[1]](diffhunk://#diff-9eaebf4d71d0cd2f3c4d4e475120f5746bc598f0f27d7eff52f4df24c94cef2aR46-R50) [[2]](diffhunk://#diff-9eaebf4d71d0cd2f3c4d4e475120f5746bc598f0f27d7eff52f4df24c94cef2aL114-L121) [[3]](diffhunk://#diff-9eaebf4d71d0cd2f3c4d4e475120f5746bc598f0f27d7eff52f4df24c94cef2aR129-R246)

**Code and documentation cleanup:**

* Refactored and simplified the `CvarSelect` class implementation for better clarity and to remove unnecessary delegate indirection. (`src/cgame/common/ui/CvarSelect.c`, [[1]](diffhunk://#diff-8c28595c95ded382afa9e5b4d9fd51ba7e601444e5cabab0d5467bca1bfc44ceL80-R94) [[2]](diffhunk://#diff-8c28595c95ded382afa9e5b4d9fd51ba7e601444e5cabab0d5467bca1bfc44ceR106-R108) [[3]](diffhunk://#diff-8c28595c95ded382afa9e5b4d9fd51ba7e601444e5cabab0d5467bca1bfc44ceL136-L138) [[4]](diffhunk://#diff-8c28595c95ded382afa9e5b4d9fd51ba7e601444e5cabab0d5467bca1bfc44ceL164-R145)
* Improved code documentation for callback and delegate functions, ensuring consistent use of `@c` for type references and clarifying descriptions. (`src/cgame/common/ui/controls/ResponseServiceViewController.c`, [[1]](diffhunk://#diff-49bc1ea1e8575c6f7bec022d8afcc06b61d0bd6e81b8d9df8492f88183055aebL31-R31) [[2]](diffhunk://#diff-49bc1ea1e8575c6f7bec022d8afcc06b61d0bd6e81b8d9df8492f88183055aebL56-R56) [[3]](diffhunk://#diff-49bc1ea1e8575c6f7bec022d8afcc06b61d0bd6e81b8d9df8492f88183055aebL67-R67) [[4]](diffhunk://#diff-49bc1ea1e8575c6f7bec022d8afcc06b61d0bd6e81b8d9df8492f88183055aebL88-R89) [[5]](diffhunk://#diff-49bc1ea1e8575c6f7bec022d8afcc06b61d0bd6e81b8d9df8492f88183055aebL98-R99) [[6]](diffhunk://#diff-49bc1ea1e8575c6f7bec022d8afcc06b61d0bd6e81b8d9df8492f88183055aebL108-R109) [[7]](diffhunk://#diff-49bc1ea1e8575c6f7bec022d8afcc06b61d0bd6e81b8d9df8492f88183055aebL118-R119) [[8]](diffhunk://#diff-49bc1ea1e8575c6f7bec022d8afcc06b61d0bd6e81b8d9df8492f88183055aebL128-R129)

**Test and scheme updates:**

* Disabled the `+map edge` command line argument in the `quetoo-all.xcscheme` file, likely to prevent automatic map loading during certain builds or test runs. (`Quetoo.xcodeproj/xcshareddata/xcschemes/quetoo-all.xcscheme`, [Quetoo.xcodeproj/xcshareddata/xcschemes/quetoo-all.xcschemeL153-R153](diffhunk://#diff-50f9d3bd5f0702ba0d4c9af760765da220446599e0bfc36bd29a54287252bc4eL153-R153))