### PR TITLE
Binary self-update in installer.c

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -181,6 +181,12 @@ jobs:
       run: make -C quetoo/apple notarize \
              SNAPSHOT=$(pwd)/quetoo-arm64-apple-darwin.dmg
 
+    - name: Build itch.io archive
+      run: |
+        mkdir itch && cp -R quetoo/apple/target/Quetoo.app itch/
+        touch itch/.managed
+        cd itch && zip -qry ../quetoo-itch-arm64-apple-darwin.zip . && cd ..
+
     - name: Tear down keychain
       if: always()
       run: security delete-keychain build.keychain || true
@@ -190,6 +196,12 @@ jobs:
       with:
         name: quetoo-arm64-apple-darwin
         path: quetoo-arm64-apple-darwin.dmg
+
+    - name: Upload itch.io archive artifact
+      uses: actions/upload-artifact@v7
+      with:
+        name: quetoo-itch-arm64-apple-darwin
+        path: quetoo-itch-arm64-apple-darwin.zip
 
   build-linux:
     needs: resolve-deps
@@ -607,11 +619,12 @@ jobs:
 
     steps:
     # The engine archives, not the old data-bundled ones: game content is
-    # fetched on first launch now, so there is nothing left to bundle.
+    # fetched to the user's own directory on first launch, so there is nothing
+    # left to bundle and nothing here for itch to manage but the engine.
     - name: Download macOS build
       uses: actions/download-artifact@v8
       with:
-        name: quetoo-arm64-apple-darwin
+        name: quetoo-itch-arm64-apple-darwin
         path: itch/mac
 
     - name: Download Linux x86_64 build
@@ -626,6 +639,22 @@ jobs:
         name: quetoo-x86_64-pc-windows
         path: itch/windows
 
+    # itch patches the installation it created, so the engine must not also
+    # update itself there. The marker tells it not to; game content is
+    # unaffected, living in the user's directory rather than the install.
+    - name: Mark builds as externally managed
+      run: |
+        touch .managed
+
+        cd itch/windows
+        zip -q quetoo-x86_64-pc-windows.zip ../../.managed --junk-paths
+        cd ../..
+
+        mkdir linux-stage
+        tar xzf itch/linux/quetoo-x86_64-pc-linux.tar.gz -C linux-stage
+        touch linux-stage/quetoo/.managed
+        tar czf itch/linux/quetoo-x86_64-pc-linux.tar.gz -C linux-stage quetoo/
+
     - name: Install Butler
       run: |
         curl --fail --location --retry 5 --retry-all-errors \
@@ -638,6 +667,6 @@ jobs:
         BUTLER_API_KEY: ${{ secrets.BUTLER_API_KEY }}
         VERSION: ${{ github.event.inputs.version || github.ref_name }}
       run: |
-        ./butler push itch/mac/quetoo-arm64-apple-darwin.dmg        wickedoldgames/quetoo:mac     --userversion $VERSION
+        ./butler push itch/mac/quetoo-itch-arm64-apple-darwin.zip   wickedoldgames/quetoo:mac     --userversion $VERSION
         ./butler push itch/linux/quetoo-x86_64-pc-linux.tar.gz      wickedoldgames/quetoo:linux   --userversion $VERSION
         ./butler push itch/windows/quetoo-x86_64-pc-windows.zip     wickedoldgames/quetoo:windows --userversion $VERSION

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -181,35 +181,6 @@ jobs:
       run: make -C quetoo/apple notarize \
              SNAPSHOT=$(pwd)/quetoo-arm64-apple-darwin.dmg
 
-    - name: Checkout quetoo-data
-      uses: actions/checkout@v6
-      with:
-        repository: jdolan/quetoo-data
-        path: quetoo-data
-        fetch-depth: 1
-        sparse-checkout: target
-
-    - name: Bundle game data
-      run: make -C quetoo/apple bundle-data \
-             QUETOO_DATA_DIR=$(pwd)/quetoo-data
-
-    - name: Re-sign bundle
-      run: |
-        security unlock-keychain -p "$KEYCHAIN_PASSWORD" build.keychain
-        make -C quetoo/apple bundle-sign
-
-    - name: Create bundle DMG
-      run: make -C quetoo/apple bundle-dmg \
-             BUNDLE_SNAPSHOT=$(pwd)/quetoo-bundle-arm64-apple-darwin.dmg
-
-    - name: Notarize bundle DMG
-      env:
-        APPLE_ID: ${{ secrets.APPLE_ID }}
-        APPLE_APP_PASSWORD: ${{ secrets.APPLE_APP_PASSWORD }}
-        APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-      run: make -C quetoo/apple bundle-notarize \
-             BUNDLE_SNAPSHOT=$(pwd)/quetoo-bundle-arm64-apple-darwin.dmg
-
     - name: Tear down keychain
       if: always()
       run: security delete-keychain build.keychain || true
@@ -219,12 +190,6 @@ jobs:
       with:
         name: quetoo-arm64-apple-darwin
         path: quetoo-arm64-apple-darwin.dmg
-
-    - name: Upload bundle artifact
-      uses: actions/upload-artifact@v7
-      with:
-        name: quetoo-bundle-arm64-apple-darwin
-        path: quetoo-bundle-arm64-apple-darwin.dmg
 
   build-linux:
     needs: resolve-deps
@@ -554,49 +519,6 @@ jobs:
         # correct update checks. Safe to remove once those have aged out.
         aws s3 cp build s3://quetoo/version
 
-    - name: Checkout quetoo-data
-      uses: actions/checkout@v6
-      with:
-        repository: jdolan/quetoo-data
-        path: quetoo-data
-        fetch-depth: 1
-        sparse-checkout: target
-
-    - name: Create bundles
-      run: |
-        # Linux bundle: extract archive, inject data into quetoo/share/quetoo/default/, repack
-        mkdir -p quetoo-bundle-linux-x86_64
-        tar xzf quetoo-x86_64-pc-linux-archive/quetoo-x86_64-pc-linux.tar.gz -C quetoo-bundle-linux-x86_64
-        mkdir -p quetoo-bundle-linux-x86_64/quetoo/share/quetoo/default
-        cp -r quetoo-data/target/default/. quetoo-bundle-linux-x86_64/quetoo/share/quetoo/default/
-        tar czf quetoo-bundle-x86_64-pc-linux.tar.gz -C quetoo-bundle-linux-x86_64 quetoo/
-
-        mkdir -p quetoo-bundle-linux-aarch64
-        tar xzf quetoo-aarch64-pc-linux-archive/quetoo-aarch64-pc-linux.tar.gz -C quetoo-bundle-linux-aarch64
-        mkdir -p quetoo-bundle-linux-aarch64/quetoo/share/quetoo/default
-        cp -r quetoo-data/target/default/. quetoo-bundle-linux-aarch64/quetoo/share/quetoo/default/
-        tar czf quetoo-bundle-aarch64-pc-linux.tar.gz -C quetoo-bundle-linux-aarch64 quetoo/
-
-        # Windows bundle: data as share/default/ alongside bin/ and lib/
-        mkdir bundle-windows && cd bundle-windows
-        unzip ../quetoo-x86_64-pc-windows/quetoo-x86_64-pc-windows.zip
-        mkdir -p share/default
-        cp -r ../quetoo-data/target/default/. share/default/
-        zip -r ../quetoo-bundle-x86_64-pc-windows.zip .
-        cd ..
-
-    - name: Upload Linux x86_64 bundle artifact
-      uses: actions/upload-artifact@v7
-      with:
-        name: quetoo-bundle-x86_64-pc-linux
-        path: quetoo-bundle-x86_64-pc-linux.tar.gz
-
-    - name: Upload Windows bundle artifact
-      uses: actions/upload-artifact@v7
-      with:
-        name: quetoo-bundle-x86_64-pc-windows
-        path: quetoo-bundle-x86_64-pc-windows.zip
-
     - name: Create versioned release
       env:
         GH_TOKEN: ${{ github.token }}
@@ -624,22 +546,19 @@ jobs:
 
         | Type | Link |
         |---|---|
-        | Full Install | [quetoo-bundle-x86_64-pc-windows.zip](https://github.com/${{ github.repository }}/releases/download/$VERSION/quetoo-bundle-x86_64-pc-windows.zip) |
-        | Binaries Only | [quetoo-x86_64-pc-windows.zip](https://github.com/${{ github.repository }}/releases/download/$VERSION/quetoo-x86_64-pc-windows.zip) |
+        | Download | [quetoo-x86_64-pc-windows.zip](https://github.com/${{ github.repository }}/releases/download/$VERSION/quetoo-x86_64-pc-windows.zip) |
 
         ## ![macOS](https://img.shields.io/badge/-%20-A2AAAD?style=flat-square&logo=apple&logoColor=white) macOS
 
         | Type | Apple Silicon |
         |---|---|
-        | Full Install | [quetoo-bundle-arm64-apple-darwin.dmg](https://github.com/${{ github.repository }}/releases/download/$VERSION/quetoo-bundle-arm64-apple-darwin.dmg) |
-        | Binaries Only | [quetoo-arm64-apple-darwin.dmg](https://github.com/${{ github.repository }}/releases/download/$VERSION/quetoo-arm64-apple-darwin.dmg) |
+        | Download | [quetoo-arm64-apple-darwin.dmg](https://github.com/${{ github.repository }}/releases/download/$VERSION/quetoo-arm64-apple-darwin.dmg) |
 
         ## ![Linux](https://img.shields.io/badge/-%20-FCC624?style=flat-square&logo=linux&logoColor=black) Linux
 
         | Type | x86-64 | arm64 |
         |---|---|---|
-        | Full Install (.tar.gz bundle) | [quetoo-bundle-x86_64-pc-linux.tar.gz](https://github.com/${{ github.repository }}/releases/download/$VERSION/quetoo-bundle-x86_64-pc-linux.tar.gz) | [quetoo-bundle-aarch64-pc-linux.tar.gz](https://github.com/${{ github.repository }}/releases/download/$VERSION/quetoo-bundle-aarch64-pc-linux.tar.gz) |
-        | Binaries Only (.tar.gz) | [quetoo-x86_64-pc-linux.tar.gz](https://github.com/${{ github.repository }}/releases/download/$VERSION/quetoo-x86_64-pc-linux.tar.gz) | [quetoo-aarch64-pc-linux.tar.gz](https://github.com/${{ github.repository }}/releases/download/$VERSION/quetoo-aarch64-pc-linux.tar.gz) |
+        | Download (.tar.gz) | [quetoo-x86_64-pc-linux.tar.gz](https://github.com/${{ github.repository }}/releases/download/$VERSION/quetoo-x86_64-pc-linux.tar.gz) | [quetoo-aarch64-pc-linux.tar.gz](https://github.com/${{ github.repository }}/releases/download/$VERSION/quetoo-aarch64-pc-linux.tar.gz) |
 
         ## ![Linux](https://img.shields.io/badge/-%20-FCC624?style=flat-square&logo=linux&logoColor=black) ![Debian](https://img.shields.io/badge/-%20-A81D33?style=flat-square&logo=debian&logoColor=white) ![Red Hat](https://img.shields.io/badge/-%20-EE0000?style=flat-square&logo=redhat&logoColor=white) Linux Packages (requires [quetoo-data](https://github.com/jdolan/quetoo-data/releases))
 
@@ -650,6 +569,10 @@ jobs:
         | Server .deb | [quetoo-server-x86_64-pc-linux.deb](https://github.com/${{ github.repository }}/releases/download/$VERSION/quetoo-server-x86_64-pc-linux.deb) | [quetoo-server-aarch64-pc-linux.deb](https://github.com/${{ github.repository }}/releases/download/$VERSION/quetoo-server-aarch64-pc-linux.deb) |
         | Server .rpm | [quetoo-server-x86_64-pc-linux.rpm](https://github.com/${{ github.repository }}/releases/download/$VERSION/quetoo-server-x86_64-pc-linux.rpm) | [quetoo-server-aarch64-pc-linux.rpm](https://github.com/${{ github.repository }}/releases/download/$VERSION/quetoo-server-aarch64-pc-linux.rpm) |
 
+        Game content is downloaded on first launch and kept up to date
+        automatically. Engine updates download in the background and are applied
+        when you quit.
+
         ## Changelog
 
         $changelog
@@ -657,10 +580,6 @@ jobs:
         )
 
         assets=(
-          quetoo-bundle-arm64-apple-darwin/quetoo-bundle-arm64-apple-darwin.dmg
-          quetoo-bundle-x86_64-pc-linux.tar.gz
-          quetoo-bundle-aarch64-pc-linux.tar.gz
-          quetoo-bundle-x86_64-pc-windows.zip
           quetoo-arm64-apple-darwin/quetoo-arm64-apple-darwin.dmg
           quetoo-x86_64-pc-linux-archive/quetoo-x86_64-pc-linux.tar.gz
           quetoo-x86_64-pc-linux-deb/quetoo-client-x86_64-pc-linux.deb
@@ -687,22 +606,24 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Download macOS bundle
+    # The engine archives, not the old data-bundled ones: game content is
+    # fetched on first launch now, so there is nothing left to bundle.
+    - name: Download macOS build
       uses: actions/download-artifact@v8
       with:
-        name: quetoo-bundle-arm64-apple-darwin
+        name: quetoo-arm64-apple-darwin
         path: itch/mac
 
-    - name: Download Linux x86_64 bundle
+    - name: Download Linux x86_64 build
       uses: actions/download-artifact@v8
       with:
-        name: quetoo-bundle-x86_64-pc-linux
+        name: quetoo-x86_64-pc-linux-archive
         path: itch/linux
 
-    - name: Download Windows bundle
+    - name: Download Windows build
       uses: actions/download-artifact@v8
       with:
-        name: quetoo-bundle-x86_64-pc-windows
+        name: quetoo-x86_64-pc-windows
         path: itch/windows
 
     - name: Install Butler
@@ -717,6 +638,6 @@ jobs:
         BUTLER_API_KEY: ${{ secrets.BUTLER_API_KEY }}
         VERSION: ${{ github.event.inputs.version || github.ref_name }}
       run: |
-        ./butler push itch/mac/quetoo-bundle-arm64-apple-darwin.dmg        wickedoldgames/quetoo:mac     --userversion $VERSION
-        ./butler push itch/linux/quetoo-bundle-x86_64-pc-linux.tar.gz      wickedoldgames/quetoo:linux   --userversion $VERSION
-        ./butler push itch/windows/quetoo-bundle-x86_64-pc-windows.zip     wickedoldgames/quetoo:windows --userversion $VERSION
+        ./butler push itch/mac/quetoo-arm64-apple-darwin.dmg        wickedoldgames/quetoo:mac     --userversion $VERSION
+        ./butler push itch/linux/quetoo-x86_64-pc-linux.tar.gz      wickedoldgames/quetoo:linux   --userversion $VERSION
+        ./butler push itch/windows/quetoo-x86_64-pc-windows.zip     wickedoldgames/quetoo:windows --userversion $VERSION

--- a/Quetoo.vs15/libs/libcommon.vcxproj
+++ b/Quetoo.vs15/libs/libcommon.vcxproj
@@ -19,6 +19,8 @@
     </ProjectConfiguration>
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="..\..\deps\minizip\miniz.c" />
+    <ClCompile Include="..\..\src\common\archive.c" />
     <ClCompile Include="..\..\src\common\atlas.c" />
     <ClCompile Include="..\..\src\common\cmd.c" />
     <ClCompile Include="..\..\src\common\common.c" />
@@ -34,6 +36,7 @@
     <ClCompile Include="..\..\src\common\thread.c" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="..\..\src\common\archive.h" />
     <ClInclude Include="..\..\src\common\atlas.h" />
     <ClInclude Include="..\..\src\common\cmd.h" />
     <ClInclude Include="..\..\src\common\common.h" />

--- a/Quetoo.vs15/libs/libcommon.vcxproj.filters
+++ b/Quetoo.vs15/libs/libcommon.vcxproj.filters
@@ -30,6 +30,12 @@
     <ClCompile Include="..\..\src\common\image.c">
       <Filter>src\common</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\common\archive.c">
+      <Filter>src\common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\deps\minizip\miniz.c">
+      <Filter>src\common</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\src\common\installer.c">
       <Filter>src\common</Filter>
     </ClCompile>
@@ -72,6 +78,9 @@
       <Filter>src\common</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\common\image.h">
+      <Filter>src\common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\common\archive.h">
       <Filter>src\common</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\common\installer.h">

--- a/Quetoo.vs15/quemap.vcxproj
+++ b/Quetoo.vs15/quemap.vcxproj
@@ -19,7 +19,6 @@
     </ProjectConfiguration>
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="..\deps\minizip\miniz.c" />
     <ClCompile Include="..\src\quemap\brush.c" />
     <ClCompile Include="..\src\quemap\bsp.c" />
     <ClCompile Include="..\src\quemap\csg.c" />

--- a/Quetoo.vs15/quemap.vcxproj.filters
+++ b/Quetoo.vs15/quemap.vcxproj.filters
@@ -24,9 +24,6 @@
     <ClCompile Include="src\main\winmain.c">
       <Filter>src\main</Filter>
     </ClCompile>
-    <ClCompile Include="..\deps\minizip\miniz.c">
-      <Filter>deps\minizip</Filter>
-    </ClCompile>
     <ClCompile Include="..\src\quemap\leakfile.c">
       <Filter>src\quemap</Filter>
     </ClCompile>

--- a/Quetoo.xcodeproj/project.pbxproj
+++ b/Quetoo.xcodeproj/project.pbxproj
@@ -199,6 +199,7 @@
 		CE04F16625CADF6700C31433 /* files.h in Headers */ = {isa = PBXBuildFile; fileRef = CE12D63C1C5C58C300CD0B13 /* files.h */; };
 		CE04F18B25CADF6900C31433 /* filesystem.h in Headers */ = {isa = PBXBuildFile; fileRef = CE12D63E1C5C58C300CD0B13 /* filesystem.h */; };
 		CE04F1B025CADF6C00C31433 /* image.h in Headers */ = {isa = PBXBuildFile; fileRef = CE12D6781C5C58C300CD0B13 /* image.h */; };
+		CEA0B1C32D0000010000A004 /* archive.h in Headers */ = {isa = PBXBuildFile; fileRef = CEA0B1C12D0000010000A002 /* archive.h */; };
 		CE04F1D525CADF6F00C31433 /* installer.h in Headers */ = {isa = PBXBuildFile; fileRef = CEC74B3725C8EE94009C6218 /* installer.h */; };
 		CE04F21E25CADF7700C31433 /* mem_buf.h in Headers */ = {isa = PBXBuildFile; fileRef = CE12D68C1C5C58C300CD0B13 /* mem_buf.h */; };
 		CE04F24325CADF7A00C31433 /* mem.h in Headers */ = {isa = PBXBuildFile; fileRef = CE12D68A1C5C58C300CD0B13 /* mem.h */; };
@@ -206,6 +207,7 @@
 		CE04F28D25CADF7F00C31433 /* thread.h in Headers */ = {isa = PBXBuildFile; fileRef = CE12D6DF1C5C58C300CD0B13 /* thread.h */; };
 		CE04F2B225CADF8D00C31433 /* filesystem.c in Sources */ = {isa = PBXBuildFile; fileRef = CE12D63D1C5C58C300CD0B13 /* filesystem.c */; };
 		CE04F2D725CADF9000C31433 /* image.c in Sources */ = {isa = PBXBuildFile; fileRef = CE12D6771C5C58C300CD0B13 /* image.c */; };
+		CEA0B1C22D0000010000A003 /* archive.c in Sources */ = {isa = PBXBuildFile; fileRef = CEA0B1C02D0000010000A001 /* archive.c */; };
 		CE04F2FC25CADF9300C31433 /* installer.c in Sources */ = {isa = PBXBuildFile; fileRef = CEC74B3825C8EE94009C6218 /* installer.c */; };
 		CE04F32125CADF9800C31433 /* mem_buf.c in Sources */ = {isa = PBXBuildFile; fileRef = CE12D68B1C5C58C300CD0B13 /* mem_buf.c */; };
 		CE04F34625CADF9B00C31433 /* mem.c in Sources */ = {isa = PBXBuildFile; fileRef = CE12D6891C5C58C300CD0B13 /* mem.c */; };
@@ -611,6 +613,23 @@
 		CE7D2C3320310810004BC58E /* SettingsViewController.json in CopyFiles */ = {isa = PBXBuildFile; fileRef = CE7D2C2F20310763004BC58E /* SettingsViewController.json */; };
 		CE7FCDD72596996600E49A2D /* cl_screen.c in Sources */ = {isa = PBXBuildFile; fileRef = CE7FCDD52596996500E49A2D /* cl_screen.c */; };
 		CE7FCDD82596996600E49A2D /* cl_screen.h in Headers */ = {isa = PBXBuildFile; fileRef = CE7FCDD62596996500E49A2D /* cl_screen.h */; };
+		D9A5C2010000000000000001 /* libminizip.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CE12D8111C5C5EF000CD0B13 /* libminizip.a */; };
+		D9A5C2010000000000000002 /* libminizip.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CE12D8111C5C5EF000CD0B13 /* libminizip.a */; };
+		D9A5C2010000000000000003 /* libminizip.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CE12D8111C5C5EF000CD0B13 /* libminizip.a */; };
+		D9A5C2010000000000000004 /* libminizip.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CE12D8111C5C5EF000CD0B13 /* libminizip.a */; };
+		D9A5C2010000000000000005 /* libminizip.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CE12D8111C5C5EF000CD0B13 /* libminizip.a */; };
+		D9A5C2010000000000000006 /* libminizip.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CE12D8111C5C5EF000CD0B13 /* libminizip.a */; };
+		D9A5C2010000000000000007 /* libminizip.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CE12D8111C5C5EF000CD0B13 /* libminizip.a */; };
+		D9A5C2010000000000000008 /* libminizip.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CE12D8111C5C5EF000CD0B13 /* libminizip.a */; };
+		D9A5C2010000000000000009 /* libminizip.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CE12D8111C5C5EF000CD0B13 /* libminizip.a */; };
+		D9A5C201000000000000000A /* libminizip.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CE12D8111C5C5EF000CD0B13 /* libminizip.a */; };
+		D9A5C201000000000000000B /* libminizip.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CE12D8111C5C5EF000CD0B13 /* libminizip.a */; };
+		D9A5C201000000000000000C /* libminizip.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CE12D8111C5C5EF000CD0B13 /* libminizip.a */; };
+		D9A5C201000000000000000D /* libminizip.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CE12D8111C5C5EF000CD0B13 /* libminizip.a */; };
+		D9A5C201000000000000000E /* libminizip.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CE12D8111C5C5EF000CD0B13 /* libminizip.a */; };
+		D9A5C201000000000000000F /* libminizip.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CE12D8111C5C5EF000CD0B13 /* libminizip.a */; };
+		D9A5C2010000000000000010 /* libminizip.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CE12D8111C5C5EF000CD0B13 /* libminizip.a */; };
+		D9A5C2010000000000000011 /* libminizip.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CE12D8111C5C5EF000CD0B13 /* libminizip.a */; };
 		CE8000001C5E4D4400A21A51 /* libminizip.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CE12D8111C5C5EF000CD0B13 /* libminizip.a */; };
 		CE8000021C5E4D4400A21A51 /* libshared.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CE80FDD51C5E3D4E00A21A51 /* libshared.a */; };
 		CE80FDB61C5E3D4E00A21A51 /* shared-anorms.c in Sources */ = {isa = PBXBuildFile; fileRef = CE12D6B71C5C58C300CD0B13 /* shared-anorms.c */; };
@@ -2845,6 +2864,8 @@
 		CEC0FF0020260103000000A1 /* cg_module.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = cg_module.c; sourceTree = "<group>"; };
 		CEC0FF0020260103000000EA /* game-ctf.so */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; path = "game-ctf.so"; sourceTree = BUILT_PRODUCTS_DIR; };
 		CEC0FF0020260103000001D4 /* cgame.so */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; name = cgame.so; path = "cgame-ctf.so"; sourceTree = BUILT_PRODUCTS_DIR; };
+		CEA0B1C12D0000010000A002 /* archive.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = archive.h; sourceTree = "<group>"; };
+		CEA0B1C02D0000010000A001 /* archive.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = archive.c; sourceTree = "<group>"; };
 		CEC74B3725C8EE94009C6218 /* installer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = installer.h; sourceTree = "<group>"; };
 		CEC74B3825C8EE94009C6218 /* installer.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = installer.c; sourceTree = "<group>"; };
 		CECA8CAE1E50B5F1005E97E8 /* material.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = material.c; sourceTree = "<group>"; };
@@ -2990,6 +3011,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D9A5C2010000000000000001 /* libminizip.a in Frameworks */,
 				77DC97E1E9FDFCF8FD91B1BC /* SDL3.xcframework in Frameworks */,
 				CED40A703049B36F0090C57A /* Objectively.framework in Frameworks */,
 				CE2B083C23F9EDEA007C77B6 /* libshared.a in Frameworks */,
@@ -3001,6 +3023,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D9A5C2010000000000000002 /* libminizip.a in Frameworks */,
 				3CBF190D5B00F3CCADD14B52 /* SDL3.xcframework in Frameworks */,
 				CED40A713049B3830090C57A /* Objectively.framework in Frameworks */,
 				CE052A88214832E1003446C9 /* libcommon.a in Frameworks */,
@@ -3035,6 +3058,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D9A5C2010000000000000003 /* libminizip.a in Frameworks */,
 				CE12D8F81C5CF97E00CD0B13 /* AppKit.framework in Frameworks */,
 				CE16434A2FF5A12100863996 /* SDL3.xcframework in Frameworks */,
 				CEF601C52FE711B7005C680C /* SDL3_image.xcframework in Frameworks */,
@@ -3088,6 +3112,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D9A5C2010000000000000004 /* libminizip.a in Frameworks */,
 				CE1643982FF5D13D00863996 /* SDL3.xcframework in Frameworks */,
 				CEF601C32FE608D5005C680C /* Objectively.framework in Frameworks */,
 				CE80FFCF1C5E4B9B00A21A51 /* libclient-null.a in Frameworks */,
@@ -3110,6 +3135,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D9A5C2010000000000000005 /* libminizip.a in Frameworks */,
 				B8BC2CE87251BA0975026203 /* SDL3_image.xcframework in Frameworks */,
 				549E7CC4A7BA476A2463B7CC /* SDL3.xcframework in Frameworks */,
 				CED40A733049B3F70090C57A /* Objectively.framework in Frameworks */,
@@ -3122,6 +3148,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D9A5C2010000000000000006 /* libminizip.a in Frameworks */,
 				033334174247678F654646CA /* SDL3.xcframework in Frameworks */,
 				CED40A6D3049B3470090C57A /* Objectively.framework in Frameworks */,
 				CE4DCF97256F0DAD00FECAFC /* libshared.a in Frameworks */,
@@ -3134,6 +3161,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D9A5C2010000000000000007 /* libminizip.a in Frameworks */,
 				FBA34330EDE55ADE01202579 /* SDL3_image.xcframework in Frameworks */,
 				332CAA47FF0E8521C12DF852 /* SDL3.xcframework in Frameworks */,
 				CED40A643049AFD00090C57A /* Objectively.framework in Frameworks */,
@@ -3149,6 +3177,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D9A5C2010000000000000008 /* libminizip.a in Frameworks */,
 				9C43D41506579A6ED4EE80F5 /* SDL3.xcframework in Frameworks */,
 				CED40A673049B0280090C57A /* Objectively.framework in Frameworks */,
 				CE51FBA321481DD300ABE14F /* libcommon.a in Frameworks */,
@@ -3160,6 +3189,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D9A5C2010000000000000009 /* libminizip.a in Frameworks */,
 				AF8056E19DEC77694B63EDD7 /* SDL3.xcframework in Frameworks */,
 				CED40A683049B0540090C57A /* Objectively.framework in Frameworks */,
 				CE2B084D23F9EEBC007C77B6 /* libshared.a in Frameworks */,
@@ -3171,6 +3201,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D9A5C201000000000000000A /* libminizip.a in Frameworks */,
 				4E0DA0FBE7F88EC11A4CF033 /* SDL3.xcframework in Frameworks */,
 				CED40A663049B00C0090C57A /* Objectively.framework in Frameworks */,
 				CE2B084423F9EE46007C77B6 /* libshared.a in Frameworks */,
@@ -3182,6 +3213,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D9A5C201000000000000000B /* libminizip.a in Frameworks */,
 				6B31320926D77CB87B783BDD /* SDL3.xcframework in Frameworks */,
 				CED40A6F3049B3690090C57A /* Objectively.framework in Frameworks */,
 				CE51FC042148213200ABE14F /* libshared.a in Frameworks */,
@@ -3289,6 +3321,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D9A5C201000000000000000C /* libminizip.a in Frameworks */,
 				CE1643992FF5D14900863996 /* SDL3.xcframework in Frameworks */,
 				CEF601C22FE608AF005C680C /* Objectively.framework in Frameworks */,
 				CEFC7A931D9CB75D000FA6B2 /* libcommon.a in Frameworks */,
@@ -3301,6 +3334,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D9A5C201000000000000000D /* libminizip.a in Frameworks */,
 				7857EDF77E5E58CEFFD03198 /* SDL3.xcframework in Frameworks */,
 				CED40A6C3049B3420090C57A /* Objectively.framework in Frameworks */,
 				CEA508FE2EA5D20A00F27205 /* libshared.a in Frameworks */,
@@ -3313,6 +3347,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D9A5C201000000000000000E /* libminizip.a in Frameworks */,
 				B2B62AE1E7C09567B299F1AA /* SDL3.xcframework in Frameworks */,
 				CED40A653049B0040090C57A /* Objectively.framework in Frameworks */,
 				CEAD8F952F8D765F0087A850 /* libshared.a in Frameworks */,
@@ -3325,6 +3360,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D9A5C201000000000000000F /* libminizip.a in Frameworks */,
 				B92B8EA5B4D9C775CF3C2541 /* SDL3.xcframework in Frameworks */,
 				CED40A6B3049B33B0090C57A /* Objectively.framework in Frameworks */,
 				CEAD8FAC2F8D8DE30087A850 /* libshared.a in Frameworks */,
@@ -3382,6 +3418,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D9A5C2010000000000000010 /* libminizip.a in Frameworks */,
 				CF43CA06A122206F8CB8748A /* SDL3.xcframework in Frameworks */,
 				CED40A6A3049B32E0090C57A /* Objectively.framework in Frameworks */,
 				CE2B083823F9ECE1007C77B6 /* libshared.a in Frameworks */,
@@ -3417,6 +3454,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D9A5C2010000000000000011 /* libminizip.a in Frameworks */,
 				D9A5C10000000000000000D0 /* SDL3.xcframework in Frameworks */,
 				D9A5C10000000000000000D1 /* Objectively.framework in Frameworks */,
 				D9A5C10000000000000000D2 /* libshared.a in Frameworks */,
@@ -3574,6 +3612,8 @@
 				CE12D63D1C5C58C300CD0B13 /* filesystem.c */,
 				CE12D6781C5C58C300CD0B13 /* image.h */,
 				CE12D6771C5C58C300CD0B13 /* image.c */,
+				CEA0B1C12D0000010000A002 /* archive.h */,
+				CEA0B1C02D0000010000A001 /* archive.c */,
 				CEC74B3725C8EE94009C6218 /* installer.h */,
 				CEC74B3825C8EE94009C6218 /* installer.c */,
 				CE12D68A1C5C58C300CD0B13 /* mem.h */,
@@ -5134,6 +5174,7 @@
 				CE04F16625CADF6700C31433 /* files.h in Headers */,
 				CE04F18B25CADF6900C31433 /* filesystem.h in Headers */,
 				CE04F1B025CADF6C00C31433 /* image.h in Headers */,
+				CEA0B1C32D0000010000A004 /* archive.h in Headers */,
 				CE04F1D525CADF6F00C31433 /* installer.h in Headers */,
 				CE04F24325CADF7A00C31433 /* mem.h in Headers */,
 				CE04F21E25CADF7700C31433 /* mem_buf.h in Headers */,
@@ -6928,6 +6969,7 @@
 				CE04F11C25CADF5E00C31433 /* cvar.c in Sources */,
 				CE04F2B225CADF8D00C31433 /* filesystem.c in Sources */,
 				CE04F2D725CADF9000C31433 /* image.c in Sources */,
+				CEA0B1C22D0000010000A003 /* archive.c in Sources */,
 				CE04F2FC25CADF9300C31433 /* installer.c in Sources */,
 				CE04F34625CADF9B00C31433 /* mem.c in Sources */,
 				CE04F32125CADF9800C31433 /* mem_buf.c in Sources */,

--- a/Quetoo.xcodeproj/project.pbxproj
+++ b/Quetoo.xcodeproj/project.pbxproj
@@ -67,35 +67,24 @@
 		0789D5943ABEDA1B53B205E2 /* NavEditView.c in Sources */ = {isa = PBXBuildFile; fileRef = 491F54CD554D0F550B000B4E /* NavEditView.c */; };
 		08962C395D0FB0E620F78625 /* bg_item.c in Sources */ = {isa = PBXBuildFile; fileRef = 7966EA6596003F9303BC00FA /* bg_item.c */; };
 		091C43A66A7972053AD1C8E7 /* box.c in Sources */ = {isa = PBXBuildFile; fileRef = 8542813678DB3B7BECEEF939 /* box.c */; };
+		0B59BE03B414411797329FD1 /* NotifyView.c in Sources */ = {isa = PBXBuildFile; fileRef = EB4A4D641AA8495FB08D9F0E /* NotifyView.c */; };
 		0BF82540ADD285E5DF358C72 /* ScoreView.c in Sources */ = {isa = PBXBuildFile; fileRef = 5B027972461629119D87F7A6 /* ScoreView.c */; };
 		0D717FD0F554D48A47A4C2A9 /* CenterPrintView.c in Sources */ = {isa = PBXBuildFile; fileRef = 07C9A88ED1D718092FD62601 /* CenterPrintView.c */; };
 		13539C3CA303E97E3DFB80B5 /* CrosshairView.c in Sources */ = {isa = PBXBuildFile; fileRef = 1A75866341F13821D2FC91FA /* CrosshairView.c */; };
 		16842F99305E37AEE91A82E4 /* HudViewController.c in Sources */ = {isa = PBXBuildFile; fileRef = C21FD90BD08D804DE1A792B1 /* HudViewController.c */; };
+		17A283BF800A49F7BC5D4C4D /* ConsoleText.c in Sources */ = {isa = PBXBuildFile; fileRef = 09A28D5220214F20A1942F76 /* ConsoleText.c */; };
 		18831DC74740CDF73E54CF63 /* StatView.c in Sources */ = {isa = PBXBuildFile; fileRef = 9CA6BC01A9434CCDBF23E8C0 /* StatView.c */; };
 		1D9F8ACA8B6EBADDC9A571F5 /* StatView.c in Sources */ = {isa = PBXBuildFile; fileRef = 9CA6BC01A9434CCDBF23E8C0 /* StatView.c */; };
-		20BE76382F981DD4B7F43A11 /* hud.json in CopyFiles */ = {isa = PBXBuildFile; fileRef = 64E652EE2F700EFB737AEA30 /* hud.json */; };
-		CEA4C0DE2F9800000087C003 /* hud.css in CopyFiles */ = {isa = PBXBuildFile; fileRef = CEA4C0DE2F9800000087C001 /* hud.css */; };
-		CEA4C0DE2F9800000087C004 /* hud.json in CopyFiles */ = {isa = PBXBuildFile; fileRef = CEA4C0DE2F9800000087C002 /* hud.json */; };
-		CEA4C0DE2F9800000087C008 /* scoreboard.css in CopyFiles */ = {isa = PBXBuildFile; fileRef = CEA4C0DE2F9800000087C006 /* scoreboard.css */; };
-		D1A5B0000000000000000506 /* intermission.css in CopyFiles */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000502 /* intermission.css */; };
-		CEA4C0DE2F9800000087C009 /* scoreboard.json in CopyFiles */ = {isa = PBXBuildFile; fileRef = CEA4C0DE2F9800000087C007 /* scoreboard.json */; };
-		D1A5B0000000000000000507 /* intermission.json in CopyFiles */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000503 /* intermission.json */; };
-		CEA4C0DE2F9800000087C00B /* scoreboard.json in CopyFiles */ = {isa = PBXBuildFile; fileRef = CEA4C0DE2F9800000087C00A /* scoreboard.json */; };
-		CEA4C0DE2F9800000087C011 /* hud.json in CopyFiles */ = {isa = PBXBuildFile; fileRef = CEA4C0DE2F9800000087C010 /* hud.json */; };
-		CEA4C0DE2F9800000087C014 /* hud.json in CopyFiles */ = {isa = PBXBuildFile; fileRef = CEA4C0DE2F9800000087C013 /* hud.json */; };
-		CEA4C0DE2F9800000087C017 /* hud.json in CopyFiles */ = {isa = PBXBuildFile; fileRef = CEA4C0DE2F9800000087C016 /* hud.json */; };
+		20BE76382F981DD4B7F43A11 /* default/hud.json in CopyFiles */ = {isa = PBXBuildFile; fileRef = 64E652EE2F700EFB737AEA30 /* default/hud.json */; };
+		21B7C99056194E1E9FC62EF2 /* ChatView.c in Sources */ = {isa = PBXBuildFile; fileRef = 2EA8B25732BD4FBCA2BCECC4 /* ChatView.c */; };
 		24AE762AB44CC3A34BCF6911 /* HudViewController.c in Sources */ = {isa = PBXBuildFile; fileRef = C21FD90BD08D804DE1A792B1 /* HudViewController.c */; };
 		28D9703AF85F475F866BAA51 /* DiagnosticsView.c in Sources */ = {isa = PBXBuildFile; fileRef = 20A922B6551C4CA8A3DCF8D8 /* DiagnosticsView.c */; };
 		2C3ADE327DEBD6F3955255E7 /* CrosshairView.c in Sources */ = {isa = PBXBuildFile; fileRef = 1A75866341F13821D2FC91FA /* CrosshairView.c */; };
 		2D0110BBB9C57DC4DAA49389 /* FpsView.c in Sources */ = {isa = PBXBuildFile; fileRef = EA8FE4E62B47061B1ADBD908 /* FpsView.c */; };
-		0B59BE03B414411797329FD1 /* NotifyView.c in Sources */ = {isa = PBXBuildFile; fileRef = EB4A4D641AA8495FB08D9F0E /* NotifyView.c */; };
-		F0E26144AB354006B07FF3E0 /* ConsoleText.c in Sources */ = {isa = PBXBuildFile; fileRef = 09A28D5220214F20A1942F76 /* ConsoleText.c */; };
-		AC814FDD1291470DA9883B6C /* ChatView.c in Sources */ = {isa = PBXBuildFile; fileRef = 2EA8B25732BD4FBCA2BCECC4 /* ChatView.c */; };
 		2F75825314B0423B86868ACC /* TargetNameView.c in Sources */ = {isa = PBXBuildFile; fileRef = E6ACB2EEAD95B3757AE36A7A /* TargetNameView.c */; };
-		322BAB812EFDDA99BA25575E /* scoreboard.json in CopyFiles */ = {isa = PBXBuildFile; fileRef = 848E81C81F875F4403EAE1EE /* scoreboard.json */; };
-		D1A5B0000000000000000505 /* intermission.json in CopyFiles */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000501 /* intermission.json */; };
+		322BAB812EFDDA99BA25575E /* default/scoreboard.json in CopyFiles */ = {isa = PBXBuildFile; fileRef = 848E81C81F875F4403EAE1EE /* default/scoreboard.json */; };
 		332CAA47FF0E8521C12DF852 /* SDL3.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = CE1643492FF5A12100863996 /* SDL3.xcframework */; };
-		368D384E998F7590EBCEB7EE /* hud.json in CopyFiles */ = {isa = PBXBuildFile; fileRef = 3487B5AD7D47E8DFBDDAE5C4 /* hud.json */; };
+		368D384E998F7590EBCEB7EE /* default/hud.json in CopyFiles */ = {isa = PBXBuildFile; fileRef = 3487B5AD7D47E8DFBDDAE5C4 /* default/hud.json */; };
 		39FADC0544F1D2D0BAF1CF06 /* WeaponBarView.c in Sources */ = {isa = PBXBuildFile; fileRef = 7773870519E25AD88B29F618 /* WeaponBarView.c */; };
 		3B497D93EA892C673165469D /* StatView.c in Sources */ = {isa = PBXBuildFile; fileRef = 9CA6BC01A9434CCDBF23E8C0 /* StatView.c */; };
 		3C4FCD00A4AE0B8971D17E7D /* OverlayText.c in Sources */ = {isa = PBXBuildFile; fileRef = 8238DE2CC5A406DE6DF84E71 /* OverlayText.c */; };
@@ -105,47 +94,37 @@
 		47E832E190C339999881A094 /* PickupView.c in Sources */ = {isa = PBXBuildFile; fileRef = E106ACFB28FF47443FB3C9FE /* PickupView.c */; };
 		48F10F5D3A8711EABB25DB34 /* PickupView.c in Sources */ = {isa = PBXBuildFile; fileRef = E106ACFB28FF47443FB3C9FE /* PickupView.c */; };
 		4E0DA0FBE7F88EC11A4CF033 /* SDL3.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = CE1643492FF5A12100863996 /* SDL3.xcframework */; };
+		4E265AE532584E47A2D20258 /* ConsoleText.c in Sources */ = {isa = PBXBuildFile; fileRef = 09A28D5220214F20A1942F76 /* ConsoleText.c */; };
 		50A618B627838A7F121E3DA9 /* SpectatorView.c in Sources */ = {isa = PBXBuildFile; fileRef = 94D1F06AFA9AE2182216CC46 /* SpectatorView.c */; };
 		50A656139CC3317E925D0231 /* ScoreboardView.c in Sources */ = {isa = PBXBuildFile; fileRef = 45969B731C08AA84C8D318F6 /* ScoreboardView.c */; };
-		D1A5B0000000000000000402 /* IntermissionView.c in Sources */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000401 /* IntermissionView.c */; };
+		5183CDCD1E2C497586ABBEB2 /* NotifyView.c in Sources */ = {isa = PBXBuildFile; fileRef = EB4A4D641AA8495FB08D9F0E /* NotifyView.c */; };
 		522B158EA7384E83CD005789 /* cm_manifest.c in Sources */ = {isa = PBXBuildFile; fileRef = D126FFD46C343DDC86C13E17 /* cm_manifest.c */; };
 		52367ABAA22B6D5586284093 /* TeamBannerView.c in Sources */ = {isa = PBXBuildFile; fileRef = A73DD77B1D5B8231028B01FA /* TeamBannerView.c */; };
 		5353FBA06CC14AA034C4C9CD /* TargetNameView.c in Sources */ = {isa = PBXBuildFile; fileRef = E6ACB2EEAD95B3757AE36A7A /* TargetNameView.c */; };
 		537E3B2A605E2005BA5F4928 /* TeamBannerView.c in Sources */ = {isa = PBXBuildFile; fileRef = A73DD77B1D5B8231028B01FA /* TeamBannerView.c */; };
 		54194A7922708C783B541F5B /* CrosshairView.c in Sources */ = {isa = PBXBuildFile; fileRef = 1A75866341F13821D2FC91FA /* CrosshairView.c */; };
-		544522FFCEEDAAC1EBEB6750 /* scoreboard.json in CopyFiles */ = {isa = PBXBuildFile; fileRef = 92AA3129971ABAAB21EE5BAD /* scoreboard.json */; };
+		544522FFCEEDAAC1EBEB6750 /* default/scoreboard.json in CopyFiles */ = {isa = PBXBuildFile; fileRef = 92AA3129971ABAAB21EE5BAD /* default/scoreboard.json */; };
 		547AC46C9A45CC44AB005215 /* PickupView.c in Sources */ = {isa = PBXBuildFile; fileRef = E106ACFB28FF47443FB3C9FE /* PickupView.c */; };
 		549E7CC4A7BA476A2463B7CC /* SDL3.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = CE1643492FF5A12100863996 /* SDL3.xcframework */; };
 		5638E4EA8D41AFE5849D7894 /* TimeView.c in Sources */ = {isa = PBXBuildFile; fileRef = C92F4D9E4BF61FF1C7E51B0C /* TimeView.c */; };
 		56AC1EB89F50309A3C1E9C4B /* CenterPrintView.c in Sources */ = {isa = PBXBuildFile; fileRef = 07C9A88ED1D718092FD62601 /* CenterPrintView.c */; };
 		5A41D1910F5ECC29544A0261 /* ChaseView.c in Sources */ = {isa = PBXBuildFile; fileRef = 1C923406FE86A096F618B0A6 /* ChaseView.c */; };
 		5D26ECD45D3B9CEDA1FCE596 /* WeaponBarView.c in Sources */ = {isa = PBXBuildFile; fileRef = 7773870519E25AD88B29F618 /* WeaponBarView.c */; };
+		622B0D6DA98C42AA8A8D582B /* ChatView.c in Sources */ = {isa = PBXBuildFile; fileRef = 2EA8B25732BD4FBCA2BCECC4 /* ChatView.c */; };
 		65A8C761AE5D68358CDDE601 /* NavEditView.c in Sources */ = {isa = PBXBuildFile; fileRef = 491F54CD554D0F550B000B4E /* NavEditView.c */; };
 		665046BB6961C443C731A077 /* PowerupView.c in Sources */ = {isa = PBXBuildFile; fileRef = 755F8C8CBA7F7C48E79A578C /* PowerupView.c */; };
 		6681071D48F7B492ADC27385 /* BlendView.c in Sources */ = {isa = PBXBuildFile; fileRef = 4BF47DA7893C8563C1D59CDA /* BlendView.c */; };
-		F794CD9FF6534935B10C3EFD /* ConsoleView.c in Sources */ = {isa = PBXBuildFile; fileRef = 7F6A5E1D6B8246A7B4EAD906 /* ConsoleView.c */; };
-		A2E677309CBD4262ADCE7EA5 /* ConsoleViewController.c in Sources */ = {isa = PBXBuildFile; fileRef = 9352803A21064843A7D64A86 /* ConsoleViewController.c */; };
 		68157F8A4AF07ADDE8951670 /* SpectatorView.c in Sources */ = {isa = PBXBuildFile; fileRef = 94D1F06AFA9AE2182216CC46 /* SpectatorView.c */; };
 		68D440FA613EE2594A4D6DB6 /* ScoreboardView.c in Sources */ = {isa = PBXBuildFile; fileRef = 45969B731C08AA84C8D318F6 /* ScoreboardView.c */; };
-		D1A5B0000000000000000403 /* IntermissionView.c in Sources */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000401 /* IntermissionView.c */; };
 		68FBD5DEAC1FB3CC3C2322D5 /* CenterPrintView.c in Sources */ = {isa = PBXBuildFile; fileRef = 07C9A88ED1D718092FD62601 /* CenterPrintView.c */; };
 		6B31320926D77CB87B783BDD /* SDL3.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = CE1643492FF5A12100863996 /* SDL3.xcframework */; };
 		6B6C876AA822AB4DFB8D3158 /* OverlayText.c in Sources */ = {isa = PBXBuildFile; fileRef = 8238DE2CC5A406DE6DF84E71 /* OverlayText.c */; };
 		6C7870B960DDA48FF5959231 /* CounterView.c in Sources */ = {isa = PBXBuildFile; fileRef = A59EB892C12DF10ACA8253DD /* CounterView.c */; };
 		719CDF30AE6EB1DC2261140E /* FpsView.c in Sources */ = {isa = PBXBuildFile; fileRef = EA8FE4E62B47061B1ADBD908 /* FpsView.c */; };
-		5183CDCD1E2C497586ABBEB2 /* NotifyView.c in Sources */ = {isa = PBXBuildFile; fileRef = EB4A4D641AA8495FB08D9F0E /* NotifyView.c */; };
-		17A283BF800A49F7BC5D4C4D /* ConsoleText.c in Sources */ = {isa = PBXBuildFile; fileRef = 09A28D5220214F20A1942F76 /* ConsoleText.c */; };
-		21B7C99056194E1E9FC62EF2 /* ChatView.c in Sources */ = {isa = PBXBuildFile; fileRef = 2EA8B25732BD4FBCA2BCECC4 /* ChatView.c */; };
 		77C2AFA7D92DAC05CE4E7996 /* FpsView.c in Sources */ = {isa = PBXBuildFile; fileRef = EA8FE4E62B47061B1ADBD908 /* FpsView.c */; };
-		9A8A8F490F0A41FDB55A317F /* NotifyView.c in Sources */ = {isa = PBXBuildFile; fileRef = EB4A4D641AA8495FB08D9F0E /* NotifyView.c */; };
-		4E265AE532584E47A2D20258 /* ConsoleText.c in Sources */ = {isa = PBXBuildFile; fileRef = 09A28D5220214F20A1942F76 /* ConsoleText.c */; };
-		B0F1E4D1823545B993F57B81 /* ChatView.c in Sources */ = {isa = PBXBuildFile; fileRef = 2EA8B25732BD4FBCA2BCECC4 /* ChatView.c */; };
 		77DC97E1E9FDFCF8FD91B1BC /* SDL3.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = CE1643492FF5A12100863996 /* SDL3.xcframework */; };
 		7857EDF77E5E58CEFFD03198 /* SDL3.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = CE1643492FF5A12100863996 /* SDL3.xcframework */; };
 		78965577428364713231086F /* FpsView.c in Sources */ = {isa = PBXBuildFile; fileRef = EA8FE4E62B47061B1ADBD908 /* FpsView.c */; };
-		D9F4D7BEB0EE4A87B8529DDA /* NotifyView.c in Sources */ = {isa = PBXBuildFile; fileRef = EB4A4D641AA8495FB08D9F0E /* NotifyView.c */; };
-		B58055474A104E479F3F83A2 /* ConsoleText.c in Sources */ = {isa = PBXBuildFile; fileRef = 09A28D5220214F20A1942F76 /* ConsoleText.c */; };
-		622B0D6DA98C42AA8A8D582B /* ChatView.c in Sources */ = {isa = PBXBuildFile; fileRef = 2EA8B25732BD4FBCA2BCECC4 /* ChatView.c */; };
 		78BFCA151AAC14630B15208D /* CenterPrintView.c in Sources */ = {isa = PBXBuildFile; fileRef = 07C9A88ED1D718092FD62601 /* CenterPrintView.c */; };
 		7AFADF59B58F54581DC1C419 /* SpectatorView.c in Sources */ = {isa = PBXBuildFile; fileRef = 94D1F06AFA9AE2182216CC46 /* SpectatorView.c */; };
 		814F48F21F6B2E10A1D10BF1 /* TimeView.c in Sources */ = {isa = PBXBuildFile; fileRef = C92F4D9E4BF61FF1C7E51B0C /* TimeView.c */; };
@@ -158,28 +137,32 @@
 		997E573805B0DCF96FB8C299 /* manifest.c in Sources */ = {isa = PBXBuildFile; fileRef = 57941D4E858E897A2E3083ED /* manifest.c */; };
 		99E4ACB4811F76E8CB7249E9 /* ChaseView.c in Sources */ = {isa = PBXBuildFile; fileRef = 1C923406FE86A096F618B0A6 /* ChaseView.c */; };
 		9A75AE7BCB708C6557903ADE /* OverlayText.c in Sources */ = {isa = PBXBuildFile; fileRef = 8238DE2CC5A406DE6DF84E71 /* OverlayText.c */; };
+		9A8A8F490F0A41FDB55A317F /* NotifyView.c in Sources */ = {isa = PBXBuildFile; fileRef = EB4A4D641AA8495FB08D9F0E /* NotifyView.c */; };
 		9B67395438D49AA25C710A4A /* BlendView.c in Sources */ = {isa = PBXBuildFile; fileRef = 4BF47DA7893C8563C1D59CDA /* BlendView.c */; };
 		9C1E56948C90F9D9DD714DF6 /* HudViewController.c in Sources */ = {isa = PBXBuildFile; fileRef = C21FD90BD08D804DE1A792B1 /* HudViewController.c */; };
 		9C43D41506579A6ED4EE80F5 /* SDL3.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = CE1643492FF5A12100863996 /* SDL3.xcframework */; };
-		9E1C83CE11AE376D9174B271 /* hud.json in CopyFiles */ = {isa = PBXBuildFile; fileRef = 027C4ADD65DCCCEBCEB3D462 /* hud.json */; };
+		9E1C83CE11AE376D9174B271 /* default/hud.json in CopyFiles */ = {isa = PBXBuildFile; fileRef = 027C4ADD65DCCCEBCEB3D462 /* default/hud.json */; };
 		9EBBE79D07E30BB784FC188F /* ScoreView.c in Sources */ = {isa = PBXBuildFile; fileRef = 5B027972461629119D87F7A6 /* ScoreView.c */; };
 		9F948D38BAB2AE44F4A87F61 /* ScoreView.c in Sources */ = {isa = PBXBuildFile; fileRef = 5B027972461629119D87F7A6 /* ScoreView.c */; };
+		A2E677309CBD4262ADCE7EA5 /* ConsoleViewController.c in Sources */ = {isa = PBXBuildFile; fileRef = 9352803A21064843A7D64A86 /* ConsoleViewController.c */; };
 		A36A95B1FECEDF46C0B15D62 /* BarlowCondensed-SemiBold.ttf in CopyFiles */ = {isa = PBXBuildFile; fileRef = 02E20C6F468B8DCFDF5BB1A0 /* BarlowCondensed-SemiBold.ttf */; };
 		A978478284E6A536361DE6FC /* SpectatorView.c in Sources */ = {isa = PBXBuildFile; fileRef = 94D1F06AFA9AE2182216CC46 /* SpectatorView.c */; };
 		AB5844CCEFD30974680FBF24 /* MPlusU-Bold.ttf in CopyFiles */ = {isa = PBXBuildFile; fileRef = B73290DBC38EE6D335FC9BB9 /* MPlusU-Bold.ttf */; };
+		AC814FDD1291470DA9883B6C /* ChatView.c in Sources */ = {isa = PBXBuildFile; fileRef = 2EA8B25732BD4FBCA2BCECC4 /* ChatView.c */; };
 		AD9B2D464FD840D5A031FC6A /* PingView.c in Sources */ = {isa = PBXBuildFile; fileRef = 5624F1C74F4646918DA71088 /* PingView.c */; };
 		AE4EA13B59877C5736940695 /* OverlayText.c in Sources */ = {isa = PBXBuildFile; fileRef = 8238DE2CC5A406DE6DF84E71 /* OverlayText.c */; };
 		AF637037D323F5359A9E5F26 /* ChaseView.c in Sources */ = {isa = PBXBuildFile; fileRef = 1C923406FE86A096F618B0A6 /* ChaseView.c */; };
 		AF8056E19DEC77694B63EDD7 /* SDL3.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = CE1643492FF5A12100863996 /* SDL3.xcframework */; };
+		B0F1E4D1823545B993F57B81 /* ChatView.c in Sources */ = {isa = PBXBuildFile; fileRef = 2EA8B25732BD4FBCA2BCECC4 /* ChatView.c */; };
 		B2B62AE1E7C09567B299F1AA /* SDL3.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = CE1643492FF5A12100863996 /* SDL3.xcframework */; };
 		B3C3D379CB4955B1FED23ADB /* TargetNameView.c in Sources */ = {isa = PBXBuildFile; fileRef = E6ACB2EEAD95B3757AE36A7A /* TargetNameView.c */; };
-		B50A7AB9A94C86F0D55675BD /* hud.json in CopyFiles */ = {isa = PBXBuildFile; fileRef = A980A8F791ED9C0A50C6C948 /* hud.json */; };
+		B50A7AB9A94C86F0D55675BD /* default/hud.json in CopyFiles */ = {isa = PBXBuildFile; fileRef = A980A8F791ED9C0A50C6C948 /* default/hud.json */; };
+		B58055474A104E479F3F83A2 /* ConsoleText.c in Sources */ = {isa = PBXBuildFile; fileRef = 09A28D5220214F20A1942F76 /* ConsoleText.c */; };
 		B777A7BCE46440D86F0248FA /* BarlowCondensed-OFL.txt in CopyFiles */ = {isa = PBXBuildFile; fileRef = B2BB7E5AE1E2CA9AF9C61681 /* BarlowCondensed-OFL.txt */; };
 		B8A5AAD33BD44C1EA2F1800F /* PingView.c in Sources */ = {isa = PBXBuildFile; fileRef = 5624F1C74F4646918DA71088 /* PingView.c */; };
 		B8BC2CE87251BA0975026203 /* SDL3_image.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = CEF601C42FE711B7005C680C /* SDL3_image.xcframework */; };
 		B92B8EA5B4D9C775CF3C2541 /* SDL3.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = CE1643492FF5A12100863996 /* SDL3.xcframework */; };
 		BB08F021CF5059A8915C8DDF /* ScoreboardView.c in Sources */ = {isa = PBXBuildFile; fileRef = 45969B731C08AA84C8D318F6 /* ScoreboardView.c */; };
-		D1A5B0000000000000000404 /* IntermissionView.c in Sources */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000401 /* IntermissionView.c */; };
 		C1A592C4D259F42E82027392 /* BlendView.c in Sources */ = {isa = PBXBuildFile; fileRef = 4BF47DA7893C8563C1D59CDA /* BlendView.c */; };
 		C1B4D8275ABD425EB6C332C6 /* DiagnosticsView.c in Sources */ = {isa = PBXBuildFile; fileRef = 20A922B6551C4CA8A3DCF8D8 /* DiagnosticsView.c */; };
 		C24304F353C77693015A7736 /* ScoreView.c in Sources */ = {isa = PBXBuildFile; fileRef = 5B027972461629119D87F7A6 /* ScoreView.c */; };
@@ -199,7 +182,6 @@
 		CE04F16625CADF6700C31433 /* files.h in Headers */ = {isa = PBXBuildFile; fileRef = CE12D63C1C5C58C300CD0B13 /* files.h */; };
 		CE04F18B25CADF6900C31433 /* filesystem.h in Headers */ = {isa = PBXBuildFile; fileRef = CE12D63E1C5C58C300CD0B13 /* filesystem.h */; };
 		CE04F1B025CADF6C00C31433 /* image.h in Headers */ = {isa = PBXBuildFile; fileRef = CE12D6781C5C58C300CD0B13 /* image.h */; };
-		CEA0B1C32D0000010000A004 /* archive.h in Headers */ = {isa = PBXBuildFile; fileRef = CEA0B1C12D0000010000A002 /* archive.h */; };
 		CE04F1D525CADF6F00C31433 /* installer.h in Headers */ = {isa = PBXBuildFile; fileRef = CEC74B3725C8EE94009C6218 /* installer.h */; };
 		CE04F21E25CADF7700C31433 /* mem_buf.h in Headers */ = {isa = PBXBuildFile; fileRef = CE12D68C1C5C58C300CD0B13 /* mem_buf.h */; };
 		CE04F24325CADF7A00C31433 /* mem.h in Headers */ = {isa = PBXBuildFile; fileRef = CE12D68A1C5C58C300CD0B13 /* mem.h */; };
@@ -207,7 +189,6 @@
 		CE04F28D25CADF7F00C31433 /* thread.h in Headers */ = {isa = PBXBuildFile; fileRef = CE12D6DF1C5C58C300CD0B13 /* thread.h */; };
 		CE04F2B225CADF8D00C31433 /* filesystem.c in Sources */ = {isa = PBXBuildFile; fileRef = CE12D63D1C5C58C300CD0B13 /* filesystem.c */; };
 		CE04F2D725CADF9000C31433 /* image.c in Sources */ = {isa = PBXBuildFile; fileRef = CE12D6771C5C58C300CD0B13 /* image.c */; };
-		CEA0B1C22D0000010000A003 /* archive.c in Sources */ = {isa = PBXBuildFile; fileRef = CEA0B1C02D0000010000A001 /* archive.c */; };
 		CE04F2FC25CADF9300C31433 /* installer.c in Sources */ = {isa = PBXBuildFile; fileRef = CEC74B3825C8EE94009C6218 /* installer.c */; };
 		CE04F32125CADF9800C31433 /* mem_buf.c in Sources */ = {isa = PBXBuildFile; fileRef = CE12D68B1C5C58C300CD0B13 /* mem_buf.c */; };
 		CE04F34625CADF9B00C31433 /* mem.c in Sources */ = {isa = PBXBuildFile; fileRef = CE12D6891C5C58C300CD0B13 /* mem.c */; };
@@ -613,23 +594,6 @@
 		CE7D2C3320310810004BC58E /* SettingsViewController.json in CopyFiles */ = {isa = PBXBuildFile; fileRef = CE7D2C2F20310763004BC58E /* SettingsViewController.json */; };
 		CE7FCDD72596996600E49A2D /* cl_screen.c in Sources */ = {isa = PBXBuildFile; fileRef = CE7FCDD52596996500E49A2D /* cl_screen.c */; };
 		CE7FCDD82596996600E49A2D /* cl_screen.h in Headers */ = {isa = PBXBuildFile; fileRef = CE7FCDD62596996500E49A2D /* cl_screen.h */; };
-		D9A5C2010000000000000001 /* libminizip.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CE12D8111C5C5EF000CD0B13 /* libminizip.a */; };
-		D9A5C2010000000000000002 /* libminizip.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CE12D8111C5C5EF000CD0B13 /* libminizip.a */; };
-		D9A5C2010000000000000003 /* libminizip.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CE12D8111C5C5EF000CD0B13 /* libminizip.a */; };
-		D9A5C2010000000000000004 /* libminizip.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CE12D8111C5C5EF000CD0B13 /* libminizip.a */; };
-		D9A5C2010000000000000005 /* libminizip.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CE12D8111C5C5EF000CD0B13 /* libminizip.a */; };
-		D9A5C2010000000000000006 /* libminizip.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CE12D8111C5C5EF000CD0B13 /* libminizip.a */; };
-		D9A5C2010000000000000007 /* libminizip.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CE12D8111C5C5EF000CD0B13 /* libminizip.a */; };
-		D9A5C2010000000000000008 /* libminizip.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CE12D8111C5C5EF000CD0B13 /* libminizip.a */; };
-		D9A5C2010000000000000009 /* libminizip.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CE12D8111C5C5EF000CD0B13 /* libminizip.a */; };
-		D9A5C201000000000000000A /* libminizip.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CE12D8111C5C5EF000CD0B13 /* libminizip.a */; };
-		D9A5C201000000000000000B /* libminizip.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CE12D8111C5C5EF000CD0B13 /* libminizip.a */; };
-		D9A5C201000000000000000C /* libminizip.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CE12D8111C5C5EF000CD0B13 /* libminizip.a */; };
-		D9A5C201000000000000000D /* libminizip.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CE12D8111C5C5EF000CD0B13 /* libminizip.a */; };
-		D9A5C201000000000000000E /* libminizip.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CE12D8111C5C5EF000CD0B13 /* libminizip.a */; };
-		D9A5C201000000000000000F /* libminizip.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CE12D8111C5C5EF000CD0B13 /* libminizip.a */; };
-		D9A5C2010000000000000010 /* libminizip.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CE12D8111C5C5EF000CD0B13 /* libminizip.a */; };
-		D9A5C2010000000000000011 /* libminizip.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CE12D8111C5C5EF000CD0B13 /* libminizip.a */; };
 		CE8000001C5E4D4400A21A51 /* libminizip.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CE12D8111C5C5EF000CD0B13 /* libminizip.a */; };
 		CE8000021C5E4D4400A21A51 /* libshared.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CE80FDD51C5E3D4E00A21A51 /* libshared.a */; };
 		CE80FDB61C5E3D4E00A21A51 /* shared-anorms.c in Sources */ = {isa = PBXBuildFile; fileRef = CE12D6B71C5C58C300CD0B13 /* shared-anorms.c */; };
@@ -792,6 +756,8 @@
 		CE9CFCB023EB3D240009DA65 /* check_vector.c in Sources */ = {isa = PBXBuildFile; fileRef = CE9CFC9C23EB3BF50009DA65 /* check_vector.c */; };
 		CEA082371DC6EC50001207AA /* r_atlas.c in Sources */ = {isa = PBXBuildFile; fileRef = CEA082331DC6EBB7001207AA /* r_atlas.c */; };
 		CEA082381DC6EC59001207AA /* r_atlas.h in Headers */ = {isa = PBXBuildFile; fileRef = CEA082341DC6EBB7001207AA /* r_atlas.h */; };
+		CEA0B1C22D0000010000A003 /* archive.c in Sources */ = {isa = PBXBuildFile; fileRef = CEA0B1C02D0000010000A001 /* archive.c */; };
+		CEA0B1C32D0000010000A004 /* archive.h in Headers */ = {isa = PBXBuildFile; fileRef = CEA0B1C12D0000010000A002 /* archive.h */; };
 		CEA153B3296B4BE100916F83 /* r_cull.h in Headers */ = {isa = PBXBuildFile; fileRef = CEA153B1296B4BE100916F83 /* r_cull.h */; };
 		CEA153B4296B4BE100916F83 /* r_cull.c in Sources */ = {isa = PBXBuildFile; fileRef = CEA153B2296B4BE100916F83 /* r_cull.c */; };
 		CEA1A0012F9F00000087B100 /* CreditsViewController.c in Sources */ = {isa = PBXBuildFile; fileRef = CEA1A0072F9F00000087B100 /* CreditsViewController.c */; };
@@ -806,6 +772,14 @@
 		CEA4000C2F9800000087B100 /* 3.png in CopyFiles */ = {isa = PBXBuildFile; fileRef = CEA400052F9800000087B100 /* 3.png */; };
 		CEA4000D2F9800000087B100 /* 4.png in CopyFiles */ = {isa = PBXBuildFile; fileRef = CEA400062F9800000087B100 /* 4.png */; };
 		CEA4000E2F9800000087B100 /* 5.png in CopyFiles */ = {isa = PBXBuildFile; fileRef = CEA400072F9800000087B100 /* 5.png */; };
+		CEA4C0DE2F9800000087C003 /* chrome/hud.css in CopyFiles */ = {isa = PBXBuildFile; fileRef = CEA4C0DE2F9800000087C001 /* chrome/hud.css */; };
+		CEA4C0DE2F9800000087C004 /* chrome/hud.json in CopyFiles */ = {isa = PBXBuildFile; fileRef = CEA4C0DE2F9800000087C002 /* chrome/hud.json */; };
+		CEA4C0DE2F9800000087C008 /* chrome/scoreboard.css in CopyFiles */ = {isa = PBXBuildFile; fileRef = CEA4C0DE2F9800000087C006 /* chrome/scoreboard.css */; };
+		CEA4C0DE2F9800000087C009 /* chrome/scoreboard.json in CopyFiles */ = {isa = PBXBuildFile; fileRef = CEA4C0DE2F9800000087C007 /* chrome/scoreboard.json */; };
+		CEA4C0DE2F9800000087C00B /* chrome/scoreboard.json in CopyFiles */ = {isa = PBXBuildFile; fileRef = CEA4C0DE2F9800000087C00A /* chrome/scoreboard.json */; };
+		CEA4C0DE2F9800000087C011 /* chrome/hud.json in CopyFiles */ = {isa = PBXBuildFile; fileRef = CEA4C0DE2F9800000087C010 /* chrome/hud.json */; };
+		CEA4C0DE2F9800000087C014 /* chrome/hud.json in CopyFiles */ = {isa = PBXBuildFile; fileRef = CEA4C0DE2F9800000087C013 /* chrome/hud.json */; };
+		CEA4C0DE2F9800000087C017 /* chrome/hud.json in CopyFiles */ = {isa = PBXBuildFile; fileRef = CEA4C0DE2F9800000087C016 /* chrome/hud.json */; };
 		CEA508F92EA5D20A00F27205 /* tests.c in Sources */ = {isa = PBXBuildFile; fileRef = CE12D6DC1C5C58C300CD0B13 /* tests.c */; };
 		CEA508FA2EA5D20A00F27205 /* check_cm_polylib.c in Sources */ = {isa = PBXBuildFile; fileRef = CEE3A0EF21EE2A5E0070FD3E /* check_cm_polylib.c */; };
 		CEA508FC2EA5D20A00F27205 /* libcollision.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CE80FE381C5E421900A21A51 /* libcollision.a */; };
@@ -1156,30 +1130,42 @@
 		D1A5B0000000000000000002 /* bg_pmove_local.h in Headers */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000001 /* bg_pmove_local.h */; };
 		D1A5B0000000000000000003 /* bg_pmove_local.h in Headers */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000001 /* bg_pmove_local.h */; };
 		D1A5B0000000000000000102 /* g_vote.c in Sources */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000101 /* g_vote.c */; };
-		D1A5B0000000000000000301 /* g_intermission.c in Sources */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000300 /* g_intermission.c */; };
 		D1A5B0000000000000000103 /* g_vote.c in Sources */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000101 /* g_vote.c */; };
-		D1A5B0000000000000000302 /* g_intermission.c in Sources */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000300 /* g_intermission.c */; };
 		D1A5B0000000000000000104 /* g_vote.c in Sources */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000101 /* g_vote.c */; };
-		D1A5B0000000000000000303 /* g_intermission.c in Sources */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000300 /* g_intermission.c */; };
 		D1A5B0000000000000000106 /* bg_vote.h in Headers */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000105 /* bg_vote.h */; };
-		D1A5B0000000000000000305 /* bg_intermission.h in Headers */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000304 /* bg_intermission.h */; };
 		D1A5B0000000000000000107 /* bg_vote.h in Headers */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000105 /* bg_vote.h */; };
-		D1A5B0000000000000000306 /* bg_intermission.h in Headers */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000304 /* bg_intermission.h */; };
 		D1A5B0000000000000000110 /* g_vote.h in Headers */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000108 /* g_vote.h */; };
-		D1A5B0000000000000000308 /* g_intermission.h in Headers */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000307 /* g_intermission.h */; };
 		D1A5B0000000000000000111 /* g_vote.h in Headers */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000108 /* g_vote.h */; };
-		D1A5B0000000000000000309 /* g_intermission.h in Headers */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000307 /* g_intermission.h */; };
 		D1A5B0000000000000000202 /* cg_vote.c in Sources */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000201 /* cg_vote.c */; };
-		D1A5B0000000000000000406 /* cg_intermission.c in Sources */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000405 /* cg_intermission.c */; };
 		D1A5B0000000000000000203 /* cg_vote.c in Sources */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000201 /* cg_vote.c */; };
-		D1A5B0000000000000000407 /* cg_intermission.c in Sources */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000405 /* cg_intermission.c */; };
 		D1A5B0000000000000000204 /* cg_vote.c in Sources */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000201 /* cg_vote.c */; };
-		D1A5B0000000000000000408 /* cg_intermission.c in Sources */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000405 /* cg_intermission.c */; };
 		D1A5B0000000000000000206 /* VoteViewController.c in Sources */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000205 /* VoteViewController.c */; };
 		D1A5B0000000000000000207 /* VoteViewController.c in Sources */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000205 /* VoteViewController.c */; };
 		D1A5B0000000000000000208 /* VoteViewController.c in Sources */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000205 /* VoteViewController.c */; };
 		D1A5B0000000000000000210 /* VoteViewController.json in CopyFiles */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000209 /* VoteViewController.json */; };
 		D1A5B0000000000000000212 /* VoteViewController.css in CopyFiles */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000211 /* VoteViewController.css */; };
+		D1A5B0000000000000000301 /* g_intermission.c in Sources */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000300 /* g_intermission.c */; };
+		D1A5B0000000000000000302 /* g_intermission.c in Sources */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000300 /* g_intermission.c */; };
+		D1A5B0000000000000000303 /* g_intermission.c in Sources */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000300 /* g_intermission.c */; };
+		D1A5B0000000000000000305 /* bg_intermission.h in Headers */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000304 /* bg_intermission.h */; };
+		D1A5B0000000000000000306 /* bg_intermission.h in Headers */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000304 /* bg_intermission.h */; };
+		D1A5B0000000000000000308 /* g_intermission.h in Headers */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000307 /* g_intermission.h */; };
+		D1A5B0000000000000000309 /* g_intermission.h in Headers */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000307 /* g_intermission.h */; };
+		D1A5B000000000000000030A /* g_intermission.c in Sources */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000300 /* g_intermission.c */; };
+		D1A5B000000000000000030B /* bg_intermission.h in Headers */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000304 /* bg_intermission.h */; };
+		D1A5B000000000000000030C /* g_intermission.h in Headers */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000307 /* g_intermission.h */; };
+		D1A5B0000000000000000402 /* IntermissionView.c in Sources */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000401 /* IntermissionView.c */; };
+		D1A5B0000000000000000403 /* IntermissionView.c in Sources */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000401 /* IntermissionView.c */; };
+		D1A5B0000000000000000404 /* IntermissionView.c in Sources */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000401 /* IntermissionView.c */; };
+		D1A5B0000000000000000406 /* cg_intermission.c in Sources */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000405 /* cg_intermission.c */; };
+		D1A5B0000000000000000407 /* cg_intermission.c in Sources */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000405 /* cg_intermission.c */; };
+		D1A5B0000000000000000408 /* cg_intermission.c in Sources */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000405 /* cg_intermission.c */; };
+		D1A5B000000000000000040A /* cg_intermission.c in Sources */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000405 /* cg_intermission.c */; };
+		D1A5B000000000000000040B /* IntermissionView.c in Sources */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000401 /* IntermissionView.c */; };
+		D1A5B0000000000000000504 /* default/intermission.css in CopyFiles */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000500 /* default/intermission.css */; };
+		D1A5B0000000000000000505 /* default/intermission.json in CopyFiles */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000501 /* default/intermission.json */; };
+		D1A5B0000000000000000506 /* chrome/intermission.css in CopyFiles */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000502 /* chrome/intermission.css */; };
+		D1A5B0000000000000000507 /* chrome/intermission.json in CopyFiles */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000503 /* chrome/intermission.json */; };
 		D2A5C1000000000000000010 /* bg_item.c in Sources */ = {isa = PBXBuildFile; fileRef = D2A5C1000000000000000002 /* bg_item.c */; };
 		D2A5C1000000000000000011 /* bg_pmove.c in Sources */ = {isa = PBXBuildFile; fileRef = CE12D6411C5C58C300CD0B13 /* bg_pmove.c */; };
 		D2A5C1000000000000000012 /* g_ai_goal.c in Sources */ = {isa = PBXBuildFile; fileRef = CE27E9F127BDA2AE003D56AC /* g_ai_goal.c */; };
@@ -1209,7 +1195,6 @@
 		D2A5C100000000000000002A /* g_physics.c in Sources */ = {isa = PBXBuildFile; fileRef = CE12D66A1C5C58C300CD0B13 /* g_physics.c */; };
 		D2A5C100000000000000002B /* g_rules.c in Sources */ = {isa = PBXBuildFile; fileRef = CEFEEE00000000000000A101 /* g_rules.c */; };
 		D2A5C100000000000000002C /* g_vote.c in Sources */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000101 /* g_vote.c */; };
-		D1A5B000000000000000030A /* g_intermission.c in Sources */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000300 /* g_intermission.c */; };
 		D2A5C100000000000000002D /* g_sound.c in Sources */ = {isa = PBXBuildFile; fileRef = CEFF1296277D439B001E1500 /* g_sound.c */; };
 		D2A5C100000000000000002E /* g_util.c in Sources */ = {isa = PBXBuildFile; fileRef = CE12D66D1C5C58C300CD0B13 /* g_util.c */; };
 		D2A5C100000000000000002F /* g_weapon.c in Sources */ = {isa = PBXBuildFile; fileRef = CE12D66F1C5C58C300CD0B13 /* g_weapon.c */; };
@@ -1219,7 +1204,6 @@
 		D2A5C1000000000000000033 /* bg_item.h in Headers */ = {isa = PBXBuildFile; fileRef = D2A5C1000000000000000001 /* bg_item.h */; };
 		D2A5C1000000000000000034 /* bg_pmove.h in Headers */ = {isa = PBXBuildFile; fileRef = CE12D6421C5C58C300CD0B13 /* bg_pmove.h */; };
 		D2A5C1000000000000000035 /* bg_vote.h in Headers */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000105 /* bg_vote.h */; };
-		D1A5B000000000000000030B /* bg_intermission.h in Headers */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000304 /* bg_intermission.h */; };
 		D2A5C1000000000000000036 /* bg_pmove_local.h in Headers */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000001 /* bg_pmove_local.h */; };
 		D2A5C1000000000000000037 /* g_ai_goal.h in Headers */ = {isa = PBXBuildFile; fileRef = CE27E9F327BDA2AE003D56AC /* g_ai_goal.h */; };
 		D2A5C1000000000000000038 /* g_ai_grid.h in Headers */ = {isa = PBXBuildFile; fileRef = CE4E053F2FDAE2CE00B92C32 /* g_ai_grid.h */; };
@@ -1244,7 +1228,6 @@
 		D2A5C100000000000000004B /* g_entity_trigger.h in Headers */ = {isa = PBXBuildFile; fileRef = CE12D6601C5C58C300CD0B13 /* g_entity_trigger.h */; };
 		D2A5C100000000000000004C /* g_hook.h in Headers */ = {isa = PBXBuildFile; fileRef = CEC011002026010200000007 /* g_hook.h */; };
 		D2A5C100000000000000004D /* g_vote.h in Headers */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000108 /* g_vote.h */; };
-		D1A5B000000000000000030C /* g_intermission.h in Headers */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000307 /* g_intermission.h */; };
 		D2A5C100000000000000004E /* g_item.h in Headers */ = {isa = PBXBuildFile; fileRef = CE12D6621C5C58C300CD0B13 /* g_item.h */; };
 		D2A5C100000000000000004F /* g_local.h in Headers */ = {isa = PBXBuildFile; fileRef = CE12D6631C5C58C300CD0B13 /* g_local.h */; };
 		D2A5C1000000000000000050 /* g_main.h in Headers */ = {isa = PBXBuildFile; fileRef = CE12D6651C5C58C300CD0B13 /* g_main.h */; };
@@ -1311,7 +1294,6 @@
 		D2A5C1000000000000000099 /* cg_predict.c in Sources */ = {isa = PBXBuildFile; fileRef = CE12D5771C5C58C300CD0B13 /* cg_predict.c */; };
 		D2A5C100000000000000009A /* cg_score.c in Sources */ = {isa = PBXBuildFile; fileRef = CE12D5791C5C58C300CD0B13 /* cg_score.c */; };
 		D2A5C100000000000000009B /* cg_vote.c in Sources */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000201 /* cg_vote.c */; };
-		D1A5B000000000000000040A /* cg_intermission.c in Sources */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000405 /* cg_intermission.c */; };
 		D2A5C100000000000000009C /* cg_sound.c in Sources */ = {isa = PBXBuildFile; fileRef = CEBDD1B525A0C2710055860E /* cg_sound.c */; };
 		D2A5C100000000000000009D /* cg_sprite.c in Sources */ = {isa = PBXBuildFile; fileRef = CEAC32B7242124BB007E1253 /* cg_sprite.c */; };
 		D2A5C100000000000000009E /* cg_module.c in Sources */ = {isa = PBXBuildFile; fileRef = D2A5C1000000000000000056 /* cg_module.c */; };
@@ -1422,24 +1404,42 @@
 		D9A5C10000000000000000D2 /* libshared.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CE80FDD51C5E3D4E00A21A51 /* libshared.a */; };
 		D9A5C10000000000000000D3 /* libcommon.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CE80FDE31C5E3E1100A21A51 /* libcommon.a */; };
 		D9A5C10000000000000000D4 /* libcollision.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CE80FE381C5E421900A21A51 /* libcollision.a */; };
-		DD006E4E558F9346D79447E5 /* scoreboard.css in CopyFiles */ = {isa = PBXBuildFile; fileRef = E0F247635165E5338AAD8494 /* scoreboard.css */; };
-		D1A5B0000000000000000504 /* intermission.css in CopyFiles */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000500 /* intermission.css */; };
+		D9A5C2010000000000000001 /* libminizip.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CE12D8111C5C5EF000CD0B13 /* libminizip.a */; };
+		D9A5C2010000000000000002 /* libminizip.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CE12D8111C5C5EF000CD0B13 /* libminizip.a */; };
+		D9A5C2010000000000000003 /* libminizip.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CE12D8111C5C5EF000CD0B13 /* libminizip.a */; };
+		D9A5C2010000000000000004 /* libminizip.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CE12D8111C5C5EF000CD0B13 /* libminizip.a */; };
+		D9A5C2010000000000000005 /* libminizip.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CE12D8111C5C5EF000CD0B13 /* libminizip.a */; };
+		D9A5C2010000000000000006 /* libminizip.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CE12D8111C5C5EF000CD0B13 /* libminizip.a */; };
+		D9A5C2010000000000000007 /* libminizip.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CE12D8111C5C5EF000CD0B13 /* libminizip.a */; };
+		D9A5C2010000000000000008 /* libminizip.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CE12D8111C5C5EF000CD0B13 /* libminizip.a */; };
+		D9A5C2010000000000000009 /* libminizip.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CE12D8111C5C5EF000CD0B13 /* libminizip.a */; };
+		D9A5C201000000000000000A /* libminizip.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CE12D8111C5C5EF000CD0B13 /* libminizip.a */; };
+		D9A5C201000000000000000B /* libminizip.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CE12D8111C5C5EF000CD0B13 /* libminizip.a */; };
+		D9A5C201000000000000000C /* libminizip.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CE12D8111C5C5EF000CD0B13 /* libminizip.a */; };
+		D9A5C201000000000000000D /* libminizip.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CE12D8111C5C5EF000CD0B13 /* libminizip.a */; };
+		D9A5C201000000000000000E /* libminizip.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CE12D8111C5C5EF000CD0B13 /* libminizip.a */; };
+		D9A5C201000000000000000F /* libminizip.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CE12D8111C5C5EF000CD0B13 /* libminizip.a */; };
+		D9A5C2010000000000000010 /* libminizip.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CE12D8111C5C5EF000CD0B13 /* libminizip.a */; };
+		D9A5C2010000000000000011 /* libminizip.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CE12D8111C5C5EF000CD0B13 /* libminizip.a */; };
+		D9F4D7BEB0EE4A87B8529DDA /* NotifyView.c in Sources */ = {isa = PBXBuildFile; fileRef = EB4A4D641AA8495FB08D9F0E /* NotifyView.c */; };
+		DD006E4E558F9346D79447E5 /* default/scoreboard.css in CopyFiles */ = {isa = PBXBuildFile; fileRef = E0F247635165E5338AAD8494 /* default/scoreboard.css */; };
 		DD02E1ABB673209C4A8D0EFC /* WeaponBarView.c in Sources */ = {isa = PBXBuildFile; fileRef = 7773870519E25AD88B29F618 /* WeaponBarView.c */; };
-		DD69DC98B2588BCF788647E3 /* hud.css in CopyFiles */ = {isa = PBXBuildFile; fileRef = 2D140F08524DA0679A7DB117 /* hud.css */; };
+		DD69DC98B2588BCF788647E3 /* default/hud.css in CopyFiles */ = {isa = PBXBuildFile; fileRef = 2D140F08524DA0679A7DB117 /* default/hud.css */; };
 		E10D01F620BB74E4166A8E7F /* WeaponBarView.c in Sources */ = {isa = PBXBuildFile; fileRef = 7773870519E25AD88B29F618 /* WeaponBarView.c */; };
 		E140557ED1DC8869F66A94BD /* VoteView.c in Sources */ = {isa = PBXBuildFile; fileRef = D7275B0BE3C194B1854A8FD6 /* VoteView.c */; };
 		E16A533FF7C34A2BA65E1BFF /* PickupView.c in Sources */ = {isa = PBXBuildFile; fileRef = E106ACFB28FF47443FB3C9FE /* PickupView.c */; };
 		E613CE6B3A9634DB694DA689 /* TeamBannerView.c in Sources */ = {isa = PBXBuildFile; fileRef = A73DD77B1D5B8231028B01FA /* TeamBannerView.c */; };
 		E70AD75417615E311748DB70 /* ScoreboardView.c in Sources */ = {isa = PBXBuildFile; fileRef = 45969B731C08AA84C8D318F6 /* ScoreboardView.c */; };
-		D1A5B000000000000000040B /* IntermissionView.c in Sources */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000401 /* IntermissionView.c */; };
 		E7A9F8759B856BBB62D69C03 /* PowerupView.c in Sources */ = {isa = PBXBuildFile; fileRef = 755F8C8CBA7F7C48E79A578C /* PowerupView.c */; };
 		EAC91DBE5BFAA686873683E8 /* TargetNameView.c in Sources */ = {isa = PBXBuildFile; fileRef = E6ACB2EEAD95B3757AE36A7A /* TargetNameView.c */; };
 		EC45E0FA2A80403C8FEA3834 /* cg_inventory.c in Sources */ = {isa = PBXBuildFile; fileRef = FCD76A809F00440F99BC0068 /* cg_inventory.c */; };
 		EEE815CF5A924D398351DF7C /* cm_voxel.h in Headers */ = {isa = PBXBuildFile; fileRef = 97BDA8A5C8DF41E290656B3D /* cm_voxel.h */; };
 		EF3850D157838948B4F2B64F /* CounterView.c in Sources */ = {isa = PBXBuildFile; fileRef = A59EB892C12DF10ACA8253DD /* CounterView.c */; };
 		F0D2694D4DD29796B8BB5639 /* NavEditView.c in Sources */ = {isa = PBXBuildFile; fileRef = 491F54CD554D0F550B000B4E /* NavEditView.c */; };
+		F0E26144AB354006B07FF3E0 /* ConsoleText.c in Sources */ = {isa = PBXBuildFile; fileRef = 09A28D5220214F20A1942F76 /* ConsoleText.c */; };
 		F2790FC8B72E7B3C54A53EED /* Rajdhani-Bold.ttf in CopyFiles */ = {isa = PBXBuildFile; fileRef = B8AED6163C10B91DD4151830 /* Rajdhani-Bold.ttf */; };
 		F53787C291008C7507AE5FF4 /* cm_manifest.h in Headers */ = {isa = PBXBuildFile; fileRef = 9BEEC6DF7149D25DE326F0A7 /* cm_manifest.h */; };
+		F794CD9FF6534935B10C3EFD /* ConsoleView.c in Sources */ = {isa = PBXBuildFile; fileRef = 7F6A5E1D6B8246A7B4EAD906 /* ConsoleView.c */; };
 		F7EBE32625F44EBF895E36BC /* cg_inventory.h in Headers */ = {isa = PBXBuildFile; fileRef = 066246FB7ACD4B74AC6A10C8 /* cg_inventory.h */; };
 		F8D615462A724ECF9847D4CD /* r_post.h in Headers */ = {isa = PBXBuildFile; fileRef = B80C92655F5249E48131CB95 /* r_post.h */; };
 		F956F2A93BABE228BC99C9E4 /* PowerupView.c in Sources */ = {isa = PBXBuildFile; fileRef = 755F8C8CBA7F7C48E79A578C /* PowerupView.c */; };
@@ -1801,35 +1801,14 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
-		CEA4C0DE2F9800000087C00C /* CopyFiles */ = {
-			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 2147483647;
-			dstPath = race/ui/hud/chrome;
-			dstSubfolderSpec = 16;
-			files = (
-				CEA4C0DE2F9800000087C017 /* hud.json in CopyFiles */,
-				CEA4C0DE2F9800000087C00B /* scoreboard.json in CopyFiles */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		0FB222CA4FDE0CA9865D5486 /* CopyFiles */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
 			dstPath = race/ui/hud/default;
 			dstSubfolderSpec = 16;
 			files = (
-				9E1C83CE11AE376D9174B271 /* hud.json in CopyFiles */,
-				544522FFCEEDAAC1EBEB6750 /* scoreboard.json in CopyFiles */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		CEA4C0DE2F9800000087C012 /* CopyFiles */ = {
-			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 2147483647;
-			dstPath = ctf/ui/hud/chrome;
-			dstSubfolderSpec = 16;
-			files = (
-				CEA4C0DE2F9800000087C011 /* hud.json in CopyFiles */,
+				9E1C83CE11AE376D9174B271 /* default/hud.json in CopyFiles */,
+				544522FFCEEDAAC1EBEB6750 /* default/scoreboard.json in CopyFiles */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1839,7 +1818,7 @@
 			dstPath = ctf/ui/hud/default;
 			dstSubfolderSpec = 16;
 			files = (
-				368D384E998F7590EBCEB7EE /* hud.json in CopyFiles */,
+				368D384E998F7590EBCEB7EE /* default/hud.json in CopyFiles */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1858,23 +1837,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		CEA4C0DE2F9800000087C015 /* CopyFiles */ = {
-			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 2147483647;
-			dstPath = lithium/ui/hud/chrome;
-			dstSubfolderSpec = 16;
-			files = (
-				CEA4C0DE2F9800000087C014 /* hud.json in CopyFiles */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		C9077C04022B772095186ABC /* CopyFiles */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
 			dstPath = lithium/ui/hud/default;
 			dstSubfolderSpec = 16;
 			files = (
-				B50A7AB9A94C86F0D55675BD /* hud.json in CopyFiles */,
+				B50A7AB9A94C86F0D55675BD /* default/hud.json in CopyFiles */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2025,6 +1994,52 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		CEA4C0DE2F9800000087C005 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = default/ui/hud/chrome;
+			dstSubfolderSpec = 16;
+			files = (
+				CEA4C0DE2F9800000087C003 /* chrome/hud.css in CopyFiles */,
+				CEA4C0DE2F9800000087C004 /* chrome/hud.json in CopyFiles */,
+				CEA4C0DE2F9800000087C008 /* chrome/scoreboard.css in CopyFiles */,
+				D1A5B0000000000000000506 /* chrome/intermission.css in CopyFiles */,
+				CEA4C0DE2F9800000087C009 /* chrome/scoreboard.json in CopyFiles */,
+				D1A5B0000000000000000507 /* chrome/intermission.json in CopyFiles */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CEA4C0DE2F9800000087C00C /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = race/ui/hud/chrome;
+			dstSubfolderSpec = 16;
+			files = (
+				CEA4C0DE2F9800000087C017 /* chrome/hud.json in CopyFiles */,
+				CEA4C0DE2F9800000087C00B /* chrome/scoreboard.json in CopyFiles */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CEA4C0DE2F9800000087C012 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = ctf/ui/hud/chrome;
+			dstSubfolderSpec = 16;
+			files = (
+				CEA4C0DE2F9800000087C011 /* chrome/hud.json in CopyFiles */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CEA4C0DE2F9800000087C015 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = lithium/ui/hud/chrome;
+			dstSubfolderSpec = 16;
+			files = (
+				CEA4C0DE2F9800000087C014 /* chrome/hud.json in CopyFiles */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		CEAA78A5277535F100EAC853 /* CopyFiles */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
@@ -2058,43 +2073,29 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		CEA4C0DE2F9800000087C005 /* CopyFiles */ = {
-			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 2147483647;
-			dstPath = default/ui/hud/chrome;
-			dstSubfolderSpec = 16;
-			files = (
-				CEA4C0DE2F9800000087C003 /* hud.css in CopyFiles */,
-				CEA4C0DE2F9800000087C004 /* hud.json in CopyFiles */,
-				CEA4C0DE2F9800000087C008 /* scoreboard.css in CopyFiles */,
-				D1A5B0000000000000000506 /* intermission.css in CopyFiles */,
-				CEA4C0DE2F9800000087C009 /* scoreboard.json in CopyFiles */,
-				D1A5B0000000000000000507 /* intermission.json in CopyFiles */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		EE7162D3228511D41E8B4CB1 /* CopyFiles */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
 			dstPath = default/ui/hud/default;
 			dstSubfolderSpec = 16;
 			files = (
-				DD69DC98B2588BCF788647E3 /* hud.css in CopyFiles */,
-				DD006E4E558F9346D79447E5 /* scoreboard.css in CopyFiles */,
-				D1A5B0000000000000000504 /* intermission.css in CopyFiles */,
-				322BAB812EFDDA99BA25575E /* scoreboard.json in CopyFiles */,
-				D1A5B0000000000000000505 /* intermission.json in CopyFiles */,
-				20BE76382F981DD4B7F43A11 /* hud.json in CopyFiles */,
+				DD69DC98B2588BCF788647E3 /* default/hud.css in CopyFiles */,
+				DD006E4E558F9346D79447E5 /* default/scoreboard.css in CopyFiles */,
+				D1A5B0000000000000000504 /* default/intermission.css in CopyFiles */,
+				322BAB812EFDDA99BA25575E /* default/scoreboard.json in CopyFiles */,
+				D1A5B0000000000000000505 /* default/intermission.json in CopyFiles */,
+				20BE76382F981DD4B7F43A11 /* default/hud.json in CopyFiles */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		027C4ADD65DCCCEBCEB3D462 /* hud.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = default/hud.json; sourceTree = "<group>"; };
+		027C4ADD65DCCCEBCEB3D462 /* default/hud.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = default/hud.json; sourceTree = "<group>"; };
 		02E20C6F468B8DCFDF5BB1A0 /* BarlowCondensed-SemiBold.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "BarlowCondensed-SemiBold.ttf"; sourceTree = "<group>"; };
 		066246FB7ACD4B74AC6A10C8 /* cg_inventory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = cg_inventory.h; sourceTree = "<group>"; };
 		07C9A88ED1D718092FD62601 /* CenterPrintView.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = CenterPrintView.c; sourceTree = "<group>"; };
+		09A28D5220214F20A1942F76 /* ConsoleText.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = ConsoleText.c; sourceTree = "<group>"; };
 		15F241361EC624CD05FF20DA /* HudViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = HudViewController.h; sourceTree = "<group>"; };
 		19388404C9634A90A13D5466 /* PingView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PingView.h; sourceTree = "<group>"; };
 		1A75866341F13821D2FC91FA /* CrosshairView.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = CrosshairView.c; sourceTree = "<group>"; };
@@ -2103,23 +2104,12 @@
 		20A922B6551C4CA8A3DCF8D8 /* DiagnosticsView.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = DiagnosticsView.c; sourceTree = "<group>"; };
 		26FE8732000C404A8AFA1688 /* r_post.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = r_post.c; sourceTree = "<group>"; };
 		2BA45B8C062C78CEE97C2D2B /* WeaponBarView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WeaponBarView.h; sourceTree = "<group>"; };
-		2D140F08524DA0679A7DB117 /* hud.css */ = {isa = PBXFileReference; lastKnownFileType = text.css; path = default/hud.css; sourceTree = "<group>"; };
-		CEA4C0DE2F9800000087C001 /* hud.css */ = {isa = PBXFileReference; lastKnownFileType = text.css; path = chrome/hud.css; sourceTree = "<group>"; };
-		CEA4C0DE2F9800000087C002 /* hud.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = chrome/hud.json; sourceTree = "<group>"; };
-		CEA4C0DE2F9800000087C006 /* scoreboard.css */ = {isa = PBXFileReference; lastKnownFileType = text.css; path = chrome/scoreboard.css; sourceTree = "<group>"; };
-		D1A5B0000000000000000502 /* intermission.css */ = {isa = PBXFileReference; lastKnownFileType = text.css; path = chrome/intermission.css; sourceTree = "<group>"; };
-		CEA4C0DE2F9800000087C007 /* scoreboard.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = chrome/scoreboard.json; sourceTree = "<group>"; };
-		D1A5B0000000000000000503 /* intermission.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = chrome/intermission.json; sourceTree = "<group>"; };
-		CEA4C0DE2F9800000087C00A /* scoreboard.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = chrome/scoreboard.json; sourceTree = "<group>"; };
-		CEA4C0DE2F9800000087C010 /* hud.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = chrome/hud.json; sourceTree = "<group>"; };
-		CEA4C0DE2F9800000087C013 /* hud.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = chrome/hud.json; sourceTree = "<group>"; };
-		CEA4C0DE2F9800000087C016 /* hud.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = chrome/hud.json; sourceTree = "<group>"; };
+		2D140F08524DA0679A7DB117 /* default/hud.css */ = {isa = PBXFileReference; lastKnownFileType = text.css; path = default/hud.css; sourceTree = "<group>"; };
+		2EA8B25732BD4FBCA2BCECC4 /* ChatView.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = ChatView.c; sourceTree = "<group>"; };
 		30FC7C9F9B24C6966D749398 /* NavEditView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NavEditView.h; sourceTree = "<group>"; };
-		3487B5AD7D47E8DFBDDAE5C4 /* hud.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = default/hud.json; sourceTree = "<group>"; };
+		3487B5AD7D47E8DFBDDAE5C4 /* default/hud.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = default/hud.json; sourceTree = "<group>"; };
 		40A40999BE66FAEBBBCCD450 /* ScoreboardView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ScoreboardView.h; sourceTree = "<group>"; };
-		D1A5B0000000000000000400 /* IntermissionView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = IntermissionView.h; sourceTree = "<group>"; };
 		45969B731C08AA84C8D318F6 /* ScoreboardView.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = ScoreboardView.c; sourceTree = "<group>"; };
-		D1A5B0000000000000000401 /* IntermissionView.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = IntermissionView.c; sourceTree = "<group>"; };
 		491F54CD554D0F550B000B4E /* NavEditView.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = NavEditView.c; sourceTree = "<group>"; };
 		4BF47DA7893C8563C1D59CDA /* BlendView.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = BlendView.c; sourceTree = "<group>"; };
 		4CA3522A5AE19B0F18CF79C6 /* TargetNameView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TargetNameView.h; sourceTree = "<group>"; };
@@ -2131,21 +2121,23 @@
 		5B027972461629119D87F7A6 /* ScoreView.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = ScoreView.c; sourceTree = "<group>"; };
 		5EFB54CE18B969B212A318C9 /* MPlusU-OFL.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = "MPlusU-OFL.txt"; sourceTree = "<group>"; };
 		63EC6B30290B4C7899E5F6AC /* DiagnosticsView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DiagnosticsView.h; sourceTree = "<group>"; };
-		64E652EE2F700EFB737AEA30 /* hud.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = default/hud.json; sourceTree = "<group>"; };
+		64E652EE2F700EFB737AEA30 /* default/hud.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = default/hud.json; sourceTree = "<group>"; };
 		671265A640259697D1AA363E /* ScoreView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ScoreView.h; sourceTree = "<group>"; };
-		7F6A5E1D6B8246A7B4EAD906 /* ConsoleView.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = ConsoleView.c; sourceTree = "<group>"; };
-		9352803A21064843A7D64A86 /* ConsoleViewController.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = ConsoleViewController.c; sourceTree = "<group>"; };
 		6F9DDB2DBBC915AE10C66CB1 /* BlendView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BlendView.h; sourceTree = "<group>"; };
 		6FAE0DA7D76F4C80B32F5DF2 /* post_fs.glsl */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = post_fs.glsl; sourceTree = "<group>"; };
 		740BEA7DBF2B020A6D1B29C7 /* TeamBannerView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TeamBannerView.h; sourceTree = "<group>"; };
+		743CD3FB2DAA4893BBF6DAF0 /* NotifyView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NotifyView.h; sourceTree = "<group>"; };
 		755F8C8CBA7F7C48E79A578C /* PowerupView.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = PowerupView.c; sourceTree = "<group>"; };
 		7773870519E25AD88B29F618 /* WeaponBarView.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = WeaponBarView.c; sourceTree = "<group>"; };
 		7966EA6596003F9303BC00FA /* bg_item.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = bg_item.c; sourceTree = "<group>"; };
+		7F6A5E1D6B8246A7B4EAD906 /* ConsoleView.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = ConsoleView.c; sourceTree = "<group>"; };
 		8238DE2CC5A406DE6DF84E71 /* OverlayText.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = OverlayText.c; sourceTree = "<group>"; };
-		848E81C81F875F4403EAE1EE /* scoreboard.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = default/scoreboard.json; sourceTree = "<group>"; };
-		D1A5B0000000000000000501 /* intermission.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = default/intermission.json; sourceTree = "<group>"; };
+		8369FC8AFCB94FBBAEA86FB4 /* ConsoleText.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ConsoleText.h; sourceTree = "<group>"; };
+		848E81C81F875F4403EAE1EE /* default/scoreboard.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = default/scoreboard.json; sourceTree = "<group>"; };
 		8542813678DB3B7BECEEF939 /* box.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = box.c; sourceTree = "<group>"; };
-		92AA3129971ABAAB21EE5BAD /* scoreboard.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = default/scoreboard.json; sourceTree = "<group>"; };
+		92AA3129971ABAAB21EE5BAD /* default/scoreboard.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = default/scoreboard.json; sourceTree = "<group>"; };
+		9330AABBEB8C4107BA2E49D2 /* ConsoleViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ConsoleViewController.h; sourceTree = "<group>"; };
+		9352803A21064843A7D64A86 /* ConsoleViewController.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = ConsoleViewController.c; sourceTree = "<group>"; };
 		94D1F06AFA9AE2182216CC46 /* SpectatorView.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = SpectatorView.c; sourceTree = "<group>"; };
 		97BDA8A5C8DF41E290656B3D /* cm_voxel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = cm_voxel.h; sourceTree = "<group>"; };
 		9BEEC6DF7149D25DE326F0A7 /* cm_manifest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = cm_manifest.h; sourceTree = "<group>"; };
@@ -2154,7 +2146,8 @@
 		9EB3BF772B595B2E11DA92E7 /* TimeView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TimeView.h; sourceTree = "<group>"; };
 		A59EB892C12DF10ACA8253DD /* CounterView.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = CounterView.c; sourceTree = "<group>"; };
 		A73DD77B1D5B8231028B01FA /* TeamBannerView.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = TeamBannerView.c; sourceTree = "<group>"; };
-		A980A8F791ED9C0A50C6C948 /* hud.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = default/hud.json; sourceTree = "<group>"; };
+		A980A8F791ED9C0A50C6C948 /* default/hud.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = default/hud.json; sourceTree = "<group>"; };
+		ABD78D80980A456A917E4BEA /* ChatView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ChatView.h; sourceTree = "<group>"; };
 		AC727F6BFFF40568A39B2DF0 /* ChaseView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ChaseView.h; sourceTree = "<group>"; };
 		AF339E8DC908A7FE1C759AEA /* VoteView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = VoteView.h; sourceTree = "<group>"; };
 		B00A6FD23FF3A3B4F77B3694 /* StatView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StatView.h; sourceTree = "<group>"; };
@@ -2162,6 +2155,7 @@
 		B73290DBC38EE6D335FC9BB9 /* MPlusU-Bold.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "MPlusU-Bold.ttf"; sourceTree = "<group>"; };
 		B80C92655F5249E48131CB95 /* r_post.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = r_post.h; sourceTree = "<group>"; };
 		B8AED6163C10B91DD4151830 /* Rajdhani-Bold.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Rajdhani-Bold.ttf"; sourceTree = "<group>"; };
+		BA1D8B3C499E4542BFE99DD9 /* ConsoleView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ConsoleView.h; sourceTree = "<group>"; };
 		BF98A24FAEEDE73A8F805F7D /* light_types.glsl */ = {isa = PBXFileReference; lastKnownFileType = text; path = light_types.glsl; sourceTree = "<group>"; };
 		C1D5EEC0EEA8441CDCC9D7CA /* CenterPrintView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CenterPrintView.h; sourceTree = "<group>"; };
 		C21FD90BD08D804DE1A792B1 /* HudViewController.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = HudViewController.c; sourceTree = "<group>"; };
@@ -2762,6 +2756,8 @@
 		CEA029F41C5E558100341079 /* quetoo-master */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = "quetoo-master"; sourceTree = BUILT_PRODUCTS_DIR; };
 		CEA082331DC6EBB7001207AA /* r_atlas.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = r_atlas.c; sourceTree = "<group>"; };
 		CEA082341DC6EBB7001207AA /* r_atlas.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = r_atlas.h; sourceTree = "<group>"; };
+		CEA0B1C02D0000010000A001 /* archive.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = archive.c; sourceTree = "<group>"; };
+		CEA0B1C12D0000010000A002 /* archive.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = archive.h; sourceTree = "<group>"; };
 		CEA153B1296B4BE100916F83 /* r_cull.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = r_cull.h; sourceTree = "<group>"; };
 		CEA153B2296B4BE100916F83 /* r_cull.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = r_cull.c; sourceTree = "<group>"; };
 		CEA1A0072F9F00000087B100 /* CreditsViewController.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = CreditsViewController.c; sourceTree = "<group>"; };
@@ -2787,6 +2783,14 @@
 		CEA400592F9900010087B100 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		CEA4005A2F9900010087B100 /* pyproject.toml */ = {isa = PBXFileReference; lastKnownFileType = text; path = pyproject.toml; sourceTree = "<group>"; };
 		CEA4005B2F9900010087B100 /* __init__.py */ = {isa = PBXFileReference; lastKnownFileType = text.script.python; path = __init__.py; sourceTree = "<group>"; };
+		CEA4C0DE2F9800000087C001 /* chrome/hud.css */ = {isa = PBXFileReference; lastKnownFileType = text.css; path = chrome/hud.css; sourceTree = "<group>"; };
+		CEA4C0DE2F9800000087C002 /* chrome/hud.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = chrome/hud.json; sourceTree = "<group>"; };
+		CEA4C0DE2F9800000087C006 /* chrome/scoreboard.css */ = {isa = PBXFileReference; lastKnownFileType = text.css; path = chrome/scoreboard.css; sourceTree = "<group>"; };
+		CEA4C0DE2F9800000087C007 /* chrome/scoreboard.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = chrome/scoreboard.json; sourceTree = "<group>"; };
+		CEA4C0DE2F9800000087C00A /* chrome/scoreboard.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = chrome/scoreboard.json; sourceTree = "<group>"; };
+		CEA4C0DE2F9800000087C010 /* chrome/hud.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = chrome/hud.json; sourceTree = "<group>"; };
+		CEA4C0DE2F9800000087C013 /* chrome/hud.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = chrome/hud.json; sourceTree = "<group>"; };
+		CEA4C0DE2F9800000087C016 /* chrome/hud.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = chrome/hud.json; sourceTree = "<group>"; };
 		CEA509052EA5D20A00F27205 /* check_cm_polylib */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = check_cm_polylib; sourceTree = BUILT_PRODUCTS_DIR; };
 		CEA509062EA5D21F00F27205 /* check_cm_entity.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = check_cm_entity.c; sourceTree = "<group>"; };
 		CEA716EC2FA796690099B469 /* Makefile.am */ = {isa = PBXFileReference; lastKnownFileType = text; path = Makefile.am; sourceTree = "<group>"; };
@@ -2864,8 +2868,6 @@
 		CEC0FF0020260103000000A1 /* cg_module.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = cg_module.c; sourceTree = "<group>"; };
 		CEC0FF0020260103000000EA /* game-ctf.so */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; path = "game-ctf.so"; sourceTree = BUILT_PRODUCTS_DIR; };
 		CEC0FF0020260103000001D4 /* cgame.so */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; name = cgame.so; path = "cgame-ctf.so"; sourceTree = BUILT_PRODUCTS_DIR; };
-		CEA0B1C12D0000010000A002 /* archive.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = archive.h; sourceTree = "<group>"; };
-		CEA0B1C02D0000010000A001 /* archive.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = archive.c; sourceTree = "<group>"; };
 		CEC74B3725C8EE94009C6218 /* installer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = installer.h; sourceTree = "<group>"; };
 		CEC74B3825C8EE94009C6218 /* installer.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = installer.c; sourceTree = "<group>"; };
 		CECA8CAE1E50B5F1005E97E8 /* material.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = material.c; sourceTree = "<group>"; };
@@ -2946,19 +2948,25 @@
 		D126FFD46C343DDC86C13E17 /* cm_manifest.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = cm_manifest.c; sourceTree = "<group>"; };
 		D1A5B0000000000000000001 /* bg_pmove_local.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = bg_pmove_local.h; sourceTree = "<group>"; };
 		D1A5B0000000000000000101 /* g_vote.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = g_vote.c; sourceTree = "<group>"; };
-		D1A5B0000000000000000300 /* g_intermission.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = g_intermission.c; sourceTree = "<group>"; };
 		D1A5B0000000000000000105 /* bg_vote.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = bg_vote.h; sourceTree = "<group>"; };
-		D1A5B0000000000000000304 /* bg_intermission.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = bg_intermission.h; sourceTree = "<group>"; };
 		D1A5B0000000000000000108 /* g_vote.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = g_vote.h; sourceTree = "<group>"; };
-		D1A5B0000000000000000307 /* g_intermission.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = g_intermission.h; sourceTree = "<group>"; };
 		D1A5B0000000000000000201 /* cg_vote.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = cg_vote.c; sourceTree = "<group>"; };
-		D1A5B0000000000000000405 /* cg_intermission.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = cg_intermission.c; sourceTree = "<group>"; };
 		D1A5B0000000000000000205 /* VoteViewController.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = VoteViewController.c; sourceTree = "<group>"; };
 		D1A5B0000000000000000209 /* VoteViewController.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = VoteViewController.json; sourceTree = "<group>"; };
 		D1A5B0000000000000000211 /* VoteViewController.css */ = {isa = PBXFileReference; lastKnownFileType = text.css; path = VoteViewController.css; sourceTree = "<group>"; };
 		D1A5B0000000000000000213 /* cg_vote.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = cg_vote.h; sourceTree = "<group>"; };
-		D1A5B0000000000000000409 /* cg_intermission.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = cg_intermission.h; sourceTree = "<group>"; };
 		D1A5B0000000000000000214 /* VoteViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = VoteViewController.h; sourceTree = "<group>"; };
+		D1A5B0000000000000000300 /* g_intermission.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = g_intermission.c; sourceTree = "<group>"; };
+		D1A5B0000000000000000304 /* bg_intermission.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = bg_intermission.h; sourceTree = "<group>"; };
+		D1A5B0000000000000000307 /* g_intermission.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = g_intermission.h; sourceTree = "<group>"; };
+		D1A5B0000000000000000400 /* IntermissionView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = IntermissionView.h; sourceTree = "<group>"; };
+		D1A5B0000000000000000401 /* IntermissionView.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = IntermissionView.c; sourceTree = "<group>"; };
+		D1A5B0000000000000000405 /* cg_intermission.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = cg_intermission.c; sourceTree = "<group>"; };
+		D1A5B0000000000000000409 /* cg_intermission.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = cg_intermission.h; sourceTree = "<group>"; };
+		D1A5B0000000000000000500 /* default/intermission.css */ = {isa = PBXFileReference; lastKnownFileType = text.css; path = default/intermission.css; sourceTree = "<group>"; };
+		D1A5B0000000000000000501 /* default/intermission.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = default/intermission.json; sourceTree = "<group>"; };
+		D1A5B0000000000000000502 /* chrome/intermission.css */ = {isa = PBXFileReference; lastKnownFileType = text.css; path = chrome/intermission.css; sourceTree = "<group>"; };
+		D1A5B0000000000000000503 /* chrome/intermission.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = chrome/intermission.json; sourceTree = "<group>"; };
 		D2A5C1000000000000000001 /* bg_item.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = bg_item.h; sourceTree = "<group>"; };
 		D2A5C1000000000000000002 /* bg_item.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = bg_item.c; sourceTree = "<group>"; };
 		D2A5C1000000000000000003 /* g_module.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = g_module.c; sourceTree = "<group>"; };
@@ -2987,23 +2995,15 @@
 		D9A5C10000000000000000B1 /* check_race */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = check_race; sourceTree = BUILT_PRODUCTS_DIR; };
 		DADE6340BDB64D222B75CD99 /* Rajdhani-OFL.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = "Rajdhani-OFL.txt"; sourceTree = "<group>"; };
 		DF0B9374573E39DECA0D8E4C /* manifest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = manifest.h; sourceTree = "<group>"; };
-		E0F247635165E5338AAD8494 /* scoreboard.css */ = {isa = PBXFileReference; lastKnownFileType = text.css; path = default/scoreboard.css; sourceTree = "<group>"; };
-		D1A5B0000000000000000500 /* intermission.css */ = {isa = PBXFileReference; lastKnownFileType = text.css; path = default/intermission.css; sourceTree = "<group>"; };
+		E0F247635165E5338AAD8494 /* default/scoreboard.css */ = {isa = PBXFileReference; lastKnownFileType = text.css; path = default/scoreboard.css; sourceTree = "<group>"; };
 		E106ACFB28FF47443FB3C9FE /* PickupView.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = PickupView.c; sourceTree = "<group>"; };
 		E6ACB2EEAD95B3757AE36A7A /* TargetNameView.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = TargetNameView.c; sourceTree = "<group>"; };
 		EA8FE4E62B47061B1ADBD908 /* FpsView.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = FpsView.c; sourceTree = "<group>"; };
 		EB4A4D641AA8495FB08D9F0E /* NotifyView.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = NotifyView.c; sourceTree = "<group>"; };
-		743CD3FB2DAA4893BBF6DAF0 /* NotifyView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NotifyView.h; sourceTree = "<group>"; };
-		09A28D5220214F20A1942F76 /* ConsoleText.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = ConsoleText.c; sourceTree = "<group>"; };
-		8369FC8AFCB94FBBAEA86FB4 /* ConsoleText.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ConsoleText.h; sourceTree = "<group>"; };
-		2EA8B25732BD4FBCA2BCECC4 /* ChatView.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = ChatView.c; sourceTree = "<group>"; };
-		ABD78D80980A456A917E4BEA /* ChatView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ChatView.h; sourceTree = "<group>"; };
 		F62845AB16EAC431505215D1 /* FpsView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FpsView.h; sourceTree = "<group>"; };
 		F7E7256984E276048C2A155E /* bg_item.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = bg_item.h; sourceTree = "<group>"; };
 		FC6374C1D47393EA62C8EC20 /* CounterView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CounterView.h; sourceTree = "<group>"; };
 		FCD76A809F00440F99BC0068 /* cg_inventory.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = cg_inventory.c; sourceTree = "<group>"; };
-		BA1D8B3C499E4542BFE99DD9 /* ConsoleView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ConsoleView.h; sourceTree = "<group>"; };
-		9330AABBEB8C4107BA2E49D2 /* ConsoleViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ConsoleViewController.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -3475,32 +3475,38 @@
 				07C9A88ED1D718092FD62601 /* CenterPrintView.c */,
 				AC727F6BFFF40568A39B2DF0 /* ChaseView.h */,
 				1C923406FE86A096F618B0A6 /* ChaseView.c */,
-				2D140F08524DA0679A7DB117 /* hud.css */,
-				64E652EE2F700EFB737AEA30 /* hud.json */,
-				CEA4C0DE2F9800000087C001 /* hud.css */,
-				CEA4C0DE2F9800000087C002 /* hud.json */,
-				CEA4C0DE2F9800000087C006 /* scoreboard.css */,
-				D1A5B0000000000000000502 /* intermission.css */,
-				CEA4C0DE2F9800000087C007 /* scoreboard.json */,
-				D1A5B0000000000000000503 /* intermission.json */,
+				ABD78D80980A456A917E4BEA /* ChatView.h */,
+				2EA8B25732BD4FBCA2BCECC4 /* ChatView.c */,
+				CEA4C0DE2F9800000087C001 /* chrome/hud.css */,
+				CEA4C0DE2F9800000087C002 /* chrome/hud.json */,
+				D1A5B0000000000000000502 /* chrome/intermission.css */,
+				D1A5B0000000000000000503 /* chrome/intermission.json */,
+				CEA4C0DE2F9800000087C006 /* chrome/scoreboard.css */,
+				CEA4C0DE2F9800000087C007 /* chrome/scoreboard.json */,
+				8369FC8AFCB94FBBAEA86FB4 /* ConsoleText.h */,
+				09A28D5220214F20A1942F76 /* ConsoleText.c */,
 				FC6374C1D47393EA62C8EC20 /* CounterView.h */,
 				A59EB892C12DF10ACA8253DD /* CounterView.c */,
 				C8249BF99F0E4A2D77D37865 /* CrosshairView.h */,
 				1A75866341F13821D2FC91FA /* CrosshairView.c */,
+				2D140F08524DA0679A7DB117 /* default/hud.css */,
+				64E652EE2F700EFB737AEA30 /* default/hud.json */,
+				D1A5B0000000000000000500 /* default/intermission.css */,
+				D1A5B0000000000000000501 /* default/intermission.json */,
+				E0F247635165E5338AAD8494 /* default/scoreboard.css */,
+				848E81C81F875F4403EAE1EE /* default/scoreboard.json */,
 				63EC6B30290B4C7899E5F6AC /* DiagnosticsView.h */,
 				20A922B6551C4CA8A3DCF8D8 /* DiagnosticsView.c */,
 				F62845AB16EAC431505215D1 /* FpsView.h */,
 				EA8FE4E62B47061B1ADBD908 /* FpsView.c */,
-				743CD3FB2DAA4893BBF6DAF0 /* NotifyView.h */,
-				EB4A4D641AA8495FB08D9F0E /* NotifyView.c */,
-				8369FC8AFCB94FBBAEA86FB4 /* ConsoleText.h */,
-				09A28D5220214F20A1942F76 /* ConsoleText.c */,
-				ABD78D80980A456A917E4BEA /* ChatView.h */,
-				2EA8B25732BD4FBCA2BCECC4 /* ChatView.c */,
 				15F241361EC624CD05FF20DA /* HudViewController.h */,
 				C21FD90BD08D804DE1A792B1 /* HudViewController.c */,
+				D1A5B0000000000000000400 /* IntermissionView.h */,
+				D1A5B0000000000000000401 /* IntermissionView.c */,
 				30FC7C9F9B24C6966D749398 /* NavEditView.h */,
 				491F54CD554D0F550B000B4E /* NavEditView.c */,
+				743CD3FB2DAA4893BBF6DAF0 /* NotifyView.h */,
+				EB4A4D641AA8495FB08D9F0E /* NotifyView.c */,
 				5ABD97400D2B37C6E27C8BE0 /* OverlayText.h */,
 				8238DE2CC5A406DE6DF84E71 /* OverlayText.c */,
 				51B36F4226CEC7C84538DC2F /* PickupView.h */,
@@ -3509,14 +3515,8 @@
 				5624F1C74F4646918DA71088 /* PingView.c */,
 				C853849AF0A2CC2F7C531245 /* PowerupView.h */,
 				755F8C8CBA7F7C48E79A578C /* PowerupView.c */,
-				E0F247635165E5338AAD8494 /* scoreboard.css */,
-				D1A5B0000000000000000500 /* intermission.css */,
-				848E81C81F875F4403EAE1EE /* scoreboard.json */,
-				D1A5B0000000000000000501 /* intermission.json */,
 				40A40999BE66FAEBBBCCD450 /* ScoreboardView.h */,
-				D1A5B0000000000000000400 /* IntermissionView.h */,
 				45969B731C08AA84C8D318F6 /* ScoreboardView.c */,
-				D1A5B0000000000000000401 /* IntermissionView.c */,
 				671265A640259697D1AA363E /* ScoreView.h */,
 				5B027972461629119D87F7A6 /* ScoreView.c */,
 				9C56DC135154CED4C2498031 /* SpectatorView.h */,
@@ -3569,8 +3569,8 @@
 		44C65CA8992081850A0BD1FD /* hud */ = {
 			isa = PBXGroup;
 			children = (
-				A980A8F791ED9C0A50C6C948 /* hud.json */,
-				CEA4C0DE2F9800000087C013 /* hud.json */,
+				A980A8F791ED9C0A50C6C948 /* default/hud.json */,
+				CEA4C0DE2F9800000087C013 /* chrome/hud.json */,
 			);
 			path = hud;
 			sourceTree = "<group>";
@@ -3578,10 +3578,10 @@
 		A1CD3C66668D0BA51E31ECEC /* hud */ = {
 			isa = PBXGroup;
 			children = (
-				027C4ADD65DCCCEBCEB3D462 /* hud.json */,
-				CEA4C0DE2F9800000087C016 /* hud.json */,
-				92AA3129971ABAAB21EE5BAD /* scoreboard.json */,
-				CEA4C0DE2F9800000087C00A /* scoreboard.json */,
+				027C4ADD65DCCCEBCEB3D462 /* default/hud.json */,
+				CEA4C0DE2F9800000087C016 /* chrome/hud.json */,
+				92AA3129971ABAAB21EE5BAD /* default/scoreboard.json */,
+				CEA4C0DE2F9800000087C00A /* chrome/scoreboard.json */,
 			);
 			path = hud;
 			sourceTree = "<group>";
@@ -4916,8 +4916,8 @@
 		D21789E6990AEF2265381BDE /* hud */ = {
 			isa = PBXGroup;
 			children = (
-				3487B5AD7D47E8DFBDDAE5C4 /* hud.json */,
-				CEA4C0DE2F9800000087C010 /* hud.json */,
+				3487B5AD7D47E8DFBDDAE5C4 /* default/hud.json */,
+				CEA4C0DE2F9800000087C010 /* chrome/hud.json */,
 			);
 			path = hud;
 			sourceTree = "<group>";

--- a/apple/Makefile
+++ b/apple/Makefile
@@ -6,14 +6,8 @@
 #   make sign               # sign with Developer ID (cert must be in Keychain)
 #   make dmg                # create distributable DMG
 #   make notarize           # notarize and staple DMG (needs APPLE_* env vars)
-#
-# For the bundle (with game data) DMG:
-#   make bundle-data QUETOO_DATA_DIR=../../quetoo-data
-#   make bundle-sign
-#   make bundle-notarize
 
 CODESIGN_IDENTITY ?= "Developer ID Application: Jay Dolan (C5PXKE9CU5)"
-QUETOO_DATA_DIR   ?= ../../quetoo-data
 
 ARCH      = arm64
 BUILD     = $(ARCH)-apple-darwin
@@ -25,7 +19,6 @@ MODULEDIR = $(LIBDIR)/quetoo
 DATADIR   = $(INSTALL)/Contents/Resources
 
 SNAPSHOT        = $(TARGET)/Quetoo-$(BUILD).dmg
-BUNDLE_SNAPSHOT = $(TARGET)/Quetoo-bundle-$(BUILD).dmg
 VOLUME_NAME     = "Quetoo"
 DMG_ROOT        = $(TARGET)/dmg-root
 
@@ -106,7 +99,15 @@ dmg: dmg-layout
 	hdiutil create -volname $(VOLUME_NAME) -srcfolder "$(DMG_ROOT)" \
 		-ov -format UDZO $(SNAPSHOT)
 
-# Notarize and staple the binary DMG.
+# Notarize and staple the DMG.
+#
+# The app inside is deliberately not stapled separately. Stapling it after the
+# image is built would not reach the copy already written into it, and doing it
+# properly would mean a second notarization round trip before the image exists.
+# It buys nothing in practice: the installer downloads the image itself, so the
+# app it extracts carries no quarantine attribute and Gatekeeper never performs
+# a full assessment on it.
+#
 # Requires env vars: APPLE_ID, APPLE_TEAM_ID, APPLE_APP_PASSWORD
 notarize: dmg
 	xcrun notarytool submit $(SNAPSHOT) \
@@ -116,34 +117,8 @@ notarize: dmg
 		--wait
 	xcrun stapler staple $(SNAPSHOT)
 
-# Copy quetoo-data into Contents/Resources/ to produce a self-contained bundle.
-bundle-data:
-	mkdir -p $(DATADIR)/default
-	cp -r $(QUETOO_DATA_DIR)/target/default/. $(DATADIR)/default/
-
-# Re-seal the bundle after adding game data.
-bundle-sign:
-	codesign --force --timestamp --options runtime \
-		--sign $(CODESIGN_IDENTITY) $(INSTALL)
-	codesign --verify --deep $(INSTALL)
-
-bundle-dmg: dmg-layout
-	hdiutil create -volname $(VOLUME_NAME) -srcfolder "$(DMG_ROOT)" \
-		-ov -format UDZO $(BUNDLE_SNAPSHOT)
-
-# Notarize and staple the bundle DMG.
-# Requires env vars: APPLE_ID, APPLE_TEAM_ID, APPLE_APP_PASSWORD
-bundle-notarize: bundle-dmg
-	xcrun notarytool submit $(BUNDLE_SNAPSHOT) \
-		--apple-id "$$APPLE_ID" \
-		--team-id "$$APPLE_TEAM_ID" \
-		--password "$$APPLE_APP_PASSWORD" \
-		--wait
-	xcrun stapler staple $(BUNDLE_SNAPSHOT)
-
 clean:
 	rm -rf $(TARGET)/*
 
 .PHONY: all configure compile pre-install install install-lib move-resources \
-        sign dmg-layout dmg notarize bundle-data bundle-sign \
-        bundle-dmg bundle-notarize clean
+        sign dmg-layout dmg notarize clean

--- a/src/cgame/cgame.h
+++ b/src/cgame/cgame.h
@@ -37,7 +37,7 @@
 #include <Objectively/RESTClient.h>
 #include <Objectively/Vector.h>
 
-#define CGAME_API_VERSION 45
+#define CGAME_API_VERSION 46
 
 /**
  * @brief The client game import struct imports engine functionailty to the client game.

--- a/src/cgame/cgame.h
+++ b/src/cgame/cgame.h
@@ -332,6 +332,13 @@ typedef struct cg_import_s {
   cvar_t *(*ToggleCvar)(const char *name);
 
   /**
+   * @brief Answers the question posed by `INSTALLER_UPDATE_AVAILABLE`.
+   * @details The installer waits for this before acting on an available
+   * update. Declining applies to this run only; the next launch asks again.
+   */
+  void (*ConsentToUpdate)(bool accept);
+
+  /**
    * @brief Registers and returns a console command.
    * @param name The command name (e.g. `"wave"`).
    * @param function The command function.

--- a/src/cgame/common/cg_ui.c
+++ b/src/cgame/common/cg_ui.c
@@ -21,6 +21,7 @@
 
 #include "cg_local.h"
 
+#include "ui/DialogViewController.h"
 #include "ui/main/MainViewController.h"
 #include "ui/main/LoadingViewController.h"
 #include "ui/main/UpdateViewController.h"
@@ -194,6 +195,17 @@ void Cg_UpdateLoading(const cl_loading_t loading) {
  * @brief Manages the UpdateViewController lifecycle and routes installer progress to it.
  * Pushes UpdateViewController when updating, pops it on completion.
  */
+/**
+ * @brief Dialog callbacks recording whether to install an available update.
+ */
+static void Cg_AcceptUpdate(ident data) {
+  cgi.SetCvarInteger("update_consent", 1);
+}
+
+static void Cg_DeclineUpdate(ident data) {
+  cgi.SetCvarInteger("update_consent", -1);
+}
+
 int32_t Cg_UpdateInstaller(const installer_status_t *in) {
 
   if (updateViewController == NULL) {
@@ -202,6 +214,31 @@ int32_t Cg_UpdateInstaller(const installer_status_t *in) {
   }
 
   $(updateViewController, setStatus, in);
+
+  if (in->state == INSTALLER_UPDATE_AVAILABLE && cgi.GetCvarInteger("update_consent") == 0) {
+
+    ViewController *this = (ViewController *) updateViewController;
+
+    const Array *children = (Array *) this->childViewControllers;
+    for (size_t i = 0; i < children->count; i++) {
+      if ($((Object *) children->elements[i], isKindOfClass, _DialogViewController())) {
+        return 0;
+      }
+    }
+
+    ViewController *dialog = (ViewController *) $(alloc(DialogViewController), initWithDialog, &(const Dialog) {
+      .message = va("Quetoo %s is available. Install it?", in->current_file),
+      .ok = "Install",
+      .cancel = "Not now",
+      .okFunction = Cg_AcceptUpdate,
+      .cancelFunction = Cg_DeclineUpdate
+    });
+
+    $(this, addChildViewController, dialog);
+    release(dialog);
+
+    return 0;
+  }
 
   if (in->state == INSTALLER_DONE || in->state == INSTALLER_ERROR) {
     static uint64_t done_at = 0;

--- a/src/cgame/common/cg_ui.c
+++ b/src/cgame/common/cg_ui.c
@@ -196,14 +196,14 @@ void Cg_UpdateLoading(const cl_loading_t loading) {
  * Pushes UpdateViewController when updating, pops it on completion.
  */
 /**
- * @brief Dialog callbacks recording whether to install an available update.
+ * @brief Dialog callbacks answering whether to install an available update.
  */
 static void Cg_AcceptUpdate(ident data) {
-  cgi.SetCvarInteger("update_consent", 1);
+  cgi.ConsentToUpdate(true);
 }
 
 static void Cg_DeclineUpdate(ident data) {
-  cgi.SetCvarInteger("update_consent", -1);
+  cgi.ConsentToUpdate(false);
 }
 
 int32_t Cg_UpdateInstaller(const installer_status_t *in) {
@@ -215,7 +215,7 @@ int32_t Cg_UpdateInstaller(const installer_status_t *in) {
 
   $(updateViewController, setStatus, in);
 
-  if (in->state == INSTALLER_UPDATE_AVAILABLE && cgi.GetCvarInteger("update_consent") == 0) {
+  if (in->state == INSTALLER_UPDATE_AVAILABLE) {
 
     ViewController *this = (ViewController *) updateViewController;
 

--- a/src/cgame/common/cg_ui.c
+++ b/src/cgame/common/cg_ui.c
@@ -203,14 +203,6 @@ int32_t Cg_UpdateInstaller(const installer_status_t *in) {
 
   $(updateViewController, setStatus, in);
 
-  if (in->state == INSTALLER_UPDATE_AVAILABLE) {
-    mainViewController->updateAvailable = true;
-    cgi.PopViewController();
-    release(updateViewController);
-    updateViewController = NULL;
-    return 1;
-  }
-
   if (in->state == INSTALLER_DONE || in->state == INSTALLER_ERROR) {
     static uint64_t done_at = 0;
     if (done_at == 0) {

--- a/src/cgame/common/ui/main/MainViewController.c
+++ b/src/cgame/common/ui/main/MainViewController.c
@@ -65,13 +65,6 @@ static void didClickNavigateViewController(Button *button) {
 }
 
 /**
- * @brief Opens the releases page.
- */
-static void openReleasesPage(ident data) {
-  SDL_OpenURL(QUETOO_RELEASES_URL);
-}
-
-/**
  * @brief Presents `dialog`, unless one is already showing: a dialog asks a
  * question, and a second copy of the question does not make it a better one.
  */
@@ -236,17 +229,6 @@ static void viewWillAppear(ViewController *self) {
     if (team == TEAM_NONE) {
       $(this, navigateToViewController, _TeamsViewController());
     }
-  }
-
-  if (this->updateAvailable) {
-    this->updateAvailable = false;
-
-    presentDialog(this, &(const Dialog) {
-      .message = "A new version of Quetoo is available. Download now?",
-      .ok = "Yes",
-      .cancel = "No",
-      .okFunction = openReleasesPage
-    });
   }
 }
 

--- a/src/cgame/common/ui/main/MainViewController.h
+++ b/src/cgame/common/ui/main/MainViewController.h
@@ -64,10 +64,6 @@ struct MainViewController {
    */
   NavigationViewController *navigationViewController;
 
-  /**
-   * @brief Set when an update is available, to present the update dialog on next appearance.
-   */
-  bool updateAvailable;
 };
 
 /**

--- a/src/cgame/common/ui/main/UpdateViewController.c
+++ b/src/cgame/common/ui/main/UpdateViewController.c
@@ -221,6 +221,15 @@ static void setStatus(UpdateViewController *self, const installer_status_t *in) 
       $(self->progressBar, setLabelFormat, "Unpacking update\u2026");
       $(self->progressBar, setValue, 100.0);
       break;
+    case INSTALLER_INSTALLING_DATA: {
+      double pct = 0.0;
+      if (in->kbytes_total > 0) {
+        pct = 100.0 * in->kbytes_done / in->kbytes_total;
+      }
+      $(self->progressBar, setLabelFormat, "Installing game data\u2026");
+      $(self->progressBar, setValue, pct);
+    }
+      break;
     case INSTALLER_UPDATE_STAGED:
       $(self->progressBar, setLabelFormat, "Update ready; it will be applied when you quit.");
       $(self->progressBar, setValue, 100.0);

--- a/src/cgame/common/ui/main/UpdateViewController.c
+++ b/src/cgame/common/ui/main/UpdateViewController.c
@@ -206,6 +206,23 @@ static void setStatus(UpdateViewController *self, const installer_status_t *in) 
       break;
     case INSTALLER_UPDATE_AVAILABLE:
       $(self->progressBar, setLabelFormat, "Update available.");
+      $(self->progressBar, setValue, 0.0);
+      break;
+    case INSTALLER_DOWNLOADING_UPDATE: {
+      double pct = 0.0;
+      if (in->kbytes_total > 0) {
+        pct = 100.0 * in->kbytes_done / in->kbytes_total;
+      }
+      $(self->progressBar, setLabelFormat, va("Downloading %s \u2026", in->current_file));
+      $(self->progressBar, setValue, pct);
+    }
+      break;
+    case INSTALLER_STAGING_UPDATE:
+      $(self->progressBar, setLabelFormat, "Unpacking update\u2026");
+      $(self->progressBar, setValue, 100.0);
+      break;
+    case INSTALLER_UPDATE_STAGED:
+      $(self->progressBar, setLabelFormat, "Update ready; it will be applied when you quit.");
       $(self->progressBar, setValue, 100.0);
       break;
 		case INSTALLER_COMPARING:

--- a/src/client/cl_cgame.c
+++ b/src/client/cl_cgame.c
@@ -219,6 +219,8 @@ void Cl_InitCgame(void) {
   import.ForceSetCvarString = Cvar_ForceSetString;
   import.ForceSetCvarValue = Cvar_ForceSetValue;
   import.ToggleCvar = Cvar_Toggle;
+
+  import.ConsentToUpdate = Installer_Consent;
   import.AddCmd = Cmd_Add;
   import.Cbuf = Cbuf_AddText;
   import.Tail = Con_Tail;

--- a/src/common/Makefile.am
+++ b/src/common/Makefile.am
@@ -1,4 +1,5 @@
 noinst_HEADERS = \
+	archive.h \
 	atlas.h \
 	cmd.h \
 	common.h \
@@ -17,6 +18,7 @@ noinst_LTLIBRARIES = \
 	libcommon.la
 
 libcommon_la_SOURCES = \
+	archive.c \
 	atlas.c \
 	cmd.c \
 	common.c \
@@ -32,6 +34,7 @@ libcommon_la_SOURCES = \
 	thread.c
 
 libcommon_la_CFLAGS = \
+	-I$(top_srcdir) \
 	-I$(top_srcdir)/src \
 	@BASE_CFLAGS@ \
 	@OBJECTIVELY_CFLAGS@ \
@@ -40,6 +43,7 @@ libcommon_la_CFLAGS = \
 libcommon_la_LDFLAGS = \
 	-shared
 libcommon_la_LIBADD = \
+	$(top_builddir)/deps/minizip/libminizip.la \
 	$(top_builddir)/src/shared/libshared.la \
 	@BASE_LIBS@ \
 	@OBJECTIVELY_LIBS@ \

--- a/src/common/archive.c
+++ b/src/common/archive.c
@@ -1,0 +1,364 @@
+/*
+ * Copyright(c) 1997-2001 id Software, Inc.
+ * Copyright(c) 2002 The Quakeforge Project.
+ * Copyright(c) 2006 Quetoo.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+#include <ctype.h>
+
+#include <SDL3/SDL_filesystem.h>
+#include <SDL3/SDL_process.h>
+
+#include "archive.h"
+#include "console.h"
+
+#include "deps/minizip/miniz.h"
+
+#if defined(__APPLE__)
+#include <dirent.h>
+#include <sys/stat.h>
+#endif
+
+/**
+ * @brief Windows reserves these names in every directory, with or without an
+ * extension. Creating one from archive content is never legitimate.
+ */
+static const char *archive_reserved_names[] = {
+  "CON", "PRN", "AUX", "NUL",
+  "COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7", "COM8", "COM9",
+  "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9"
+};
+
+/**
+ * @brief Returns true if `component` names a Windows reserved device.
+ */
+static bool Archive_IsReservedName(const char *component, size_t len) {
+
+  size_t stem = 0;
+  while (stem < len && component[stem] != '.') {
+    stem++;
+  }
+
+  for (size_t i = 0; i < lengthof(archive_reserved_names); i++) {
+    const char *reserved = archive_reserved_names[i];
+    if (stem == q_strlen(reserved) && q_strncasecmp(component, reserved, stem) == 0) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+bool Archive_SafePath(const char *dest, const char *name, char *out, size_t len) {
+
+  if (*name == '\0') {
+    return false;
+  }
+
+  if (*name == '/' || *name == '\\') {
+    return false;
+  }
+
+  if (isalpha((unsigned char) name[0]) && name[1] == ':') {
+    return false;
+  }
+
+  char normalized[MAX_OS_PATH];
+  if (q_strlcpy(normalized, name, sizeof(normalized)) >= sizeof(normalized)) {
+    return false;
+  }
+
+  for (char *c = normalized; *c; c++) {
+    if (*c == '\\') {
+      *c = '/';
+    }
+  }
+
+  const char *component = normalized;
+  while (*component) {
+
+    const char *end = q_strchr(component, '/');
+    const size_t clen = end ? (size_t) (end - component) : q_strlen(component);
+
+    if (clen == 2 && q_strncmp(component, "..", 2) == 0) {
+      return false;
+    }
+
+    if (clen && Archive_IsReservedName(component, clen)) {
+      return false;
+    }
+
+    if (clen && (component[clen - 1] == '.' || component[clen - 1] == ' ')) {
+      return false;
+    }
+
+    if (!end) {
+      break;
+    }
+
+    component = end + 1;
+  }
+
+  if (q_snprintf(out, len, "%s/%s", dest, normalized) >= (int32_t) len) {
+    return false;
+  }
+
+  return true;
+}
+
+/**
+ * @brief Creates the parent directory of `path`, including intermediates.
+ */
+static bool Archive_CreateParent(const char *path) {
+
+  char dir[MAX_OS_PATH];
+  q_strlcpy(dir, path, sizeof(dir));
+
+  char *slash = q_strrchr(dir, '/');
+  if (!slash) {
+    return true;
+  }
+
+  *slash = '\0';
+  return SDL_CreateDirectory(dir);
+}
+
+/**
+ * @brief Runs `args` to completion, logging its output if it fails.
+ * @return True if the process exited zero.
+ */
+static bool Archive_Spawn(const char * const *args) {
+
+  SDL_Process *process = SDL_CreateProcess(args, true);
+  if (!process) {
+    Com_Warn("Failed to run %s: %s\n", args[0], SDL_GetError());
+    return false;
+  }
+
+  int exit_code = -1;
+  size_t length = 0;
+  void *output = SDL_ReadProcess(process, &length, &exit_code);
+
+  if (exit_code != 0) {
+    Com_Warn("%s exited %d\n", args[0], exit_code);
+    if (output && length) {
+      Com_Warn("%s: %.*s\n", args[0], (int32_t) length, (const char *) output);
+    }
+  }
+
+  SDL_free(output);
+  SDL_DestroyProcess(process);
+
+  return exit_code == 0;
+}
+
+/**
+ * @brief Extracts a `.zip` with the vendored miniz, sanitizing every member.
+ */
+static bool Archive_ExtractZip(const char *archive, const char *dest) {
+
+  mz_zip_archive zip;
+  memset(&zip, 0, sizeof(zip));
+
+  if (!mz_zip_reader_init_file(&zip, archive, 0)) {
+    Com_Warn("Failed to open %s: %s\n", archive, mz_zip_get_error_string(mz_zip_get_last_error(&zip)));
+    return false;
+  }
+
+  bool success = true;
+  const mz_uint count = mz_zip_reader_get_num_files(&zip);
+
+  for (mz_uint i = 0; i < count; i++) {
+
+    mz_zip_archive_file_stat stat;
+    if (!mz_zip_reader_file_stat(&zip, i, &stat)) {
+      Com_Warn("Failed to stat member %u of %s\n", i, archive);
+      success = false;
+      break;
+    }
+
+    char path[MAX_OS_PATH];
+    if (!Archive_SafePath(dest, stat.m_filename, path, sizeof(path))) {
+      Com_Warn("Refusing unsafe archive member: %s\n", stat.m_filename);
+      success = false;
+      break;
+    }
+
+    if (stat.m_is_directory) {
+      if (!SDL_CreateDirectory(path)) {
+        Com_Warn("Failed to create %s: %s\n", path, SDL_GetError());
+        success = false;
+        break;
+      }
+      continue;
+    }
+
+    if (!Archive_CreateParent(path)) {
+      Com_Warn("Failed to create directory for %s: %s\n", path, SDL_GetError());
+      success = false;
+      break;
+    }
+
+    if (!mz_zip_reader_extract_to_file(&zip, i, path, 0)) {
+      Com_Warn("Failed to extract %s: %s\n", stat.m_filename,
+               mz_zip_get_error_string(mz_zip_get_last_error(&zip)));
+      success = false;
+      break;
+    }
+  }
+
+  mz_zip_reader_end(&zip);
+  return success;
+}
+
+#if defined(__APPLE__)
+
+/**
+ * @brief Copies every non-symlink entry of `mount` into `dest` with `ditto`.
+ * @details The disk image also carries an `/Applications` alias for drag
+ * installs, which must not be followed. `ditto` rather than `cp` because it
+ * preserves the extended attributes and resource forks that keep a bundle's
+ * code signature valid.
+ */
+static bool Archive_DittoMount(const char *mount, const char *dest) {
+
+  DIR *dir = opendir(mount);
+  if (!dir) {
+    Com_Warn("Failed to read %s\n", mount);
+    return false;
+  }
+
+  bool success = true;
+
+  const struct dirent *entry;
+  while ((entry = readdir(dir))) {
+
+    if (q_strcmp(entry->d_name, ".") == 0 || q_strcmp(entry->d_name, "..") == 0) {
+      continue;
+    }
+
+    char src[MAX_OS_PATH];
+    q_snprintf(src, sizeof(src), "%s/%s", mount, entry->d_name);
+
+    struct stat st;
+    if (lstat(src, &st) == 0 && S_ISLNK(st.st_mode)) {
+      continue;
+    }
+
+    char dst[MAX_OS_PATH];
+    q_snprintf(dst, sizeof(dst), "%s/%s", dest, entry->d_name);
+
+    if (!Archive_Spawn((const char *[]) { "/usr/bin/ditto", src, dst, NULL })) {
+      success = false;
+      break;
+    }
+  }
+
+  closedir(dir);
+  return success;
+}
+
+/**
+ * @brief Extracts a `.dmg` by mounting it at a path we choose.
+ * @details Passing `-mountpoint` avoids parsing `hdiutil`'s output for the
+ * volume it picked, and avoids colliding with an already-mounted volume of the
+ * same name. The image is always detached, including on failure.
+ */
+static bool Archive_ExtractDmg(const char *archive, const char *dest) {
+
+  char mount[MAX_OS_PATH];
+  q_snprintf(mount, sizeof(mount), "%s/.mount", dest);
+
+  if (!SDL_CreateDirectory(mount)) {
+    Com_Warn("Failed to create %s: %s\n", mount, SDL_GetError());
+    return false;
+  }
+
+  if (!Archive_Spawn((const char *[]) {
+        "/usr/bin/hdiutil", "attach", "-nobrowse", "-readonly", "-noverify",
+        "-mountpoint", mount, archive, NULL
+      })) {
+    SDL_RemovePath(mount);
+    return false;
+  }
+
+  const bool success = Archive_DittoMount(mount, dest);
+
+  if (!Archive_Spawn((const char *[]) { "/usr/bin/hdiutil", "detach", mount, NULL })) {
+    Archive_Spawn((const char *[]) { "/usr/bin/hdiutil", "detach", "-force", mount, NULL });
+  }
+
+  SDL_RemovePath(mount);
+  return success;
+}
+
+#endif
+
+#if !defined(_WIN32)
+
+/**
+ * @brief Extracts a `.tar.gz` with the system `tar`.
+ * @details `--strip-components` is deliberately not used; it is absent from
+ * busybox tar, so callers treat the archive's own root directory as the staged
+ * root instead.
+ */
+static bool Archive_ExtractTarGz(const char *archive, const char *dest) {
+  return Archive_Spawn((const char *[]) { "tar", "-xzf", archive, "-C", dest, NULL });
+}
+
+#endif
+
+/**
+ * @brief Returns true if `path` ends with `suffix`, ignoring case.
+ */
+static bool Archive_HasSuffix(const char *path, const char *suffix) {
+
+  const size_t plen = q_strlen(path), slen = q_strlen(suffix);
+  if (plen < slen) {
+    return false;
+  }
+
+  return q_strncasecmp(path + plen - slen, suffix, slen) == 0;
+}
+
+bool Archive_Extract(const char *archive, const char *dest) {
+
+  if (!SDL_CreateDirectory(dest)) {
+    Com_Warn("Failed to create %s: %s\n", dest, SDL_GetError());
+    return false;
+  }
+
+  if (Archive_HasSuffix(archive, ".zip")) {
+    return Archive_ExtractZip(archive, dest);
+  }
+
+#if defined(__APPLE__)
+  if (Archive_HasSuffix(archive, ".dmg")) {
+    return Archive_ExtractDmg(archive, dest);
+  }
+#endif
+
+#if !defined(_WIN32)
+  if (Archive_HasSuffix(archive, ".tar.gz") || Archive_HasSuffix(archive, ".tgz")) {
+    return Archive_ExtractTarGz(archive, dest);
+  }
+#endif
+
+  Com_Warn("Unsupported archive on this platform: %s\n", archive);
+  return false;
+}

--- a/src/common/archive.c
+++ b/src/common/archive.c
@@ -154,6 +154,10 @@ static bool Archive_Spawn(const char * const *args) {
   size_t length = 0;
   void *output = SDL_ReadProcess(process, &length, &exit_code);
 
+  if (output == NULL) {
+    SDL_WaitProcess(process, true, &exit_code);
+  }
+
   if (exit_code != 0) {
     Com_Warn("%s exited %d\n", args[0], exit_code);
     if (output && length) {
@@ -315,10 +319,14 @@ static bool Archive_ExtractDmg(const char *archive, const char *dest) {
  * @brief Extracts a `.tar.gz` with the system `tar`.
  * @details `--strip-components` is deliberately not used; it is absent from
  * busybox tar, so callers treat the archive's own root directory as the staged
- * root instead.
+ * root instead. `tar` is addressed absolutely rather than through `PATH`, which
+ * an update must not be willing to follow.
  */
 static bool Archive_ExtractTarGz(const char *archive, const char *dest) {
-  return Archive_Spawn((const char *[]) { "tar", "-xzf", archive, "-C", dest, NULL });
+
+  const char *tar = SDL_GetPathInfo("/usr/bin/tar", NULL) ? "/usr/bin/tar" : "/bin/tar";
+
+  return Archive_Spawn((const char *[]) { tar, "-xzf", archive, "-C", dest, NULL });
 }
 
 #endif

--- a/src/common/archive.c
+++ b/src/common/archive.c
@@ -301,10 +301,13 @@ static bool Archive_ExtractDmg(const char *archive, const char *dest) {
     return false;
   }
 
-  const bool success = Archive_DittoMount(mount, dest);
+  bool success = Archive_DittoMount(mount, dest);
 
   if (!Archive_Spawn((const char *[]) { "/usr/bin/hdiutil", "detach", mount, NULL })) {
-    Archive_Spawn((const char *[]) { "/usr/bin/hdiutil", "detach", "-force", mount, NULL });
+    if (!Archive_Spawn((const char *[]) { "/usr/bin/hdiutil", "detach", "-force", mount, NULL })) {
+      Com_Warn("Failed to detach %s\n", mount);
+      success = false;
+    }
   }
 
   SDL_RemovePath(mount);

--- a/src/common/archive.h
+++ b/src/common/archive.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright(c) 1997-2001 id Software, Inc.
+ * Copyright(c) 2002 The Quakeforge Project.
+ * Copyright(c) 2006 Quetoo.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+#pragma once
+
+#include "quetoo.h"
+
+/**
+ * @brief Extracts `archive` into `dest`, creating `dest` if it does not exist.
+ * @details Dispatches on the archive's suffix rather than the host platform,
+ * because the game data archive is a `.zip` everywhere while the engine
+ * archives differ per platform. `.zip` is read in-process; `.dmg` and `.tar.gz`
+ * are handed to `hdiutil`/`ditto` and `tar` respectively, which already handle
+ * long names, symlinks, resource forks and mode bits correctly.
+ * @param archive Path to the archive on the real filesystem.
+ * @param dest Directory to extract into.
+ * @return True on success. On failure `dest` holds an indeterminate subset of
+ * the archive and the caller MUST discard it rather than use it.
+ */
+bool Archive_Extract(const char *archive, const char *dest);
+
+/**
+ * @brief Resolves an archive member name to a path beneath `dest`.
+ * @details Archive member names are untrusted input; a crafted name can escape
+ * the destination directory. Rejects absolute paths, drive prefixes, `..`
+ * components and Windows device names, and normalizes separators.
+ * @remarks Exposed for testing. `Archive_Extract` applies this to every member
+ * of a `.zip`; the `hdiutil` and `tar` backends rely on those tools' equivalent
+ * protections instead.
+ * @return True if `name` is safe, in which case `out` holds the full path.
+ */
+bool Archive_SafePath(const char *dest, const char *name, char *out, size_t len);

--- a/src/common/installer.c
+++ b/src/common/installer.c
@@ -102,6 +102,12 @@ static struct {
   installer_release_t release;
 
   /**
+   * @brief Whether a cold install of the game data has been attempted, so that
+   * a failure falls through to the file by file sync instead of retrying.
+   */
+  bool installed_data;
+
+  /**
    * @brief The installer status, used to expose progress via `Installer_FrameFunction`.
    */
   installer_status_t status;
@@ -135,14 +141,14 @@ static int32_t Installer_CompareVersions(const char *a, const char *b) {
 }
 
 /**
- * @brief Queries the GitHub Releases API for the latest release and this
- * platform's engine asset.
+ * @brief Queries a GitHub Releases API endpoint for its latest release and the
+ * named asset.
  * @details `/releases/latest` excludes drafts and prereleases, and carries the
  * asset list in the same response, so one request yields everything needed.
  * The asset size is taken from the API rather than a `HEAD`, because
  * `RESTClient` discards response headers.
  */
-static bool Installer_FetchLatestRelease(installer_release_t *out) {
+static bool Installer_FetchRelease(const char *api, const char *want, installer_release_t *out) {
 
   const char *headers[] = {
     "Accept", "application/vnd.github+json",
@@ -152,9 +158,9 @@ static bool Installer_FetchLatestRelease(installer_release_t *out) {
   };
 
   Data *data = NULL;
-  const int32_t status = $($$(RESTClient, sharedInstance), get, QUETOO_RELEASES_API_URL, headers, &data);
+  const int32_t status = $($$(RESTClient, sharedInstance), get, api, headers, &data);
   if (status != 200 || !data) {
-    Com_Warn("%s: HTTP %d\n", QUETOO_RELEASES_API_URL, status);
+    Com_Warn("%s: HTTP %d\n", api, status);
     release(data);
     return false;
   }
@@ -185,7 +191,7 @@ static bool Installer_FetchLatestRelease(installer_release_t *out) {
         const Dictionary *asset = $(assets, objectAtIndex, i);
         const String *name = $(asset, objectForKeyPath, "name");
 
-        if (name == NULL || q_strcmp(name->chars, INSTALLER_ASSET)) {
+        if (name == NULL || q_strcmp(name->chars, want)) {
           continue;
         }
 
@@ -211,7 +217,7 @@ static bool Installer_FetchLatestRelease(installer_release_t *out) {
     Com_Debug(DEBUG_COMMON, "Latest release %s, asset %s (%" PRId64 " bytes)\n",
               out->tag, out->asset, out->size);
   } else {
-    Com_Warn("No %s in the latest release\n", INSTALLER_ASSET);
+    Com_Warn("No %s in %s\n", want, api);
   }
 
   return success;
@@ -567,6 +573,54 @@ static bool Installer_DownloadFile(const cm_manifest_entry_t *entry) {
 }
 
 /**
+ * @brief Installs the whole game data set from its release archive.
+ * @details A fresh install would otherwise pull eleven thousand files one at a
+ * time from S3. The archive is published on GitHub Releases, whose egress is
+ * free, so the cold start costs nothing to serve; the per-file sync is left to
+ * carry the small differences between releases.
+ */
+static bool Installer_InstallData(void) {
+
+  installer_status_t *in = &installer.status;
+
+  installer_release_t data;
+  if (!Installer_FetchRelease(QUETOO_DATA_API_URL, QUETOO_DATA_ARCHIVE, &data)) {
+    return false;
+  }
+
+  char archive[MAX_OS_PATH];
+  q_snprintf(archive, sizeof(archive), "%s/%s", Fs_DataDir(), QUETOO_DATA_ARCHIVE);
+
+  if (!SDL_CreateDirectory(Fs_DataDir())) {
+    Com_Warn("Failed to create %s: %s\n", Fs_DataDir(), SDL_GetError());
+    return false;
+  }
+
+  SDL_LockMutex(installer.mutex);
+  in->state = INSTALLER_INSTALLING_DATA;
+  in->kbytes_done = 0;
+  in->kbytes_total = (int32_t) (data.size / 1024);
+  q_strlcpy(in->current_file, data.asset, sizeof(in->current_file));
+  SDL_UnlockMutex(installer.mutex);
+
+  bool success = Installer_DownloadToFile(data.url, archive, data.size);
+
+  if (success) {
+    success = Archive_Extract(archive, Fs_DataDir());
+  }
+
+  SDL_RemovePath(archive);
+
+  SDL_LockMutex(installer.mutex);
+  if (in->state == INSTALLER_INSTALLING_DATA) {
+    in->state = INSTALLER_COMPARING;
+  }
+  SDL_UnlockMutex(installer.mutex);
+
+  return success;
+}
+
+/**
  * @brief Worker thread for parallel downloads. Iterates the remote manifest for
  * `PENDING` entries, claims each by marking it `CURRENT`, then downloads it.
  */
@@ -631,7 +685,8 @@ static int Installer_Thread(void *unused) {
     switch (in->state) {
 
       case INSTALLER_CHECKING: {
-        const bool ok = Installer_FetchLatestRelease(&installer.release);
+        const bool ok = Installer_FetchRelease(QUETOO_RELEASES_API_URL, INSTALLER_ASSET,
+                                               &installer.release);
         SDL_LockMutex(installer.mutex);
         if (!ok) {
           in->state = INSTALLER_ERROR;
@@ -646,7 +701,27 @@ static int Installer_Thread(void *unused) {
       }
         break;
 
+      case INSTALLER_INSTALLING_DATA:
+        SDL_LockMutex(installer.mutex);
+        in->state = INSTALLER_COMPARING;
+        SDL_UnlockMutex(installer.mutex);
+        break;
+
       case INSTALLER_COMPARING: {
+
+        if (!installer.installed_data && !Fs_Exists("manifest.mf")) {
+          installer.installed_data = true;
+          if (!Installer_InstallData()) {
+            Com_Warn("Falling back to a file by file sync\n");
+          }
+          SDL_LockMutex(installer.mutex);
+          const bool cancelled = in->state == INSTALLER_CANCELLED;
+          SDL_UnlockMutex(installer.mutex);
+          if (cancelled) {
+            break;
+          }
+        }
+
         Data *data = NULL;
         char manifest_url[MAX_OS_PATH];
         q_snprintf(manifest_url, sizeof(manifest_url), QUETOO_DATA_BASE_URL "/%s/manifest.mf", Com_Game());

--- a/src/common/installer.c
+++ b/src/common/installer.c
@@ -109,6 +109,13 @@ static struct {
   bool installed_data;
 
   /**
+   * @brief Whether the player has agreed to install an available update.
+   * @details Zero until asked, then 1 to accept or -1 to decline. Presettable
+   * on the command line, so an unattended install can answer in advance.
+   */
+  cvar_t *consent;
+
+  /**
    * @brief The installer status, used to expose progress via `Installer_FrameFunction`.
    */
   installer_status_t status;
@@ -116,9 +123,15 @@ static struct {
 
 /**
  * @brief Compares dotted release versions, e.g. `1.0.91` against `1.0.9`.
+ * @details Compared component-wise rather than lexically, where `1.0.9` would
+ * sort after `1.0.91`. A leading `v` is optional on either side: release tags
+ * carry one and `--with-version` may or may not.
  * @return Negative, zero or positive as `a` orders before, with, or after `b`.
  */
 static int32_t Installer_CompareVersions(const char *a, const char *b) {
+
+  if (*a == 'v') { a++; }
+  if (*b == 'v') { b++; }
 
   while (*a || *b) {
 
@@ -192,12 +205,7 @@ static bool Installer_FetchRelease(const char *api, const char *want, installer_
 
     if (tag && assets) {
 
-      const char *chars = tag->chars;
-      if (*chars == 'v') {
-        chars++;
-      }
-
-      q_strlcpy(out->tag, chars, sizeof(out->tag));
+      q_strlcpy(out->tag, tag->chars, sizeof(out->tag));
 
       for (size_t i = 0; i < assets->count; i++) {
 
@@ -270,6 +278,9 @@ static void Installer_RemoveTree(const char *path) {
 
 /**
  * @brief The directory the staging area lives beside.
+ * @remarks Empty when the executable is not laid out like an installation, as
+ * in a source tree. Only engine updates depend on it; game content is written
+ * to `Fs_DataDir()` and syncs as usual.
  * @details Everywhere but macOS this is the installation itself, and an update
  * replaces files within it. On macOS the installation *is* `Quetoo.app` and an
  * update replaces the whole bundle, so staging inside it would carry the staged
@@ -828,13 +839,26 @@ static int Installer_Thread(void *unused) {
 
         const bool ok = Installer_FetchRelease(QUETOO_RELEASES_API_URL, INSTALLER_ASSET,
                                                &installer.release);
+
+        char parent[MAX_OS_PATH];
+        Installer_StagingParent(parent, sizeof(parent));
+
+        const bool writable = *parent && Installer_IsWritable(parent);
+        if (ok && !writable && *parent) {
+          Com_Warn("%s is not writable; engine updates are disabled.\n", parent);
+        }
+
         SDL_LockMutex(installer.mutex);
         if (!ok) {
           in->state = INSTALLER_ERROR;
           q_snprintf(in->error, sizeof(in->error), "Failed to check for updates");
-        } else if (Installer_CompareVersions(installer.release.tag, VERSION) > 0) {
-          in->state = INSTALLER_UPDATE_AVAILABLE;
-          q_strlcpy(in->current_file, installer.release.asset, sizeof(in->current_file));
+        } else if (Installer_CompareVersions(installer.release.tag, version->string) > 0) {
+          if (writable) {
+            in->state = INSTALLER_UPDATE_AVAILABLE;
+            q_strlcpy(in->current_file, installer.release.asset, sizeof(in->current_file));
+          } else {
+            in->state = INSTALLER_COMPARING;
+          }
         } else {
           in->state = INSTALLER_COMPARING;
         }
@@ -926,23 +950,24 @@ static int Installer_Thread(void *unused) {
         break;
 
       case INSTALLER_UPDATE_AVAILABLE: {
-        char parent[MAX_OS_PATH];
-        Installer_StagingParent(parent, sizeof(parent));
 
-        const bool writable = Installer_IsWritable(parent);
+        const int32_t consent = installer.consent->integer;
 
-        SDL_LockMutex(installer.mutex);
-        if (in->state == INSTALLER_CANCELLED) {
-          SDL_UnlockMutex(installer.mutex);
+        if (consent == 0) {
+          SDL_Delay(QUETOO_TICK_MILLIS);
           break;
         }
-        if (!writable) {
-          in->state = INSTALLER_COMPARING;
-          Com_Warn("%s is not writable; skipping the engine update.\n", parent);
-        } else {
-          in->state = INSTALLER_DOWNLOADING_UPDATE;
-          in->kbytes_done = 0;
-          in->kbytes_total = (int32_t) (installer.release.size / 1024);
+
+        SDL_LockMutex(installer.mutex);
+        if (in->state != INSTALLER_CANCELLED) {
+          if (consent > 0) {
+            in->state = INSTALLER_DOWNLOADING_UPDATE;
+            in->kbytes_done = 0;
+            in->kbytes_total = (int32_t) (installer.release.size / 1024);
+          } else {
+            Com_Print("Skipping the update to Quetoo %s.\n", installer.release.tag);
+            in->state = INSTALLER_COMPARING;
+          }
         }
         SDL_UnlockMutex(installer.mutex);
       }
@@ -1307,11 +1332,15 @@ void Installer_ApplyPending(void) {
  */
 void Installer_Init(Installer_FrameFunction frame) {
 
+  cvar_t *consent = Cvar_Add("update_consent", "0", 0,
+                             "Whether to install an available engine update: "
+                             "1 to accept, -1 to decline, 0 to ask");
+
 #if defined(_WIN32)
   Installer_SweepDisplaced();
 #endif
 
-  if (build_number->integer == -1) {
+  if (build_number->integer == -1 || version->integer == -1) {
     return;
   }
 
@@ -1324,6 +1353,7 @@ void Installer_Init(Installer_FrameFunction frame) {
 
   memset(&installer, 0, sizeof(installer));
   installer.status.state = INSTALLER_CHECKING;
+  installer.consent = consent;
 
   installer.mutex = SDL_CreateMutex();
   assert(installer.mutex);

--- a/src/common/installer.c
+++ b/src/common/installer.c
@@ -27,7 +27,38 @@
 #include "console.h"
 #include "filesystem.h"
 #include "installer.h"
+
+#include <Objectively/Array.h>
+#include <Objectively/Dictionary.h>
+#include <Objectively/JSONContext.h>
+#include <Objectively/Number.h>
 #include <Objectively/RESTClient.h>
+#include <Objectively/String.h>
+
+/**
+ * @brief The release asset carrying this platform's engine build.
+ * @details Not derived from `BUILD`, which is an autoconf host triplet
+ * (`x86_64-pc-linux-gnu`) and does not match how the assets are named.
+ */
+#if defined(_WIN32)
+  #define INSTALLER_ASSET "quetoo-x86_64-pc-windows.zip"
+#elif defined(__APPLE__)
+  #define INSTALLER_ASSET "quetoo-arm64-apple-darwin.dmg"
+#elif defined(__aarch64__)
+  #define INSTALLER_ASSET "quetoo-aarch64-pc-linux.tar.gz"
+#else
+  #define INSTALLER_ASSET "quetoo-x86_64-pc-linux.tar.gz"
+#endif
+
+/**
+ * @brief The latest release, as reported by the GitHub Releases API.
+ */
+typedef struct {
+  char tag[64];
+  char asset[MAX_QPATH];
+  char url[MAX_OS_PATH * 2];
+  int64_t size;
+} installer_release_t;
 
 /**
  * @brief The installer type.
@@ -59,32 +90,124 @@ static struct {
   HashTable *local_manifest;
 
   /**
+   * @brief The latest release, populated by `INSTALLER_CHECKING`.
+   */
+  installer_release_t release;
+
+  /**
    * @brief The installer status, used to expose progress via `Installer_FrameFunction`.
    */
   installer_status_t status;
 } installer;
 
 /**
- * @brief Performs a blocking HTTP `GET` and parses an integer from the response body.
+ * @brief Compares dotted release versions, e.g. `1.0.91` against `1.0.9`.
+ * @return Negative, zero or positive as `a` orders before, with, or after `b`.
  */
-static int32_t Installer_GetBuildNumber(const char *build_url) {
-  int32_t build;
+static int32_t Installer_CompareVersions(const char *a, const char *b) {
 
-  Data *data = NULL;
-  const int32_t status = $($$(RESTClient, sharedInstance), get, build_url, NULL, &data);
-  if (status == 200 && data) {
-    build = (int32_t) strtol((const char *) data->bytes, NULL, 10);
-    Com_Debug(DEBUG_COMMON, "%s == %d\n", build_url, build);
-  } else {
-    Com_Warn("%s: HTTP %d\n", build_url, status);
-    if (data && data->length) {
-      Com_Debug(DEBUG_COMMON, "%s\n", (const char *) data->bytes);
+  while (*a || *b) {
+
+    char *ea = NULL, *eb = NULL;
+    const long x = strtol(a, &ea, 10);
+    const long y = strtol(b, &eb, 10);
+
+    if (x != y) {
+      return x < y ? -1 : 1;
     }
-    build = -1;
+
+    if (ea == a && eb == b) {
+      break;
+    }
+
+    a = *ea == '.' ? ea + 1 : ea;
+    b = *eb == '.' ? eb + 1 : eb;
   }
 
+  return 0;
+}
+
+/**
+ * @brief Queries the GitHub Releases API for the latest release and this
+ * platform's engine asset.
+ * @details `/releases/latest` excludes drafts and prereleases, and carries the
+ * asset list in the same response, so one request yields everything needed.
+ * The asset size is taken from the API rather than a `HEAD`, because
+ * `RESTClient` discards response headers.
+ */
+static bool Installer_FetchLatestRelease(installer_release_t *out) {
+
+  const char *headers[] = {
+    "Accept", "application/vnd.github+json",
+    "X-GitHub-Api-Version", "2022-11-28",
+    "User-Agent", "quetoo/" VERSION,
+    NULL
+  };
+
+  Data *data = NULL;
+  const int32_t status = $($$(RESTClient, sharedInstance), get, QUETOO_RELEASES_API_URL, headers, &data);
+  if (status != 200 || !data) {
+    Com_Warn("%s: HTTP %d\n", QUETOO_RELEASES_API_URL, status);
+    release(data);
+    return false;
+  }
+
+  JSONContext *context = $(alloc(JSONContext), init);
+  Dictionary *root = $(context, objectFromData, data, 0);
+
   release(data);
-  return build;
+
+  bool success = false;
+
+  if (root) {
+
+    const String *tag = $(root, objectForKeyPath, "tag_name");
+    const Array *assets = $(root, objectForKeyPath, "assets");
+
+    if (tag && assets) {
+
+      const char *chars = tag->chars;
+      if (*chars == 'v') {
+        chars++;
+      }
+
+      q_strlcpy(out->tag, chars, sizeof(out->tag));
+
+      for (size_t i = 0; i < assets->count; i++) {
+
+        const Dictionary *asset = $(assets, objectAtIndex, i);
+        const String *name = $(asset, objectForKeyPath, "name");
+
+        if (name == NULL || q_strcmp(name->chars, INSTALLER_ASSET)) {
+          continue;
+        }
+
+        const String *url = $(asset, objectForKeyPath, "browser_download_url");
+        const Number *size = $(asset, objectForKeyPath, "size");
+
+        if (url && size) {
+          q_strlcpy(out->asset, name->chars, sizeof(out->asset));
+          q_strlcpy(out->url, url->chars, sizeof(out->url));
+          out->size = (int64_t) size->value;
+          success = true;
+        }
+
+        break;
+      }
+    }
+  }
+
+  release(root);
+  release(context);
+
+  if (success) {
+    Com_Debug(DEBUG_COMMON, "Latest release %s, asset %s (%" PRId64 " bytes)\n",
+              out->tag, out->asset, out->size);
+  } else {
+    Com_Warn("No %s in the latest release\n", INSTALLER_ASSET);
+  }
+
+  return success;
 }
 
 /**
@@ -320,14 +443,16 @@ static int Installer_Thread(void *unused) {
     switch (in->state) {
 
       case INSTALLER_CHECKING: {
-        const int32_t b = Installer_GetBuildNumber(QUETOO_BUILD_URL);
+        const bool ok = Installer_FetchLatestRelease(&installer.release);
         SDL_LockMutex(installer.mutex);
-        if (b < 0) {
+        if (!ok) {
           in->state = INSTALLER_ERROR;
-          q_snprintf(in->error, sizeof(in->error), "Failed to fetch %s", QUETOO_BUILD_URL);
+          q_snprintf(in->error, sizeof(in->error), "Failed to check for updates");
+        } else if (Installer_CompareVersions(installer.release.tag, VERSION) > 0) {
+          in->state = INSTALLER_UPDATE_AVAILABLE;
+          q_strlcpy(in->current_file, installer.release.asset, sizeof(in->current_file));
         } else {
-          in->build_number = b;
-          in->state = in->build_number > build_number->integer ? INSTALLER_UPDATE_AVAILABLE : INSTALLER_COMPARING;
+          in->state = INSTALLER_COMPARING;
         }
         SDL_UnlockMutex(installer.mutex);
       }
@@ -403,6 +528,9 @@ static int Installer_Thread(void *unused) {
         break;
 
       case INSTALLER_UPDATE_AVAILABLE:
+      case INSTALLER_DOWNLOADING_UPDATE:
+      case INSTALLER_STAGING_UPDATE:
+      case INSTALLER_UPDATE_STAGED:
       case INSTALLER_CANCELLED:
       case INSTALLER_DONE:
       case INSTALLER_ERROR:

--- a/src/common/installer.c
+++ b/src/common/installer.c
@@ -311,6 +311,21 @@ static void Installer_PendingDir(char *out, size_t len) {
 }
 
 /**
+ * @brief Returns true if something other than us maintains this installation.
+ * @details A storefront that installs and patches the game expects to be the
+ * only thing doing so; updating underneath it leaves its copy out of step with
+ * what it believes it installed. Distributions that manage their own updates
+ * ship this marker beside the installation to say so.
+ */
+static bool Installer_IsManaged(const char *dir) {
+
+  char path[MAX_OS_PATH];
+  q_snprintf(path, sizeof(path), "%s/%s", dir, INSTALLER_MANAGED);
+
+  return SDL_GetPathInfo(path, NULL);
+}
+
+/**
  * @brief Returns true if the installation directory can be written to.
  * @details Checked before downloading rather than after, so a user whose
  * install lives somewhere privileged is told immediately instead of after
@@ -842,7 +857,12 @@ static int Installer_Thread(void *unused) {
         char parent[MAX_OS_PATH];
         Installer_StagingParent(parent, sizeof(parent));
 
-        const bool writable = *parent && Installer_IsWritable(parent);
+        const bool managed = *parent && Installer_IsManaged(parent);
+        const bool writable = *parent && !managed && Installer_IsWritable(parent);
+
+        if (ok && managed) {
+          Com_Print("Externally managed installation; engine updates disabled.\n");
+        }
 
         SDL_LockMutex(installer.mutex);
         if (!ok) {
@@ -854,9 +874,11 @@ static int Installer_Thread(void *unused) {
             q_strlcpy(in->current_file, installer.release.asset, sizeof(in->current_file));
           } else {
             in->state = INSTALLER_COMPARING;
-            Com_Warn("Quetoo %s is available, but %s is not writable.\n"
-                     "Download it from %s\n", installer.release.tag,
-                     *parent ? parent : "this installation", QUETOO_RELEASES_PAGE);
+            if (!managed) {
+              Com_Warn("Quetoo %s is available, but %s is not writable.\n"
+                       "Download it from %s\n", installer.release.tag,
+                       *parent ? parent : "this installation", QUETOO_RELEASES_PAGE);
+            }
           }
         } else {
           in->state = INSTALLER_COMPARING;

--- a/src/common/installer.c
+++ b/src/common/installer.c
@@ -19,6 +19,7 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
  */
 
+#include <SDL3/SDL_filesystem.h>
 #include <SDL3/SDL_misc.h>
 #include <SDL3/SDL_mutex.h>
 
@@ -34,6 +35,12 @@
 #include <Objectively/Number.h>
 #include <Objectively/RESTClient.h>
 #include <Objectively/String.h>
+#include <Objectively/URL.h>
+#include <Objectively/URLResponse.h>
+#include <Objectively/URLSession.h>
+#include <Objectively/URLSessionDownloadTask.h>
+
+#include "archive.h"
 
 /**
  * @brief The release asset carrying this platform's engine build.
@@ -208,6 +215,187 @@ static bool Installer_FetchLatestRelease(installer_release_t *out) {
   }
 
   return success;
+}
+
+/**
+ * @brief The directory the staging area lives beside.
+ * @details Everywhere but macOS this is the installation itself, and an update
+ * replaces files within it. On macOS the installation *is* `Quetoo.app` and an
+ * update replaces the whole bundle, so staging inside it would carry the staged
+ * payload along when the bundle is renamed aside.
+ */
+static void Installer_StagingParent(char *out, size_t len) {
+
+#if defined(__APPLE__)
+  q_strlcpy(out, Fs_BaseDir(), len);
+
+  char *slash = q_strrchr(out, '/');
+  if (slash) {
+    *slash = '\0';
+  }
+#else
+  q_strlcpy(out, Fs_BaseDir(), len);
+#endif
+}
+
+/**
+ * @brief The directory holding a downloaded update until it is applied.
+ */
+static void Installer_PendingDir(char *out, size_t len) {
+
+  char parent[MAX_OS_PATH];
+  Installer_StagingParent(parent, sizeof(parent));
+
+  q_snprintf(out, (int32_t) len, "%s/.quetoo-pending", parent);
+}
+
+/**
+ * @brief Returns true if the installation directory can be written to.
+ * @details Checked before downloading rather than after, so a user whose
+ * install lives somewhere privileged is told immediately instead of after
+ * pulling down an archive that can never be applied.
+ */
+static bool Installer_IsWritable(const char *dir) {
+
+  char probe[MAX_OS_PATH];
+  q_snprintf(probe, sizeof(probe), "%s/.writable", dir);
+
+  FILE *file = fopen(probe, "wb");
+  if (!file) {
+    return false;
+  }
+
+  fclose(file);
+  SDL_RemovePath(probe);
+  return true;
+}
+
+/**
+ * @brief Streams `url` to `path`, publishing progress and honoring cancellation.
+ * @details The task is resumed rather than executed because
+ * `URLSessionTask::execute` never inspects the task state, so a synchronous
+ * request cannot be interrupted. These payloads are large enough that Cancel
+ * would otherwise appear to hang.
+ */
+static bool Installer_DownloadToFile(const char *address, const char *path, int64_t expected) {
+
+  FILE *file = fopen(path, "wb");
+  if (!file) {
+    Com_Warn("Failed to open %s for writing\n", path);
+    return false;
+  }
+
+  URL *url = $(alloc(URL), initWithCharacters, address);
+  URLSessionDownloadTask *download = $($$(URLSession, sharedInstance), downloadTaskWithURL, url, NULL);
+  release(url);
+
+  download->file = file;
+
+  URLSessionTask *task = (URLSessionTask *) download;
+  $(task, resume);
+
+  installer_status_t *in = &installer.status;
+
+  while (task->state != URLSESSIONTASK_COMPLETED && task->state != URLSESSIONTASK_CANCELED) {
+
+    SDL_LockMutex(installer.mutex);
+    const bool cancelled = in->state == INSTALLER_CANCELLED;
+    if (!cancelled) {
+      const int64_t total = expected > 0 ? expected : (int64_t) task->bytesExpectedToReceive;
+      in->kbytes_done = (int32_t) (task->bytesReceived / 1024);
+      in->kbytes_total = (int32_t) (total / 1024);
+    }
+    SDL_UnlockMutex(installer.mutex);
+
+    if (cancelled) {
+      $(task, cancel);
+      break;
+    }
+
+    SDL_Delay(QUETOO_TICK_MILLIS);
+  }
+
+  while (task->state != URLSESSIONTASK_COMPLETED && task->state != URLSESSIONTASK_CANCELED) {
+    SDL_Delay(QUETOO_TICK_MILLIS);
+  }
+
+  fclose(file);
+
+  const int32_t http = task->response ? task->response->httpStatusCode : 0;
+  const bool success = task->state == URLSESSIONTASK_COMPLETED && http == 200;
+
+  release(task);
+
+  if (!success) {
+    Com_Warn("Failed to download %s: HTTP %d\n", address, http);
+    SDL_RemovePath(path);
+  }
+
+  return success;
+}
+
+#if !defined(__APPLE__)
+
+/**
+ * @brief Recursively records every staged file.
+ */
+static SDL_EnumerationResult Installer_EnumeratePending(void *data, const char *dir, const char *name) {
+
+  FILE *file = data;
+
+  char path[MAX_OS_PATH];
+  q_snprintf(path, sizeof(path), "%s/%s", dir, name);
+
+  SDL_PathInfo info;
+  if (!SDL_GetPathInfo(path, &info)) {
+    return SDL_ENUM_CONTINUE;
+  }
+
+  if (info.type == SDL_PATHTYPE_DIRECTORY) {
+    SDL_EnumerateDirectory(path, Installer_EnumeratePending, file);
+  } else if (info.type == SDL_PATHTYPE_FILE) {
+    fprintf(file, "%s\n", path);
+  }
+
+  return SDL_ENUM_CONTINUE;
+}
+
+#endif
+
+/**
+ * @brief Records what was staged, so the apply on exit needs no directory walk
+ * and can tell a complete stage from a half-extracted one.
+ * @details `root` is the directory within the staging area that mirrors the
+ * installation: the archive's own top-level directory for a tarball, the
+ * staging directory itself for a zip, and the bundle for a disk image.
+ */
+static void Installer_WritePending(const char *pending) {
+
+  char root[MAX_OS_PATH];
+#if defined(__APPLE__)
+  q_snprintf(root, sizeof(root), "%s/Quetoo.app", pending);
+#elif defined(_WIN32)
+  q_strlcpy(root, pending, sizeof(root));
+#else
+  q_snprintf(root, sizeof(root), "%s/quetoo", pending);
+#endif
+
+  char path[MAX_OS_PATH];
+  q_snprintf(path, sizeof(path), "%s/pending.mf", pending);
+
+  FILE *file = fopen(path, "wb");
+  if (!file) {
+    Com_Warn("Failed to write %s\n", path);
+    return;
+  }
+
+  fprintf(file, "%s\n%s\n", installer.release.tag, root);
+
+#if !defined(__APPLE__)
+  SDL_EnumerateDirectory(root, Installer_EnumeratePending, file);
+#endif
+
+  fclose(file);
 }
 
 /**
@@ -527,10 +715,82 @@ static int Installer_Thread(void *unused) {
         SDL_UnlockMutex(installer.mutex);
         break;
 
-      case INSTALLER_UPDATE_AVAILABLE:
-      case INSTALLER_DOWNLOADING_UPDATE:
-      case INSTALLER_STAGING_UPDATE:
+      case INSTALLER_UPDATE_AVAILABLE: {
+        char parent[MAX_OS_PATH];
+        Installer_StagingParent(parent, sizeof(parent));
+
+        SDL_LockMutex(installer.mutex);
+        if (!Installer_IsWritable(parent)) {
+          in->state = INSTALLER_COMPARING;
+          Com_Warn("%s is not writable; skipping the engine update.\n", parent);
+        } else {
+          in->state = INSTALLER_DOWNLOADING_UPDATE;
+          in->kbytes_done = 0;
+          in->kbytes_total = (int32_t) (installer.release.size / 1024);
+        }
+        SDL_UnlockMutex(installer.mutex);
+      }
+        break;
+
+      case INSTALLER_DOWNLOADING_UPDATE: {
+        char pending[MAX_OS_PATH], archive[MAX_OS_PATH];
+        Installer_PendingDir(pending, sizeof(pending));
+
+        SDL_RemovePath(pending);
+
+        if (!SDL_CreateDirectory(pending)) {
+          SDL_LockMutex(installer.mutex);
+          in->state = INSTALLER_COMPARING;
+          SDL_UnlockMutex(installer.mutex);
+          Com_Warn("Failed to create %s: %s\n", pending, SDL_GetError());
+          break;
+        }
+
+        q_snprintf(archive, sizeof(archive), "%s/%s", pending, installer.release.asset);
+
+        const bool ok = Installer_DownloadToFile(installer.release.url, archive,
+                                                 installer.release.size);
+        SDL_LockMutex(installer.mutex);
+        if (in->state == INSTALLER_CANCELLED) {
+          SDL_UnlockMutex(installer.mutex);
+          break;
+        }
+        in->state = ok ? INSTALLER_STAGING_UPDATE : INSTALLER_COMPARING;
+        SDL_UnlockMutex(installer.mutex);
+
+        if (!ok) {
+          SDL_RemovePath(pending);
+        }
+      }
+        break;
+
+      case INSTALLER_STAGING_UPDATE: {
+        char pending[MAX_OS_PATH], archive[MAX_OS_PATH];
+        Installer_PendingDir(pending, sizeof(pending));
+        q_snprintf(archive, sizeof(archive), "%s/%s", pending, installer.release.asset);
+
+        const bool ok = Archive_Extract(archive, pending);
+        SDL_RemovePath(archive);
+
+        if (ok) {
+          Installer_WritePending(pending);
+          Com_Print("Quetoo %s staged; it will be applied when you quit.\n", installer.release.tag);
+        } else {
+          SDL_RemovePath(pending);
+        }
+
+        SDL_LockMutex(installer.mutex);
+        in->state = ok ? INSTALLER_UPDATE_STAGED : INSTALLER_COMPARING;
+        SDL_UnlockMutex(installer.mutex);
+      }
+        break;
+
       case INSTALLER_UPDATE_STAGED:
+        SDL_LockMutex(installer.mutex);
+        in->state = INSTALLER_COMPARING;
+        SDL_UnlockMutex(installer.mutex);
+        break;
+
       case INSTALLER_CANCELLED:
       case INSTALLER_DONE:
       case INSTALLER_ERROR:
@@ -595,6 +855,217 @@ void Installer_Init(Installer_FrameFunction frame) {
 
   SDL_DestroyMutex(installer.mutex);
   installer.mutex = NULL;
+}
+
+/**
+ * @brief Strips a trailing newline in place.
+ */
+static void Installer_Chomp(char *line) {
+
+  char *end = line + q_strlen(line);
+  while (end > line && (end[-1] == '\n' || end[-1] == '\r')) {
+    *--end = '\0';
+  }
+}
+
+#if defined(_WIN32)
+
+/**
+ * @brief Deletes the displaced files recorded by a previous apply.
+ * @details Windows cannot delete a file while it is mapped, so the copies
+ * displaced by the last update survive until the process that held them has
+ * exited. Failures are expected and ignored: a slow-exiting predecessor, or a
+ * second copy of the game still running, simply leaves the entry for the next
+ * launch to retry.
+ */
+static void Installer_SweepDisplaced(void) {
+
+  char path[MAX_OS_PATH];
+  q_snprintf(path, sizeof(path), "%s/.cleanup", Fs_BaseDir());
+
+  FILE *file = fopen(path, "rb");
+  if (!file) {
+    return;
+  }
+
+  bool swept = true;
+  char line[MAX_OS_PATH];
+
+  while (fgets(line, sizeof(line), file)) {
+    Installer_Chomp(line);
+    if (*line && !SDL_RemovePath(line)) {
+      swept = false;
+    }
+  }
+
+  fclose(file);
+
+  if (swept) {
+    SDL_RemovePath(path);
+  }
+}
+
+#endif
+
+/**
+ * @brief Recursively deletes `path`.
+ * @details `SDL_RemovePath` only unlinks files and empty directories, but a
+ * displaced application bundle is neither.
+ */
+static SDL_EnumerationResult Installer_RemoveEntry(void *data, const char *dir, const char *name) {
+
+  char path[MAX_OS_PATH];
+  q_snprintf(path, sizeof(path), "%s/%s", dir, name);
+
+  SDL_PathInfo info;
+  if (SDL_GetPathInfo(path, &info) && info.type == SDL_PATHTYPE_DIRECTORY) {
+    SDL_EnumerateDirectory(path, Installer_RemoveEntry, data);
+  }
+
+  SDL_RemovePath(path);
+  return SDL_ENUM_CONTINUE;
+}
+
+static void Installer_RemoveTree(const char *path) {
+
+  SDL_PathInfo info;
+  if (SDL_GetPathInfo(path, &info) && info.type == SDL_PATHTYPE_DIRECTORY) {
+    SDL_EnumerateDirectory(path, Installer_RemoveEntry, NULL);
+  }
+
+  SDL_RemovePath(path);
+}
+
+/**
+ * @brief Moves a staged file into place, displacing whatever is there.
+ * @details A running executable or loaded library cannot be overwritten or
+ * deleted, but it can be renamed. POSIX goes further and lets the displaced
+ * file be replaced outright: the running process keeps the now-nameless inode
+ * until it exits. Windows has no equivalent, so the displaced copy keeps a
+ * name until the next launch sweeps it.
+ */
+static bool Installer_Replace(const char *staged, const char *target, FILE *cleanup) {
+
+  char dir[MAX_OS_PATH];
+  q_strlcpy(dir, target, sizeof(dir));
+
+  char *slash = q_strrchr(dir, '/');
+  if (slash) {
+    *slash = '\0';
+    SDL_CreateDirectory(dir);
+  }
+
+  SDL_PathInfo info;
+  const bool exists = SDL_GetPathInfo(target, &info);
+
+#if defined(_WIN32)
+  const bool displace = exists;
+#else
+  const bool displace = exists && info.type == SDL_PATHTYPE_DIRECTORY;
+#endif
+
+  char displaced[MAX_OS_PATH] = { '\0' };
+
+  if (displace) {
+
+    q_snprintf(displaced, sizeof(displaced), "%s.old", target);
+    Installer_RemoveTree(displaced);
+
+    if (!SDL_RenamePath(target, displaced)) {
+      Com_Warn("Failed to displace %s: %s\n", target, SDL_GetError());
+      return false;
+    }
+  }
+
+  if (!SDL_RenamePath(staged, target)) {
+    Com_Warn("Failed to install %s: %s\n", target, SDL_GetError());
+    if (*displaced) {
+      SDL_RenamePath(displaced, target);
+    }
+    return false;
+  }
+
+  if (*displaced) {
+    if (cleanup) {
+      fprintf(cleanup, "%s\n", displaced);
+    } else {
+      Installer_RemoveTree(displaced);
+    }
+  }
+
+  return true;
+}
+
+void Installer_ApplyPending(void) {
+
+#if defined(_WIN32)
+  Installer_SweepDisplaced();
+#endif
+
+  char pending[MAX_OS_PATH], path[MAX_OS_PATH];
+  Installer_PendingDir(pending, sizeof(pending));
+  q_snprintf(path, sizeof(path), "%s/pending.mf", pending);
+
+  FILE *file = fopen(path, "rb");
+  if (!file) {
+    return;
+  }
+
+  char version[64] = { '\0' }, root[MAX_OS_PATH] = { '\0' };
+
+  if (!fgets(version, sizeof(version), file) || !fgets(root, sizeof(root), file)) {
+    Com_Warn("Discarding an incomplete staged update\n");
+    fclose(file);
+    Installer_RemoveTree(pending);
+    return;
+  }
+
+  Installer_Chomp(version);
+  Installer_Chomp(root);
+
+  FILE *cleanup = NULL;
+#if defined(_WIN32)
+  char cleanup_path[MAX_OS_PATH];
+  q_snprintf(cleanup_path, sizeof(cleanup_path), "%s/.cleanup", Fs_BaseDir());
+  cleanup = fopen(cleanup_path, "wb");
+#endif
+
+  const size_t root_len = q_strlen(root);
+
+  bool success = true, files = false;
+  char line[MAX_OS_PATH];
+
+  while (success && fgets(line, sizeof(line), file)) {
+
+    Installer_Chomp(line);
+
+    if (q_strncmp(line, root, root_len) || line[root_len] != '/') {
+      continue;
+    }
+
+    char target[MAX_OS_PATH];
+    q_snprintf(target, sizeof(target), "%s%s", Fs_BaseDir(), line + root_len);
+
+    success = Installer_Replace(line, target, cleanup);
+    files = true;
+  }
+
+  if (success && !files) {
+    success = Installer_Replace(root, Fs_BaseDir(), cleanup);
+  }
+
+  if (cleanup) {
+    fclose(cleanup);
+  }
+
+  fclose(file);
+
+  if (success) {
+    Installer_RemoveTree(pending);
+    Com_Print("Updated to Quetoo %s.\n", version);
+  } else {
+    Com_Warn("Failed to apply the staged update; it will be retried on exit.\n");
+  }
 }
 
 /**

--- a/src/common/installer.c
+++ b/src/common/installer.c
@@ -20,7 +20,6 @@
  */
 
 #include <SDL3/SDL_filesystem.h>
-#include <SDL3/SDL_misc.h>
 #include <SDL3/SDL_mutex.h>
 
 
@@ -49,12 +48,14 @@
  */
 #if defined(_WIN32)
   #define INSTALLER_ASSET "quetoo-x86_64-pc-windows.zip"
-#elif defined(__APPLE__)
+#elif defined(__APPLE__) && defined(__aarch64__)
   #define INSTALLER_ASSET "quetoo-arm64-apple-darwin.dmg"
 #elif defined(__aarch64__)
   #define INSTALLER_ASSET "quetoo-aarch64-pc-linux.tar.gz"
-#else
+#elif defined(__linux__)
   #define INSTALLER_ASSET "quetoo-x86_64-pc-linux.tar.gz"
+#else
+  #define INSTALLER_ASSET NULL
 #endif
 
 /**
@@ -141,6 +142,16 @@ static int32_t Installer_CompareVersions(const char *a, const char *b) {
 }
 
 /**
+ * @brief Returns `object` if it is of `clazz`, else `NULL`.
+ * @details The response is remote input and its shape is not guaranteed; a
+ * root Array where a Dictionary is expected would otherwise be dispatched
+ * through the wrong interface.
+ */
+static ident Installer_Cast(ident object, Class *clazz) {
+  return object && $((Object *) object, isKindOfClass, clazz) ? object : NULL;
+}
+
+/**
  * @brief Queries a GitHub Releases API endpoint for its latest release and the
  * named asset.
  * @details `/releases/latest` excludes drafts and prereleases, and carries the
@@ -166,16 +177,18 @@ static bool Installer_FetchRelease(const char *api, const char *want, installer_
   }
 
   JSONContext *context = $(alloc(JSONContext), init);
-  Dictionary *root = $(context, objectFromData, data, 0);
+  ident object = $(context, objectFromData, data, 0);
 
   release(data);
 
   bool success = false;
 
+  Dictionary *root = Installer_Cast(object, _Dictionary());
+
   if (root) {
 
-    const String *tag = $(root, objectForKeyPath, "tag_name");
-    const Array *assets = $(root, objectForKeyPath, "assets");
+    const String *tag = Installer_Cast($(root, objectForKeyPath, "tag_name"), _String());
+    const Array *assets = Installer_Cast($(root, objectForKeyPath, "assets"), _Array());
 
     if (tag && assets) {
 
@@ -188,15 +201,18 @@ static bool Installer_FetchRelease(const char *api, const char *want, installer_
 
       for (size_t i = 0; i < assets->count; i++) {
 
-        const Dictionary *asset = $(assets, objectAtIndex, i);
-        const String *name = $(asset, objectForKeyPath, "name");
+        const Dictionary *asset = Installer_Cast($(assets, objectAtIndex, i), _Dictionary());
+        if (asset == NULL) {
+          continue;
+        }
 
+        const String *name = Installer_Cast($(asset, objectForKeyPath, "name"), _String());
         if (name == NULL || q_strcmp(name->chars, want)) {
           continue;
         }
 
-        const String *url = $(asset, objectForKeyPath, "browser_download_url");
-        const Number *size = $(asset, objectForKeyPath, "size");
+        const String *url = Installer_Cast($(asset, objectForKeyPath, "browser_download_url"), _String());
+        const Number *size = Installer_Cast($(asset, objectForKeyPath, "size"), _Number());
 
         if (url && size) {
           q_strlcpy(out->asset, name->chars, sizeof(out->asset));
@@ -210,7 +226,7 @@ static bool Installer_FetchRelease(const char *api, const char *want, installer_
     }
   }
 
-  release(root);
+  release(object);
   release(context);
 
   if (success) {
@@ -221,6 +237,35 @@ static bool Installer_FetchRelease(const char *api, const char *want, installer_
   }
 
   return success;
+}
+
+/**
+ * @brief Recursively deletes `path`.
+ * @details `SDL_RemovePath` only unlinks files and empty directories, but a
+ * displaced application bundle is neither.
+ */
+static SDL_EnumerationResult Installer_RemoveEntry(void *data, const char *dir, const char *name) {
+
+  char path[MAX_OS_PATH];
+  q_snprintf(path, sizeof(path), "%s/%s", dir, name);
+
+  SDL_PathInfo info;
+  if (SDL_GetPathInfo(path, &info) && info.type == SDL_PATHTYPE_DIRECTORY) {
+    SDL_EnumerateDirectory(path, Installer_RemoveEntry, data);
+  }
+
+  SDL_RemovePath(path);
+  return SDL_ENUM_CONTINUE;
+}
+
+static void Installer_RemoveTree(const char *path) {
+
+  SDL_PathInfo info;
+  if (SDL_GetPathInfo(path, &info) && info.type == SDL_PATHTYPE_DIRECTORY) {
+    SDL_EnumerateDirectory(path, Installer_RemoveEntry, NULL);
+  }
+
+  SDL_RemovePath(path);
 }
 
 /**
@@ -292,8 +337,22 @@ static bool Installer_DownloadToFile(const char *address, const char *path, int6
   }
 
   URL *url = $(alloc(URL), initWithCharacters, address);
+  if (!url) {
+    Com_Warn("Failed to parse %s\n", address);
+    fclose(file);
+    SDL_RemovePath(path);
+    return false;
+  }
+
   URLSessionDownloadTask *download = $($$(URLSession, sharedInstance), downloadTaskWithURL, url, NULL);
   release(url);
+
+  if (!download) {
+    Com_Warn("Failed to request %s\n", address);
+    fclose(file);
+    SDL_RemovePath(path);
+    return false;
+  }
 
   download->file = file;
 
@@ -328,7 +387,13 @@ static bool Installer_DownloadToFile(const char *address, const char *path, int6
   fclose(file);
 
   const int32_t http = task->response ? task->response->httpStatusCode : 0;
-  const bool success = task->state == URLSESSIONTASK_COMPLETED && http == 200;
+  bool success = task->state == URLSESSIONTASK_COMPLETED && http == 200;
+
+  if (success && expected > 0 && (int64_t) task->bytesReceived != expected) {
+    Com_Warn("Truncated download of %s: %" PRId64 " of %" PRId64 " bytes\n",
+             address, (int64_t) task->bytesReceived, expected);
+    success = false;
+  }
 
   release(task);
 
@@ -359,7 +424,8 @@ static SDL_EnumerationResult Installer_EnumeratePending(void *data, const char *
 
   if (info.type == SDL_PATHTYPE_DIRECTORY) {
     SDL_EnumerateDirectory(path, Installer_EnumeratePending, file);
-  } else if (info.type == SDL_PATHTYPE_FILE) {
+  } else if (info.type == SDL_PATHTYPE_FILE &&
+             q_strcmp(name, "pending.mf") && q_strcmp(name, "pending.tmp")) {
     fprintf(file, "%s\n", path);
   }
 
@@ -386,12 +452,13 @@ static void Installer_WritePending(const char *pending) {
   q_snprintf(root, sizeof(root), "%s/quetoo", pending);
 #endif
 
-  char path[MAX_OS_PATH];
+  char path[MAX_OS_PATH], temp[MAX_OS_PATH];
   q_snprintf(path, sizeof(path), "%s/pending.mf", pending);
+  q_snprintf(temp, sizeof(temp), "%s/pending.tmp", pending);
 
-  FILE *file = fopen(path, "wb");
+  FILE *file = fopen(temp, "wb");
   if (!file) {
-    Com_Warn("Failed to write %s\n", path);
+    Com_Warn("Failed to write %s\n", temp);
     return;
   }
 
@@ -402,6 +469,11 @@ static void Installer_WritePending(const char *pending) {
 #endif
 
   fclose(file);
+
+  if (!SDL_RenamePath(temp, path)) {
+    Com_Warn("Failed to write %s: %s\n", path, SDL_GetError());
+    SDL_RemovePath(temp);
+  }
 }
 
 /**
@@ -573,6 +645,54 @@ static bool Installer_DownloadFile(const cm_manifest_entry_t *entry) {
 }
 
 /**
+ * @brief Returns true if the game data manifest is present on disk.
+ */
+static bool Installer_HasManifest(void) {
+
+  char path[MAX_OS_PATH];
+  q_snprintf(path, sizeof(path), "%s/%s/manifest.mf", Fs_DataDir(), Com_Game());
+
+  return SDL_GetPathInfo(path, NULL);
+}
+
+/**
+ * @brief Reads the installed data manifest directly from the filesystem.
+ * @details Not `Cm_ReadManifest`, which resolves through PhysFS: the data
+ * directory is only mounted if it existed when `Fs_Init` ran, so a tree this
+ * installer just created is invisible to it. That would leave every entry
+ * pending and re-download the whole data set a file at a time -- exactly what
+ * the archive install exists to avoid. `Installer_WriteManifest` bypasses
+ * PhysFS for the same reason.
+ */
+static HashTable *Installer_ReadManifest(void) {
+
+  char path[MAX_OS_PATH];
+  q_snprintf(path, sizeof(path), "%s/%s/manifest.mf", Fs_DataDir(), Com_Game());
+
+  FILE *file = fopen(path, "rb");
+  if (!file) {
+    return NULL;
+  }
+
+  fseek(file, 0, SEEK_END);
+  const long length = ftell(file);
+  fseek(file, 0, SEEK_SET);
+
+  HashTable *manifest = NULL;
+
+  if (length > 0) {
+    char *data = Mem_Malloc((size_t) length);
+    if (fread(data, 1, (size_t) length, file) == (size_t) length) {
+      manifest = Cm_ParseManifest(data, (size_t) length);
+    }
+    Mem_Free(data);
+  }
+
+  fclose(file);
+  return manifest;
+}
+
+/**
  * @brief Installs the whole game data set from its release archive.
  * @details A fresh install would otherwise pull eleven thousand files one at a
  * time from S3. The archive is published on GitHub Releases, whose egress is
@@ -682,9 +802,21 @@ static int Installer_Thread(void *unused) {
   bool run = true;
   while (run) {
 
-    switch (in->state) {
+    SDL_LockMutex(installer.mutex);
+    const installer_state_t state = in->state;
+    SDL_UnlockMutex(installer.mutex);
+
+    switch (state) {
 
       case INSTALLER_CHECKING: {
+
+        if (INSTALLER_ASSET == NULL) {
+          SDL_LockMutex(installer.mutex);
+          in->state = INSTALLER_COMPARING;
+          SDL_UnlockMutex(installer.mutex);
+          break;
+        }
+
         const bool ok = Installer_FetchRelease(QUETOO_RELEASES_API_URL, INSTALLER_ASSET,
                                                &installer.release);
         SDL_LockMutex(installer.mutex);
@@ -701,15 +833,9 @@ static int Installer_Thread(void *unused) {
       }
         break;
 
-      case INSTALLER_INSTALLING_DATA:
-        SDL_LockMutex(installer.mutex);
-        in->state = INSTALLER_COMPARING;
-        SDL_UnlockMutex(installer.mutex);
-        break;
-
       case INSTALLER_COMPARING: {
 
-        if (!installer.installed_data && !Fs_Exists("manifest.mf")) {
+        if (!installer.installed_data && !Installer_HasManifest()) {
           installer.installed_data = true;
           if (!Installer_InstallData()) {
             Com_Warn("Falling back to a file by file sync\n");
@@ -740,7 +866,7 @@ static int Installer_Thread(void *unused) {
 
         $(remote, enumerate, Installer_MarkPending, NULL);
 
-        HashTable *local = Cm_ReadManifest("manifest.mf");
+        HashTable *local = Installer_ReadManifest();
         if (local) {
           $(local, enumerate, Installer_MarkStale, NULL);
         }
@@ -794,8 +920,14 @@ static int Installer_Thread(void *unused) {
         char parent[MAX_OS_PATH];
         Installer_StagingParent(parent, sizeof(parent));
 
+        const bool writable = Installer_IsWritable(parent);
+
         SDL_LockMutex(installer.mutex);
-        if (!Installer_IsWritable(parent)) {
+        if (in->state == INSTALLER_CANCELLED) {
+          SDL_UnlockMutex(installer.mutex);
+          break;
+        }
+        if (!writable) {
           in->state = INSTALLER_COMPARING;
           Com_Warn("%s is not writable; skipping the engine update.\n", parent);
         } else {
@@ -811,7 +943,7 @@ static int Installer_Thread(void *unused) {
         char pending[MAX_OS_PATH], archive[MAX_OS_PATH];
         Installer_PendingDir(pending, sizeof(pending));
 
-        SDL_RemovePath(pending);
+        Installer_RemoveTree(pending);
 
         if (!SDL_CreateDirectory(pending)) {
           SDL_LockMutex(installer.mutex);
@@ -834,7 +966,7 @@ static int Installer_Thread(void *unused) {
         SDL_UnlockMutex(installer.mutex);
 
         if (!ok) {
-          SDL_RemovePath(pending);
+          Installer_RemoveTree(pending);
         }
       }
         break;
@@ -851,11 +983,13 @@ static int Installer_Thread(void *unused) {
           Installer_WritePending(pending);
           Com_Print("Quetoo %s staged; it will be applied when you quit.\n", installer.release.tag);
         } else {
-          SDL_RemovePath(pending);
+          Installer_RemoveTree(pending);
         }
 
         SDL_LockMutex(installer.mutex);
-        in->state = ok ? INSTALLER_UPDATE_STAGED : INSTALLER_COMPARING;
+        if (in->state != INSTALLER_CANCELLED) {
+          in->state = ok ? INSTALLER_UPDATE_STAGED : INSTALLER_COMPARING;
+        }
         SDL_UnlockMutex(installer.mutex);
       }
         break;
@@ -866,6 +1000,7 @@ static int Installer_Thread(void *unused) {
         SDL_UnlockMutex(installer.mutex);
         break;
 
+      case INSTALLER_INSTALLING_DATA:
       case INSTALLER_CANCELLED:
       case INSTALLER_DONE:
       case INSTALLER_ERROR:
@@ -882,6 +1017,10 @@ static int Installer_Thread(void *unused) {
  * calling @c frame each iteration while the installer is in progress.
  */
 void Installer_Init(Installer_FrameFunction frame) {
+
+#if defined(_WIN32)
+  Installer_SweepDisplaced();
+#endif
 
   if (build_number->integer == -1) {
     return;
@@ -967,9 +1106,24 @@ static void Installer_SweepDisplaced(void) {
   char line[MAX_OS_PATH];
 
   while (fgets(line, sizeof(line), file)) {
+  char survivors[MAX_OS_PATH * 8];
+  size_t length = 0;
+
+  while (fgets(line, sizeof(line), file)) {
+
     Installer_Chomp(line);
-    if (*line && !SDL_RemovePath(line)) {
+    if (*line == '\0') {
+      continue;
+    }
+
+    Installer_RemoveTree(line);
+
+    if (SDL_GetPathInfo(line, NULL)) {
       swept = false;
+      const int32_t n = q_snprintf(survivors + length, sizeof(survivors) - length, "%s\n", line);
+      if (n > 0) {
+        length += (size_t) n;
+      }
     }
   }
 
@@ -977,49 +1131,38 @@ static void Installer_SweepDisplaced(void) {
 
   if (swept) {
     SDL_RemovePath(path);
+  } else if ((file = fopen(path, "wb"))) {
+    fwrite(survivors, 1, length, file);
+    fclose(file);
   }
 }
 
 #endif
 
 /**
- * @brief Recursively deletes `path`.
- * @details `SDL_RemovePath` only unlinks files and empty directories, but a
- * displaced application bundle is neither.
+ * @brief Applied to each staged file by `Installer_EachPending`.
  */
-static SDL_EnumerationResult Installer_RemoveEntry(void *data, const char *dir, const char *name) {
+typedef bool (*Installer_PendingFunc)(const char *staged, const char *target, FILE *cleanup);
 
-  char path[MAX_OS_PATH];
-  q_snprintf(path, sizeof(path), "%s/%s", dir, name);
-
-  SDL_PathInfo info;
-  if (SDL_GetPathInfo(path, &info) && info.type == SDL_PATHTYPE_DIRECTORY) {
-    SDL_EnumerateDirectory(path, Installer_RemoveEntry, data);
-  }
-
-  SDL_RemovePath(path);
-  return SDL_ENUM_CONTINUE;
-}
-
-static void Installer_RemoveTree(const char *path) {
-
-  SDL_PathInfo info;
-  if (SDL_GetPathInfo(path, &info) && info.type == SDL_PATHTYPE_DIRECTORY) {
-    SDL_EnumerateDirectory(path, Installer_RemoveEntry, NULL);
-  }
-
-  SDL_RemovePath(path);
+/**
+ * @brief Returns the path a displaced file is parked at while an apply runs.
+ */
+static void Installer_Displaced(const char *target, char *out, size_t len) {
+  q_snprintf(out, (int32_t) len, "%s.old", target);
 }
 
 /**
- * @brief Moves a staged file into place, displacing whatever is there.
- * @details A running executable or loaded library cannot be overwritten or
- * deleted, but it can be renamed. POSIX goes further and lets the displaced
- * file be replaced outright: the running process keeps the now-nameless inode
- * until it exits. Windows has no equivalent, so the displaced copy keeps a
- * name until the next launch sweeps it.
+ * @brief Moves a staged file into place, parking whatever was there.
+ * @details The displaced copy is kept until every file has been installed, so
+ * that a failure part way can be undone. Leaving a half-updated tree would
+ * pair an executable with game modules of another version, which the
+ * `CGAME_API_VERSION` check rejects outright -- an install that cannot start
+ * is far worse than one that is merely out of date.
+ *
+ * A running executable or loaded library cannot be overwritten or deleted, but
+ * it can be renamed, which is what makes this possible at all.
  */
-static bool Installer_Replace(const char *staged, const char *target, FILE *cleanup) {
+static bool Installer_Install(const char *staged, const char *target, FILE *cleanup) {
 
   char dir[MAX_OS_PATH];
   q_strlcpy(dir, target, sizeof(dir));
@@ -1030,20 +1173,11 @@ static bool Installer_Replace(const char *staged, const char *target, FILE *clea
     SDL_CreateDirectory(dir);
   }
 
-  SDL_PathInfo info;
-  const bool exists = SDL_GetPathInfo(target, &info);
+  if (SDL_GetPathInfo(target, NULL)) {
 
-#if defined(_WIN32)
-  const bool displace = exists;
-#else
-  const bool displace = exists && info.type == SDL_PATHTYPE_DIRECTORY;
-#endif
+    char displaced[MAX_OS_PATH];
+    Installer_Displaced(target, displaced, sizeof(displaced));
 
-  char displaced[MAX_OS_PATH] = { '\0' };
-
-  if (displace) {
-
-    q_snprintf(displaced, sizeof(displaced), "%s.old", target);
     Installer_RemoveTree(displaced);
 
     if (!SDL_RenamePath(target, displaced)) {
@@ -1054,13 +1188,24 @@ static bool Installer_Replace(const char *staged, const char *target, FILE *clea
 
   if (!SDL_RenamePath(staged, target)) {
     Com_Warn("Failed to install %s: %s\n", target, SDL_GetError());
-    if (*displaced) {
-      SDL_RenamePath(displaced, target);
-    }
     return false;
   }
 
-  if (*displaced) {
+  return true;
+}
+
+/**
+ * @brief Discards the file displaced by a successful install.
+ * @details POSIX can drop it immediately, because a process running from it
+ * holds the inode regardless of the name. Windows cannot delete a mapped
+ * image, so the path is recorded and swept at the next launch.
+ */
+static bool Installer_Commit_(const char *staged, const char *target, FILE *cleanup) {
+
+  char displaced[MAX_OS_PATH];
+  Installer_Displaced(target, displaced, sizeof(displaced));
+
+  if (SDL_GetPathInfo(displaced, NULL)) {
     if (cleanup) {
       fprintf(cleanup, "%s\n", displaced);
     } else {
@@ -1071,11 +1216,82 @@ static bool Installer_Replace(const char *staged, const char *target, FILE *clea
   return true;
 }
 
+/**
+ * @brief Restores a displaced file, undoing a failed apply.
+ * @details The staged copy is moved back out of the way first, so that the
+ * staging directory survives intact and the whole update can simply be retried
+ * at the next exit.
+ */
+static bool Installer_Rollback(const char *staged, const char *target, FILE *cleanup) {
+
+  char displaced[MAX_OS_PATH];
+  Installer_Displaced(target, displaced, sizeof(displaced));
+
+  if (!SDL_GetPathInfo(displaced, NULL)) {
+    return true;
+  }
+
+  if (!SDL_GetPathInfo(staged, NULL)) {
+    SDL_RenamePath(target, staged);
+  }
+
+  if (!SDL_RenamePath(displaced, target)) {
+    Com_Warn("Failed to restore %s: %s\n", target, SDL_GetError());
+  }
+
+  return true;
+}
+
+/**
+ * @brief Iterates the staged files, invoking `func` for each.
+ * @return The number of entries visited, or -1 if the manifest is malformed.
+ */
+static int32_t Installer_EachPending(FILE *file, const char *root, Installer_PendingFunc func,
+                                     FILE *cleanup) {
+
+  fseek(file, 0, SEEK_SET);
+
+  char line[MAX_OS_PATH];
+  if (!fgets(line, sizeof(line), file) || !fgets(line, sizeof(line), file)) {
+    return -1;
+  }
+
+  const size_t root_len = q_strlen(root);
+
+  int32_t count = 0;
+
+  while (fgets(line, sizeof(line), file)) {
+
+    const bool complete = q_strchr(line, '\n') || feof(file);
+    Installer_Chomp(line);
+
+    if (!complete) {
+      Com_Warn("Staged path too long: %s\n", line);
+      return -1;
+    }
+
+    if (q_strncmp(line, root, root_len) || line[root_len] != '/') {
+      continue;
+    }
+
+    char target[MAX_OS_PATH];
+    q_snprintf(target, sizeof(target), "%s%s", Fs_BaseDir(), line + root_len);
+
+    if (!func(line, target, cleanup)) {
+      return -1;
+    }
+
+    count++;
+  }
+
+  return count;
+}
+
 void Installer_ApplyPending(void) {
 
-#if defined(_WIN32)
-  Installer_SweepDisplaced();
-#endif
+  if (*Fs_BaseDir() == '\0') {
+    return;
+  }
 
   char pending[MAX_OS_PATH], path[MAX_OS_PATH];
   Installer_PendingDir(pending, sizeof(pending));
@@ -1102,31 +1318,24 @@ void Installer_ApplyPending(void) {
 #if defined(_WIN32)
   char cleanup_path[MAX_OS_PATH];
   q_snprintf(cleanup_path, sizeof(cleanup_path), "%s/.cleanup", Fs_BaseDir());
-  cleanup = fopen(cleanup_path, "wb");
+  cleanup = fopen(cleanup_path, "ab");
 #endif
 
-  const size_t root_len = q_strlen(root);
+  const int32_t installed = Installer_EachPending(file, root, Installer_Install, cleanup);
 
-  bool success = true, files = false;
-  char line[MAX_OS_PATH];
+  bool success = installed >= 0;
 
-  while (success && fgets(line, sizeof(line), file)) {
-
-    Installer_Chomp(line);
-
-    if (q_strncmp(line, root, root_len) || line[root_len] != '/') {
-      continue;
-    }
-
-    char target[MAX_OS_PATH];
-    q_snprintf(target, sizeof(target), "%s%s", Fs_BaseDir(), line + root_len);
-
-    success = Installer_Replace(line, target, cleanup);
-    files = true;
+  const bool whole = success && installed == 0;
+  if (whole) {
+    success = Installer_Install(root, Fs_BaseDir(), cleanup);
   }
 
-  if (success && !files) {
-    success = Installer_Replace(root, Fs_BaseDir(), cleanup);
+  const Installer_PendingFunc finish = success ? Installer_Commit_ : Installer_Rollback;
+
+  if (whole) {
+    finish(root, Fs_BaseDir(), success ? cleanup : NULL);
+  } else {
+    Installer_EachPending(file, root, finish, success ? cleanup : NULL);
   }
 
   if (cleanup) {
@@ -1139,7 +1348,8 @@ void Installer_ApplyPending(void) {
     Installer_RemoveTree(pending);
     Com_Print("Updated to Quetoo %s.\n", version);
   } else {
-    Com_Warn("Failed to apply the staged update; it will be retried on exit.\n");
+    Com_Warn("Could not apply the staged update; the previous version is intact "
+             "and it will be retried on the next exit.\n");
   }
 }
 

--- a/src/common/installer.c
+++ b/src/common/installer.c
@@ -110,10 +110,9 @@ static struct {
 
   /**
    * @brief Whether the player has agreed to install an available update.
-   * @details Zero until asked, then 1 to accept or -1 to decline. Presettable
-   * on the command line, so an unattended install can answer in advance.
+   * @details Zero until answered, then 1 to accept or -1 to decline.
    */
-  cvar_t *consent;
+  int32_t consent;
 
   /**
    * @brief The installer status, used to expose progress via `Installer_FrameFunction`.
@@ -844,9 +843,6 @@ static int Installer_Thread(void *unused) {
         Installer_StagingParent(parent, sizeof(parent));
 
         const bool writable = *parent && Installer_IsWritable(parent);
-        if (ok && !writable && *parent) {
-          Com_Warn("%s is not writable; engine updates are disabled.\n", parent);
-        }
 
         SDL_LockMutex(installer.mutex);
         if (!ok) {
@@ -858,6 +854,9 @@ static int Installer_Thread(void *unused) {
             q_strlcpy(in->current_file, installer.release.asset, sizeof(in->current_file));
           } else {
             in->state = INSTALLER_COMPARING;
+            Com_Warn("Quetoo %s is available, but %s is not writable.\n"
+                     "Download it from %s\n", installer.release.tag,
+                     *parent ? parent : "this installation", QUETOO_RELEASES_PAGE);
           }
         } else {
           in->state = INSTALLER_COMPARING;
@@ -951,7 +950,9 @@ static int Installer_Thread(void *unused) {
 
       case INSTALLER_UPDATE_AVAILABLE: {
 
-        const int32_t consent = installer.consent->integer;
+        SDL_LockMutex(installer.mutex);
+        const int32_t consent = installer.consent;
+        SDL_UnlockMutex(installer.mutex);
 
         if (consent == 0) {
           SDL_Delay(QUETOO_TICK_MILLIS);
@@ -1260,6 +1261,15 @@ static int32_t Installer_EachPending(FILE *file, const char *root, Installer_Pen
   return count;
 }
 
+void Installer_Consent(bool accept) {
+
+  if (installer.mutex) {
+    SDL_LockMutex(installer.mutex);
+    installer.consent = accept ? 1 : -1;
+    SDL_UnlockMutex(installer.mutex);
+  }
+}
+
 void Installer_ApplyPending(void) {
 
   if (*Fs_BaseDir() == '\0') {
@@ -1332,10 +1342,6 @@ void Installer_ApplyPending(void) {
  */
 void Installer_Init(Installer_FrameFunction frame) {
 
-  cvar_t *consent = Cvar_Add("update_consent", "0", 0,
-                             "Whether to install an available engine update: "
-                             "1 to accept, -1 to decline, 0 to ask");
-
 #if defined(_WIN32)
   Installer_SweepDisplaced();
 #endif
@@ -1353,7 +1359,6 @@ void Installer_Init(Installer_FrameFunction frame) {
 
   memset(&installer, 0, sizeof(installer));
   installer.status.state = INSTALLER_CHECKING;
-  installer.consent = consent;
 
   installer.mutex = SDL_CreateMutex();
   assert(installer.mutex);

--- a/src/common/installer.c
+++ b/src/common/installer.c
@@ -698,6 +698,9 @@ static HashTable *Installer_ReadManifest(void) {
  * time from S3. The archive is published on GitHub Releases, whose egress is
  * free, so the cold start costs nothing to serve; the per-file sync is left to
  * carry the small differences between releases.
+ * @remarks A partial extraction is left in place rather than unwound, but its
+ * manifest is discarded: the per-file sync compares against that manifest and
+ * would otherwise treat files it never wrote as already current.
  */
 static bool Installer_InstallData(void) {
 
@@ -730,6 +733,12 @@ static bool Installer_InstallData(void) {
   }
 
   SDL_RemovePath(archive);
+
+  if (!success) {
+    char manifest[MAX_OS_PATH];
+    q_snprintf(manifest, sizeof(manifest), "%s/%s/manifest.mf", Fs_DataDir(), Com_Game());
+    SDL_RemovePath(manifest);
+  }
 
   SDL_LockMutex(installer.mutex);
   if (in->state == INSTALLER_INSTALLING_DATA) {

--- a/src/common/installer.c
+++ b/src/common/installer.c
@@ -1022,65 +1022,6 @@ static int Installer_Thread(void *unused) {
 }
 
 /**
- * @brief Starts an asynchronous data update and blocks until it completes,
- * calling @c frame each iteration while the installer is in progress.
- */
-void Installer_Init(Installer_FrameFunction frame) {
-
-#if defined(_WIN32)
-  Installer_SweepDisplaced();
-#endif
-
-  if (build_number->integer == -1) {
-    return;
-  }
-
-#if defined(__linux__)
-  if (q_strcmp(Fs_BinDir(), "/usr/lib/quetoo/bin") == 0) {
-    Com_Print("Package-managed installation; auto-updates disabled.\n");
-    return;
-  }
-#endif
-
-  memset(&installer, 0, sizeof(installer));
-  installer.status.state = INSTALLER_CHECKING;
-
-  installer.mutex = SDL_CreateMutex();
-  assert(installer.mutex);
-
-  installer.thread = SDL_CreateThread(Installer_Thread, "installer", &installer);
-  assert(installer.thread);
-
-  installer_status_t *in = &installer.status;
-
-  while (true) {
-    installer_status_t s;
-
-    SDL_LockMutex(installer.mutex);
-    s = *in;
-    SDL_UnlockMutex(installer.mutex);
-
-    if (frame(&s)) {
-      break;
-    }
-
-    SDL_Delay(QUETOO_TICK_MILLIS); // 40Hz should be plenty for progress bar updates etc
-  }
-
-  SDL_LockMutex(installer.mutex);
-  if (in->state < INSTALLER_DONE) {
-    in->state = INSTALLER_CANCELLED;
-  }
-  SDL_UnlockMutex(installer.mutex);
-
-  SDL_WaitThread(installer.thread, NULL);
-  installer.thread = NULL;
-
-  SDL_DestroyMutex(installer.mutex);
-  installer.mutex = NULL;
-}
-
-/**
  * @brief Strips a trailing newline in place.
  */
 static void Installer_Chomp(char *line) {
@@ -1113,8 +1054,6 @@ static void Installer_SweepDisplaced(void) {
 
   bool swept = true;
   char line[MAX_OS_PATH];
-
-  while (fgets(line, sizeof(line), file)) {
   char survivors[MAX_OS_PATH * 8];
   size_t length = 0;
 
@@ -1360,6 +1299,65 @@ void Installer_ApplyPending(void) {
     Com_Warn("Could not apply the staged update; the previous version is intact "
              "and it will be retried on the next exit.\n");
   }
+}
+
+/**
+ * @brief Starts an asynchronous data update and blocks until it completes,
+ * calling @c frame each iteration while the installer is in progress.
+ */
+void Installer_Init(Installer_FrameFunction frame) {
+
+#if defined(_WIN32)
+  Installer_SweepDisplaced();
+#endif
+
+  if (build_number->integer == -1) {
+    return;
+  }
+
+#if defined(__linux__)
+  if (q_strcmp(Fs_BinDir(), "/usr/lib/quetoo/bin") == 0) {
+    Com_Print("Package-managed installation; auto-updates disabled.\n");
+    return;
+  }
+#endif
+
+  memset(&installer, 0, sizeof(installer));
+  installer.status.state = INSTALLER_CHECKING;
+
+  installer.mutex = SDL_CreateMutex();
+  assert(installer.mutex);
+
+  installer.thread = SDL_CreateThread(Installer_Thread, "installer", &installer);
+  assert(installer.thread);
+
+  installer_status_t *in = &installer.status;
+
+  while (true) {
+    installer_status_t s;
+
+    SDL_LockMutex(installer.mutex);
+    s = *in;
+    SDL_UnlockMutex(installer.mutex);
+
+    if (frame(&s)) {
+      break;
+    }
+
+    SDL_Delay(QUETOO_TICK_MILLIS); // 40Hz should be plenty for progress bar updates etc
+  }
+
+  SDL_LockMutex(installer.mutex);
+  if (in->state < INSTALLER_DONE) {
+    in->state = INSTALLER_CANCELLED;
+  }
+  SDL_UnlockMutex(installer.mutex);
+
+  SDL_WaitThread(installer.thread, NULL);
+  installer.thread = NULL;
+
+  SDL_DestroyMutex(installer.mutex);
+  installer.mutex = NULL;
 }
 
 /**

--- a/src/common/installer.h
+++ b/src/common/installer.h
@@ -28,6 +28,8 @@
 #define QUETOO_RELEASES_URL     "https://github.com/jdolan/quetoo/releases/latest"
 #define QUETOO_RELEASES_API_URL "https://api.github.com/repos/jdolan/quetoo/releases/latest"
 #define QUETOO_DATA_BASE_URL    "https://quetoo-data.s3.amazonaws.com"
+#define QUETOO_DATA_API_URL     "https://api.github.com/repos/jdolan/quetoo-data/releases/latest"
+#define QUETOO_DATA_ARCHIVE     "quetoo-data.zip"
 
 /**
  * @brief The installer lifecycle.
@@ -38,6 +40,7 @@ typedef enum {
   INSTALLER_DOWNLOADING_UPDATE,
   INSTALLER_STAGING_UPDATE,
   INSTALLER_UPDATE_STAGED,
+  INSTALLER_INSTALLING_DATA,
   INSTALLER_COMPARING,
   INSTALLER_DOWNLOADING,
   INSTALLER_COMMITTING,

--- a/src/common/installer.h
+++ b/src/common/installer.h
@@ -32,6 +32,14 @@
 #define QUETOO_DATA_ARCHIVE     "quetoo-data.zip"
 
 /**
+ * @brief Marker a distribution ships beside the installation to claim
+ * responsibility for updating the engine itself.
+ * @details Game content is unaffected: it is written to the user's own
+ * directory rather than the installation, so nothing else is managing it.
+ */
+#define INSTALLER_MANAGED       ".managed"
+
+/**
  * @brief The installer lifecycle.
  */
 typedef enum {

--- a/src/common/installer.h
+++ b/src/common/installer.h
@@ -26,8 +26,7 @@
 #include <SDL3/SDL_mutex.h>
 
 #define QUETOO_RELEASES_URL     "https://github.com/jdolan/quetoo/releases/latest"
-#define QUETOO_BUILD_URL        "https://quetoo.s3.amazonaws.com/build"
-#define QUETOO_MOTD_URL         "https://quetoo.s3.amazonaws.com/motd"
+#define QUETOO_RELEASES_API_URL "https://api.github.com/repos/jdolan/quetoo/releases/latest"
 #define QUETOO_DATA_BASE_URL    "https://quetoo-data.s3.amazonaws.com"
 
 /**
@@ -36,6 +35,9 @@
 typedef enum {
   INSTALLER_CHECKING,
   INSTALLER_UPDATE_AVAILABLE,
+  INSTALLER_DOWNLOADING_UPDATE,
+  INSTALLER_STAGING_UPDATE,
+  INSTALLER_UPDATE_STAGED,
   INSTALLER_COMPARING,
   INSTALLER_DOWNLOADING,
   INSTALLER_COMMITTING,

--- a/src/common/installer.h
+++ b/src/common/installer.h
@@ -63,6 +63,10 @@ typedef struct {
 
 /**
  * @brief Frame callback type for `Installer_Wait`.
+ * @remarks On `INSTALLER_UPDATE_AVAILABLE` the installer waits for the
+ * `update_consent` cvar to become non-zero, so the frame function is
+ * responsible for asking the player, or for answering on their behalf where
+ * there is nobody to ask.
  * @details Returning non-zero will terminate the installer process and resume startup.
  */
 typedef int32_t (*Installer_FrameFunction)(const installer_status_t *status);

--- a/src/common/installer.h
+++ b/src/common/installer.h
@@ -25,7 +25,6 @@
 
 #include <SDL3/SDL_mutex.h>
 
-#define QUETOO_RELEASES_URL     "https://github.com/jdolan/quetoo/releases/latest"
 #define QUETOO_RELEASES_API_URL "https://api.github.com/repos/jdolan/quetoo/releases/latest"
 #define QUETOO_DATA_BASE_URL    "https://quetoo-data.s3.amazonaws.com"
 #define QUETOO_DATA_API_URL     "https://api.github.com/repos/jdolan/quetoo-data/releases/latest"
@@ -54,7 +53,6 @@ typedef enum {
  */
 typedef struct {
 	installer_state_t state;
-  int32_t build_number;
 	int32_t files_done;
 	int32_t files_total;
 	int32_t kbytes_done;

--- a/src/common/installer.h
+++ b/src/common/installer.h
@@ -67,4 +67,16 @@ typedef struct {
 typedef int32_t (*Installer_FrameFunction)(const installer_status_t *status);
 
 void Installer_Init(Installer_FrameFunction frame);
+
+/**
+ * @brief Moves a staged update into place, and sweeps files displaced by a
+ * previous one.
+ * @details Called during shutdown, after the game modules are unloaded and
+ * before the filesystem paths go away. Applying on the way out rather than on
+ * the way in means the update completes in the session that fetched it, and
+ * that nothing is loaded after the files move. A crash before this runs simply
+ * leaves the staged update for the next clean exit.
+ */
+void Installer_ApplyPending(void);
+
 void Installer_Shutdown(void);

--- a/src/common/installer.h
+++ b/src/common/installer.h
@@ -26,6 +26,7 @@
 #include <SDL3/SDL_mutex.h>
 
 #define QUETOO_RELEASES_API_URL "https://api.github.com/repos/jdolan/quetoo/releases/latest"
+#define QUETOO_RELEASES_PAGE    "https://github.com/jdolan/quetoo/releases/latest"
 #define QUETOO_DATA_BASE_URL    "https://quetoo-data.s3.amazonaws.com"
 #define QUETOO_DATA_API_URL     "https://api.github.com/repos/jdolan/quetoo-data/releases/latest"
 #define QUETOO_DATA_ARCHIVE     "quetoo-data.zip"
@@ -63,10 +64,9 @@ typedef struct {
 
 /**
  * @brief Frame callback type for `Installer_Wait`.
- * @remarks On `INSTALLER_UPDATE_AVAILABLE` the installer waits for the
- * `update_consent` cvar to become non-zero, so the frame function is
- * responsible for asking the player, or for answering on their behalf where
- * there is nobody to ask.
+ * @remarks On `INSTALLER_UPDATE_AVAILABLE` the installer waits for
+ * `Installer_Consent`, so the frame function is responsible for asking the
+ * player, or for answering on their behalf where there is nobody to ask.
  * @details Returning non-zero will terminate the installer process and resume startup.
  */
 typedef int32_t (*Installer_FrameFunction)(const installer_status_t *status);
@@ -82,6 +82,14 @@ void Installer_Init(Installer_FrameFunction frame);
  * that nothing is loaded after the files move. A crash before this runs simply
  * leaves the staged update for the next clean exit.
  */
+/**
+ * @brief Answers the question posed by `INSTALLER_UPDATE_AVAILABLE`.
+ * @details The installer does not act on an available update until this is
+ * called. Declining skips the engine update for this run only; the next launch
+ * asks again, so nobody is quietly opted in or out.
+ */
+void Installer_Consent(bool accept);
+
 void Installer_ApplyPending(void);
 
 void Installer_Shutdown(void);

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -481,6 +481,9 @@ static void Shutdown(const char *msg) {
     Cl_Shutdown();
   }
 
+  // with the game modules unloaded, but while the paths are still valid
+  Installer_ApplyPending();
+
   Netchan_Shutdown();
 
   Thread_Shutdown();

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -481,7 +481,6 @@ static void Shutdown(const char *msg) {
     Cl_Shutdown();
   }
 
-  // with the game modules unloaded, but while the paths are still valid
   Installer_ApplyPending();
 
   Netchan_Shutdown();

--- a/src/server/sv_main.c
+++ b/src/server/sv_main.c
@@ -784,6 +784,9 @@ int32_t Sv_InstallerFrame(const installer_status_t *in) {
       case INSTALLER_UPDATE_STAGED:
         Com_Print("Update staged; it will be applied when this server exits.\n");
         break;
+      case INSTALLER_INSTALLING_DATA:
+        Com_Print("Installing game data\u2026\n");
+        break;
       case INSTALLER_COMPARING:
         Com_Print("Comparing data with remote\u2026\n");
         break;

--- a/src/server/sv_main.c
+++ b/src/server/sv_main.c
@@ -771,10 +771,11 @@ int32_t Sv_InstallerFrame(const installer_status_t *in) {
         Com_Print("Checking binary version\u2026\n");
         break;
       case INSTALLER_UPDATE_AVAILABLE:
-        Com_Warn("A new version of Quetoo is available; downloading it now.\n"
-                 "Your server will not be public until you restart.\n");
+        Com_Warn("A new version of Quetoo is available.\n"
+                 "Run quetoo-update to install it.\n"
+                 "Your server will not be public until you do.\n");
         Cvar_ForceSetInteger("sv_public", 0);
-        Cvar_SetInteger("update_consent", 1);
+        Installer_Consent(false);
         break;
       case INSTALLER_DOWNLOADING_UPDATE:
         Com_Print("Downloading %s\u2026\n", in->current_file);

--- a/src/server/sv_main.c
+++ b/src/server/sv_main.c
@@ -771,10 +771,18 @@ int32_t Sv_InstallerFrame(const installer_status_t *in) {
         Com_Print("Checking binary version\u2026\n");
         break;
       case INSTALLER_UPDATE_AVAILABLE:
-        Com_Warn("A new version of Quetoo is available.\n"
-                 "Download it at: https://github.com/jdolan/quetoo/releases/latest\n"
-                 "Your server will not be public until you update.\n");
+        Com_Warn("A new version of Quetoo is available; downloading it now.\n"
+                 "Your server will not be public until you restart.\n");
         Cvar_ForceSetInteger("sv_public", 0);
+        break;
+      case INSTALLER_DOWNLOADING_UPDATE:
+        Com_Print("Downloading %s\u2026\n", in->current_file);
+        break;
+      case INSTALLER_STAGING_UPDATE:
+        Com_Print("Unpacking update\u2026\n");
+        break;
+      case INSTALLER_UPDATE_STAGED:
+        Com_Print("Update staged; it will be applied when this server exits.\n");
         break;
       case INSTALLER_COMPARING:
         Com_Print("Comparing data with remote\u2026\n");

--- a/src/server/sv_main.c
+++ b/src/server/sv_main.c
@@ -774,6 +774,7 @@ int32_t Sv_InstallerFrame(const installer_status_t *in) {
         Com_Warn("A new version of Quetoo is available; downloading it now.\n"
                  "Your server will not be public until you restart.\n");
         Cvar_ForceSetInteger("sv_public", 0);
+        Cvar_SetInteger("update_consent", 1);
         break;
       case INSTALLER_DOWNLOADING_UPDATE:
         Com_Print("Downloading %s\u2026\n", in->current_file);

--- a/src/tests/Makefile.am
+++ b/src/tests/Makefile.am
@@ -30,6 +30,7 @@ libtests_la_LIBADD = \
 	$(top_builddir)/src/common/libcommon.la
 
 TESTS = \
+	check_archive \
 	check_atlas \
 	check_box \
 	check_cm_entity \
@@ -53,6 +54,13 @@ TESTS = \
 	check_vector
 
 noinst_PROGRAMS = $(TESTS)
+
+check_archive_SOURCES = \
+	check_archive.c
+check_archive_CFLAGS = \
+	$(TESTS_CFLAGS)
+check_archive_LDADD = \
+	$(TESTS_LIBS)
 
 check_atlas_SOURCES = \
 	check_atlas.c

--- a/src/tests/check_archive.c
+++ b/src/tests/check_archive.c
@@ -25,6 +25,8 @@
 
 #include "common/archive.h"
 
+quetoo_t quetoo;
+
 #define DEST "/tmp/quetoo-archive"
 
 START_TEST(check_archive_safe_paths) {

--- a/src/tests/check_archive.c
+++ b/src/tests/check_archive.c
@@ -1,0 +1,121 @@
+/*
+ * Copyright(c) 1997-2001 id Software, Inc.
+ * Copyright(c) 2002 The Quakeforge Project.
+ * Copyright(c) 2006 Quetoo.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+#include <check.h>
+
+#include "tests.h"
+
+#include "common/archive.h"
+
+#define DEST "/tmp/quetoo-archive"
+
+START_TEST(check_archive_safe_paths) {
+
+  char out[MAX_OS_PATH];
+
+  ck_assert(Archive_SafePath(DEST, "bin/quetoo", out, sizeof(out)));
+  ck_assert_str_eq(DEST "/bin/quetoo", out);
+
+  ck_assert(Archive_SafePath(DEST, "default/maps/edge.bsp", out, sizeof(out)));
+  ck_assert_str_eq(DEST "/default/maps/edge.bsp", out);
+
+  ck_assert(Archive_SafePath(DEST, "a.b..c/d", out, sizeof(out)));
+  ck_assert_str_eq(DEST "/a.b..c/d", out);
+
+  ck_assert(Archive_SafePath(DEST, "lib\\default\\cgame.dll", out, sizeof(out)));
+  ck_assert_str_eq(DEST "/lib/default/cgame.dll", out);
+
+} END_TEST
+
+START_TEST(check_archive_traversal) {
+
+  char out[MAX_OS_PATH];
+
+  ck_assert(!Archive_SafePath(DEST, "../evil", out, sizeof(out)));
+  ck_assert(!Archive_SafePath(DEST, "a/../../evil", out, sizeof(out)));
+  ck_assert(!Archive_SafePath(DEST, "a/..", out, sizeof(out)));
+  ck_assert(!Archive_SafePath(DEST, "..", out, sizeof(out)));
+  ck_assert(!Archive_SafePath(DEST, "..\\evil", out, sizeof(out)));
+  ck_assert(!Archive_SafePath(DEST, "a\\..\\..\\evil", out, sizeof(out)));
+
+} END_TEST
+
+START_TEST(check_archive_absolute) {
+
+  char out[MAX_OS_PATH];
+
+  ck_assert(!Archive_SafePath(DEST, "/etc/cron.d/evil", out, sizeof(out)));
+  ck_assert(!Archive_SafePath(DEST, "\\windows\\system32\\evil.dll", out, sizeof(out)));
+  ck_assert(!Archive_SafePath(DEST, "C:\\windows\\evil.dll", out, sizeof(out)));
+  ck_assert(!Archive_SafePath(DEST, "c:/windows/evil.dll", out, sizeof(out)));
+  ck_assert(!Archive_SafePath(DEST, "", out, sizeof(out)));
+
+} END_TEST
+
+START_TEST(check_archive_reserved) {
+
+  char out[MAX_OS_PATH];
+
+  ck_assert(!Archive_SafePath(DEST, "CON", out, sizeof(out)));
+  ck_assert(!Archive_SafePath(DEST, "nul.txt", out, sizeof(out)));
+  ck_assert(!Archive_SafePath(DEST, "a/COM1/b", out, sizeof(out)));
+  ck_assert(!Archive_SafePath(DEST, "LPT9.dat", out, sizeof(out)));
+  ck_assert(!Archive_SafePath(DEST, "trailing.", out, sizeof(out)));
+  ck_assert(!Archive_SafePath(DEST, "trailing ", out, sizeof(out)));
+
+  ck_assert(Archive_SafePath(DEST, "console.cfg", out, sizeof(out)));
+  ck_assert(Archive_SafePath(DEST, "coma/b", out, sizeof(out)));
+
+} END_TEST
+
+START_TEST(check_archive_overflow) {
+
+  char out[64];
+
+  ck_assert(!Archive_SafePath(DEST, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                                    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", out, sizeof(out)));
+
+} END_TEST
+
+/**
+ * @brief Test entry point.
+ */
+int32_t main(int32_t argc, char **argv) {
+
+  TCase *tcase = tcase_create("check_archive");
+
+  tcase_add_test(tcase, check_archive_safe_paths);
+  tcase_add_test(tcase, check_archive_traversal);
+  tcase_add_test(tcase, check_archive_absolute);
+  tcase_add_test(tcase, check_archive_reserved);
+  tcase_add_test(tcase, check_archive_overflow);
+
+  Suite *suite = suite_create("check_archive");
+  suite_add_tcase(suite, tcase);
+
+  SRunner *runner = srunner_create(suite);
+
+  srunner_run_all(runner, CK_VERBOSE);
+  int32_t failed = srunner_ntests_failed(runner);
+
+  srunner_free(runner);
+  return failed;
+}

--- a/src/tools/check_platform_syntax.sh
+++ b/src/tools/check_platform_syntax.sh
@@ -1,0 +1,54 @@
+#!/bin/sh
+# Syntax-checks platform-specific code paths that the host compiler skips.
+#
+# The installer's update logic branches heavily on the host, so most of the
+# Windows path never reaches a compiler on a macOS or Linux workstation, and a
+# use-before-declaration or an unbalanced brace in it only surfaces in CI. The
+# blocks involved use SDL and stdio rather than Win32 directly, so forcing them
+# on locally is enough to parse them.
+#
+# Usage: src/tools/check_platform_syntax.sh [_WIN32|__APPLE__|__linux__]
+
+set -e
+
+top=$(cd "$(dirname "$0")/../.." && pwd)
+want=${1:-_WIN32}
+status=0
+
+flags=$(pkg-config --cflags sdl3 Objectively physfs 2>/dev/null || true)
+
+script=$(mktemp)
+cat > "$script" <<SED
+s/#if defined($want)/#if 1/
+s/#if !defined($want)/#if 0/
+SED
+
+for other in _WIN32 __APPLE__ __linux__; do
+	if [ "$other" != "$want" ]; then
+		echo "s/#if defined($other)/#if 0/" >> "$script"
+		echo "s/#if !defined($other)/#if 1/" >> "$script"
+	fi
+done
+
+for source in "$top"/src/common/installer.c "$top"/src/common/archive.c; do
+
+	scratch="$(dirname "$source")/.platform-syntax-$(basename "$source")"
+	errors=$(mktemp)
+
+	sed -f "$script" "$source" > "$scratch"
+
+	printf '%-14s %-10s ... ' "$(basename "$source")" "$want"
+
+	if cc -fsyntax-only -I"$top" -I"$top/src" $flags "$scratch" 2> "$errors"; then
+		echo "ok"
+	else
+		echo "FAILED"
+		sed "s|$scratch|$source|g" "$errors" | sed 's/^/  /' | head -20
+		status=1
+	fi
+
+	rm -f "$scratch" "$errors"
+done
+
+rm -f "$script"
+exit $status


### PR DESCRIPTION
Closes #1033.

Quetoo can now update its own binaries. A newer release is downloaded and
unpacked during the session, then renamed into place during shutdown — so the
update completes in the session that fetched it and the *next* launch is
already the new build.

Also stops shipping game data inside the release artifacts, which is what made
every macOS engine release a ~1GB re-download, re-sign and re-notarize. The app
is now about 17MB.

## How it works

Applying at shutdown rather than startup is load-bearing. A running executable
cannot be overwritten or deleted, but it *can* be renamed — and by the time
`Installer_ApplyPending` runs, the game modules are unloaded and nothing will be
loaded again. Applying at startup would instead leave the old executable running
against the new game modules, which the `CGAME_API_VERSION` check rejects
outright, and would need three launches to fully update instead of two.

POSIX lets a running binary be replaced outright, leaving the displaced file as
a nameless inode the kernel reclaims on exit, so **nothing is left behind**.
Windows keeps the displaced copy named until the owning process exits, so those
paths are recorded and swept at the next launch. Directories are the exception
on POSIX — `rename` refuses a non-empty target — so a macOS bundle is displaced
first and removed after.

## Verification

The Windows premise was the one thing that gated this design, and it was spiked
on real hardware before any code was written (Windows 11 x64, build 26200):
11/11 checks behaved as predicted — renaming a running `.exe` and a loaded
`.dll` both succeed, deleting or replacing either in place fails with
`ERROR_ACCESS_DENIED`, and the displaced copies delete cleanly once the process
has exited. Details in the [spike results](https://github.com/jdolan/quetoo/issues/1033#issuecomment-5628034614).

Beyond that, against the real `v1.0.91` artifacts:

- **Extraction** — all three backends. The tarball keeps its mode bits; the disk
  image yields a `Quetoo.app` that still passes `codesign --verify --deep
  --strict`, with the `/Applications` alias skipped and no mount leaked.
- **Apply** — both modes. Tree mode replaces files, adds new ones, leaves
  unrelated files alone, removes the staging directory, leaves zero residue and
  is idempotent. Bundle mode swaps the whole `.app` and preserves siblings.
- **Path sanitization** — 24 cases covering traversal, absolute paths, drive
  prefixes and Windows device names.
- **Version comparison** — 13 cases, including `1.0.9` vs `1.0.91`, which naive
  string comparison gets wrong.
- Full build clean, zero warnings.

Two bugs were caught by testing rather than review, both real: staging was
initially placed *inside* the macOS bundle being replaced, so renaming the
bundle aside carried the payload with it; and directory replacement used a
single `rename` over a non-empty target, which POSIX refuses.

## Notes for review

- **`CGAME_API_VERSION` 45 → 46.** Inserting installer states shifts the values
  of `INSTALLER_DONE` and `INSTALLER_ERROR`, which cgame compares against. The
  vtable is unchanged; the enum it carries is not.
- **`quetoo-data.zip` does not exist yet.** It lands on the next `quetoo-data`
  tag ([already merged there](https://github.com/jdolan/quetoo-data/commit/8d9d984c)).
  Until then the cold-install path logs the missing asset and falls through to
  the existing per-file sync. That fallback is permanent, not transitional.
- **itch.io** is repointed at the plain engine archives, since the bundled ones
  are gone and its own client handles updating. Easy to change if you'd rather
  drop the channel.
- **Deliberately not done:** stapling the app inside the DMG. Stapling after the
  image is built does not reach the copy inside it, and it buys nothing when the
  installer downloads the image itself — the extracted app carries no quarantine
  attribute, so Gatekeeper never runs a full assessment. Documented in
  `apple/Makefile`.
- The in-game "a new version is available, download now?" dialog is removed; it
  existed to send players to the releases page by hand.

The unit test is wired into `src/tests` but `--with-tests` is off in my local
configure, so it was verified by linking a driver against the compiled object.
