### PR TITLE
Count down the intermission, and vote for what follows it

### DIFF
--- a/Quetoo.vs15/cgame-ctf.vcxproj.filters
+++ b/Quetoo.vs15/cgame-ctf.vcxproj.filters
@@ -129,7 +129,7 @@
     <ClInclude Include="..\src\cgame\common\cg_ctf.h">
       <Filter>src\common</Filter>
     </ClInclude>
-    <ClInclude Include="\.\.\src\cgame\common\cg_intermission.h">
+    <ClInclude Include="..\src\cgame\common\cg_intermission.h">
       <Filter>src\common</Filter>
     </ClInclude>
     <ClInclude Include="..\src\cgame\common\cg_vote.h">
@@ -222,7 +222,7 @@
     <ClInclude Include="..\src\cgame\common\ui\hud\PowerupView.h">
       <Filter>src\common\ui\hud</Filter>
     </ClInclude>
-    <ClInclude Include="\.\.\src\cgame\common\ui\hud\IntermissionView.h">
+    <ClInclude Include="..\src\cgame\common\ui\hud\IntermissionView.h">
       <Filter>src\common\ui\hud</Filter>
     </ClInclude>
     <ClInclude Include="..\src\cgame\common\ui\hud\ScoreboardView.h">
@@ -461,7 +461,7 @@
     <ClCompile Include="..\src\cgame\common\cg_view.c">
       <Filter>src\common</Filter>
     </ClCompile>
-    <ClCompile Include="\.\.\src\cgame\common\cg_intermission.c">
+    <ClCompile Include="..\src\cgame\common\cg_intermission.c">
       <Filter>src\common</Filter>
     </ClCompile>
     <ClCompile Include="..\src\cgame\common\cg_vote.c">
@@ -527,7 +527,7 @@
     <ClCompile Include="..\src\cgame\common\ui\hud\PowerupView.c">
       <Filter>src\common\ui\hud</Filter>
     </ClCompile>
-    <ClCompile Include="\.\.\src\cgame\common\ui\hud\IntermissionView.c">
+    <ClCompile Include="..\src\cgame\common\ui\hud\IntermissionView.c">
       <Filter>src\common\ui\hud</Filter>
     </ClCompile>
     <ClCompile Include="..\src\cgame\common\ui\hud\ScoreboardView.c">

--- a/Quetoo.vs15/cgame-ctf.vcxproj.filters
+++ b/Quetoo.vs15/cgame-ctf.vcxproj.filters
@@ -129,6 +129,9 @@
     <ClInclude Include="..\src\cgame\common\cg_ctf.h">
       <Filter>src\common</Filter>
     </ClInclude>
+    <ClInclude Include="\.\.\src\cgame\common\cg_intermission.h">
+      <Filter>src\common</Filter>
+    </ClInclude>
     <ClInclude Include="..\src\cgame\common\cg_vote.h">
       <Filter>src\common</Filter>
     </ClInclude>
@@ -217,6 +220,9 @@
       <Filter>src\common\ui\hud</Filter>
     </ClInclude>
     <ClInclude Include="..\src\cgame\common\ui\hud\PowerupView.h">
+      <Filter>src\common\ui\hud</Filter>
+    </ClInclude>
+    <ClInclude Include="\.\.\src\cgame\common\ui\hud\IntermissionView.h">
       <Filter>src\common\ui\hud</Filter>
     </ClInclude>
     <ClInclude Include="..\src\cgame\common\ui\hud\ScoreboardView.h">
@@ -455,6 +461,9 @@
     <ClCompile Include="..\src\cgame\common\cg_view.c">
       <Filter>src\common</Filter>
     </ClCompile>
+    <ClCompile Include="\.\.\src\cgame\common\cg_intermission.c">
+      <Filter>src\common</Filter>
+    </ClCompile>
     <ClCompile Include="..\src\cgame\common\cg_vote.c">
       <Filter>src\common</Filter>
     </ClCompile>
@@ -516,6 +525,9 @@
       <Filter>src\common\ui\hud</Filter>
     </ClCompile>
     <ClCompile Include="..\src\cgame\common\ui\hud\PowerupView.c">
+      <Filter>src\common\ui\hud</Filter>
+    </ClCompile>
+    <ClCompile Include="\.\.\src\cgame\common\ui\hud\IntermissionView.c">
       <Filter>src\common\ui\hud</Filter>
     </ClCompile>
     <ClCompile Include="..\src\cgame\common\ui\hud\ScoreboardView.c">

--- a/Quetoo.vs15/cgame-lithium.vcxproj.filters
+++ b/Quetoo.vs15/cgame-lithium.vcxproj.filters
@@ -153,6 +153,9 @@
     <ClInclude Include="..\src\cgame\common\cg_view.h">
       <Filter>src\common</Filter>
     </ClInclude>
+    <ClInclude Include="\.\.\src\cgame\common\cg_intermission.h">
+      <Filter>src\common</Filter>
+    </ClInclude>
     <ClInclude Include="..\src\cgame\common\cg_vote.h">
       <Filter>src\common</Filter>
     </ClInclude>
@@ -214,6 +217,9 @@
       <Filter>src\common\ui\hud</Filter>
     </ClInclude>
     <ClInclude Include="..\src\cgame\common\ui\hud\PowerupView.h">
+      <Filter>src\common\ui\hud</Filter>
+    </ClInclude>
+    <ClInclude Include="\.\.\src\cgame\common\ui\hud\IntermissionView.h">
       <Filter>src\common\ui\hud</Filter>
     </ClInclude>
     <ClInclude Include="..\src\cgame\common\ui\hud\ScoreboardView.h">
@@ -449,6 +455,9 @@
     <ClCompile Include="..\src\cgame\common\cg_view.c">
       <Filter>src\common</Filter>
     </ClCompile>
+    <ClCompile Include="\.\.\src\cgame\common\cg_intermission.c">
+      <Filter>src\common</Filter>
+    </ClCompile>
     <ClCompile Include="..\src\cgame\common\cg_vote.c">
       <Filter>src\common</Filter>
     </ClCompile>
@@ -510,6 +519,9 @@
       <Filter>src\common\ui\hud</Filter>
     </ClCompile>
     <ClCompile Include="..\src\cgame\common\ui\hud\PowerupView.c">
+      <Filter>src\common\ui\hud</Filter>
+    </ClCompile>
+    <ClCompile Include="\.\.\src\cgame\common\ui\hud\IntermissionView.c">
       <Filter>src\common\ui\hud</Filter>
     </ClCompile>
     <ClCompile Include="..\src\cgame\common\ui\hud\ScoreboardView.c">

--- a/Quetoo.vs15/cgame-lithium.vcxproj.filters
+++ b/Quetoo.vs15/cgame-lithium.vcxproj.filters
@@ -153,7 +153,7 @@
     <ClInclude Include="..\src\cgame\common\cg_view.h">
       <Filter>src\common</Filter>
     </ClInclude>
-    <ClInclude Include="\.\.\src\cgame\common\cg_intermission.h">
+    <ClInclude Include="..\src\cgame\common\cg_intermission.h">
       <Filter>src\common</Filter>
     </ClInclude>
     <ClInclude Include="..\src\cgame\common\cg_vote.h">
@@ -219,7 +219,7 @@
     <ClInclude Include="..\src\cgame\common\ui\hud\PowerupView.h">
       <Filter>src\common\ui\hud</Filter>
     </ClInclude>
-    <ClInclude Include="\.\.\src\cgame\common\ui\hud\IntermissionView.h">
+    <ClInclude Include="..\src\cgame\common\ui\hud\IntermissionView.h">
       <Filter>src\common\ui\hud</Filter>
     </ClInclude>
     <ClInclude Include="..\src\cgame\common\ui\hud\ScoreboardView.h">
@@ -455,7 +455,7 @@
     <ClCompile Include="..\src\cgame\common\cg_view.c">
       <Filter>src\common</Filter>
     </ClCompile>
-    <ClCompile Include="\.\.\src\cgame\common\cg_intermission.c">
+    <ClCompile Include="..\src\cgame\common\cg_intermission.c">
       <Filter>src\common</Filter>
     </ClCompile>
     <ClCompile Include="..\src\cgame\common\cg_vote.c">
@@ -521,7 +521,7 @@
     <ClCompile Include="..\src\cgame\common\ui\hud\PowerupView.c">
       <Filter>src\common\ui\hud</Filter>
     </ClCompile>
-    <ClCompile Include="\.\.\src\cgame\common\ui\hud\IntermissionView.c">
+    <ClCompile Include="..\src\cgame\common\ui\hud\IntermissionView.c">
       <Filter>src\common\ui\hud</Filter>
     </ClCompile>
     <ClCompile Include="..\src\cgame\common\ui\hud\ScoreboardView.c">

--- a/Quetoo.vs15/cgame-race.vcxproj.filters
+++ b/Quetoo.vs15/cgame-race.vcxproj.filters
@@ -153,6 +153,9 @@
     <ClInclude Include="..\src\cgame\common\cg_view.h">
       <Filter>src\common</Filter>
     </ClInclude>
+    <ClInclude Include="\.\.\src\cgame\common\cg_intermission.h">
+      <Filter>src\common</Filter>
+    </ClInclude>
     <ClInclude Include="..\src\cgame\common\cg_vote.h">
       <Filter>src\common</Filter>
     </ClInclude>
@@ -214,6 +217,9 @@
       <Filter>src\common\ui\hud</Filter>
     </ClInclude>
     <ClInclude Include="..\src\cgame\common\ui\hud\PowerupView.h">
+      <Filter>src\common\ui\hud</Filter>
+    </ClInclude>
+    <ClInclude Include="\.\.\src\cgame\common\ui\hud\IntermissionView.h">
       <Filter>src\common\ui\hud</Filter>
     </ClInclude>
     <ClInclude Include="..\src\cgame\common\ui\hud\ScoreboardView.h">
@@ -455,6 +461,9 @@
     <ClCompile Include="..\src\cgame\common\cg_view.c">
       <Filter>src\common</Filter>
     </ClCompile>
+    <ClCompile Include="\.\.\src\cgame\common\cg_intermission.c">
+      <Filter>src\common</Filter>
+    </ClCompile>
     <ClCompile Include="..\src\cgame\common\cg_vote.c">
       <Filter>src\common</Filter>
     </ClCompile>
@@ -516,6 +525,9 @@
       <Filter>src\common\ui\hud</Filter>
     </ClCompile>
     <ClCompile Include="..\src\cgame\common\ui\hud\PowerupView.c">
+      <Filter>src\common\ui\hud</Filter>
+    </ClCompile>
+    <ClCompile Include="\.\.\src\cgame\common\ui\hud\IntermissionView.c">
       <Filter>src\common\ui\hud</Filter>
     </ClCompile>
     <ClCompile Include="..\src\cgame\common\ui\hud\ScoreboardView.c">

--- a/Quetoo.vs15/cgame-race.vcxproj.filters
+++ b/Quetoo.vs15/cgame-race.vcxproj.filters
@@ -153,7 +153,7 @@
     <ClInclude Include="..\src\cgame\common\cg_view.h">
       <Filter>src\common</Filter>
     </ClInclude>
-    <ClInclude Include="\.\.\src\cgame\common\cg_intermission.h">
+    <ClInclude Include="..\src\cgame\common\cg_intermission.h">
       <Filter>src\common</Filter>
     </ClInclude>
     <ClInclude Include="..\src\cgame\common\cg_vote.h">
@@ -219,7 +219,7 @@
     <ClInclude Include="..\src\cgame\common\ui\hud\PowerupView.h">
       <Filter>src\common\ui\hud</Filter>
     </ClInclude>
-    <ClInclude Include="\.\.\src\cgame\common\ui\hud\IntermissionView.h">
+    <ClInclude Include="..\src\cgame\common\ui\hud\IntermissionView.h">
       <Filter>src\common\ui\hud</Filter>
     </ClInclude>
     <ClInclude Include="..\src\cgame\common\ui\hud\ScoreboardView.h">
@@ -461,7 +461,7 @@
     <ClCompile Include="..\src\cgame\common\cg_view.c">
       <Filter>src\common</Filter>
     </ClCompile>
-    <ClCompile Include="\.\.\src\cgame\common\cg_intermission.c">
+    <ClCompile Include="..\src\cgame\common\cg_intermission.c">
       <Filter>src\common</Filter>
     </ClCompile>
     <ClCompile Include="..\src\cgame\common\cg_vote.c">
@@ -527,7 +527,7 @@
     <ClCompile Include="..\src\cgame\common\ui\hud\PowerupView.c">
       <Filter>src\common\ui\hud</Filter>
     </ClCompile>
-    <ClCompile Include="\.\.\src\cgame\common\ui\hud\IntermissionView.c">
+    <ClCompile Include="..\src\cgame\common\ui\hud\IntermissionView.c">
       <Filter>src\common\ui\hud</Filter>
     </ClCompile>
     <ClCompile Include="..\src\cgame\common\ui\hud\ScoreboardView.c">

--- a/Quetoo.vs15/cgame.vcxproj.filters
+++ b/Quetoo.vs15/cgame.vcxproj.filters
@@ -150,7 +150,7 @@
     <ClInclude Include="..\src\cgame\common\cg_view.h">
       <Filter>src\common</Filter>
     </ClInclude>
-    <ClInclude Include="\.\.\src\cgame\common\cg_intermission.h">
+    <ClInclude Include="..\src\cgame\common\cg_intermission.h">
       <Filter>src\common</Filter>
     </ClInclude>
     <ClInclude Include="..\src\cgame\common\cg_vote.h">
@@ -216,7 +216,7 @@
     <ClInclude Include="..\src\cgame\common\ui\hud\PowerupView.h">
       <Filter>src\common\ui\hud</Filter>
     </ClInclude>
-    <ClInclude Include="\.\.\src\cgame\common\ui\hud\IntermissionView.h">
+    <ClInclude Include="..\src\cgame\common\ui\hud\IntermissionView.h">
       <Filter>src\common\ui\hud</Filter>
     </ClInclude>
     <ClInclude Include="..\src\cgame\common\ui\hud\ScoreboardView.h">
@@ -449,7 +449,7 @@
     <ClCompile Include="..\src\cgame\common\cg_view.c">
       <Filter>src\common</Filter>
     </ClCompile>
-    <ClCompile Include="\.\.\src\cgame\common\cg_intermission.c">
+    <ClCompile Include="..\src\cgame\common\cg_intermission.c">
       <Filter>src\common</Filter>
     </ClCompile>
     <ClCompile Include="..\src\cgame\common\cg_vote.c">
@@ -515,7 +515,7 @@
     <ClCompile Include="..\src\cgame\common\ui\hud\PowerupView.c">
       <Filter>src\common\ui\hud</Filter>
     </ClCompile>
-    <ClCompile Include="\.\.\src\cgame\common\ui\hud\IntermissionView.c">
+    <ClCompile Include="..\src\cgame\common\ui\hud\IntermissionView.c">
       <Filter>src\common\ui\hud</Filter>
     </ClCompile>
     <ClCompile Include="..\src\cgame\common\ui\hud\ScoreboardView.c">

--- a/Quetoo.vs15/cgame.vcxproj.filters
+++ b/Quetoo.vs15/cgame.vcxproj.filters
@@ -150,6 +150,9 @@
     <ClInclude Include="..\src\cgame\common\cg_view.h">
       <Filter>src\common</Filter>
     </ClInclude>
+    <ClInclude Include="\.\.\src\cgame\common\cg_intermission.h">
+      <Filter>src\common</Filter>
+    </ClInclude>
     <ClInclude Include="..\src\cgame\common\cg_vote.h">
       <Filter>src\common</Filter>
     </ClInclude>
@@ -211,6 +214,9 @@
       <Filter>src\common\ui\hud</Filter>
     </ClInclude>
     <ClInclude Include="..\src\cgame\common\ui\hud\PowerupView.h">
+      <Filter>src\common\ui\hud</Filter>
+    </ClInclude>
+    <ClInclude Include="\.\.\src\cgame\common\ui\hud\IntermissionView.h">
       <Filter>src\common\ui\hud</Filter>
     </ClInclude>
     <ClInclude Include="..\src\cgame\common\ui\hud\ScoreboardView.h">
@@ -443,6 +449,9 @@
     <ClCompile Include="..\src\cgame\common\cg_view.c">
       <Filter>src\common</Filter>
     </ClCompile>
+    <ClCompile Include="\.\.\src\cgame\common\cg_intermission.c">
+      <Filter>src\common</Filter>
+    </ClCompile>
     <ClCompile Include="..\src\cgame\common\cg_vote.c">
       <Filter>src\common</Filter>
     </ClCompile>
@@ -504,6 +513,9 @@
       <Filter>src\common\ui\hud</Filter>
     </ClCompile>
     <ClCompile Include="..\src\cgame\common\ui\hud\PowerupView.c">
+      <Filter>src\common\ui\hud</Filter>
+    </ClCompile>
+    <ClCompile Include="\.\.\src\cgame\common\ui\hud\IntermissionView.c">
       <Filter>src\common\ui\hud</Filter>
     </ClCompile>
     <ClCompile Include="..\src\cgame\common\ui\hud\ScoreboardView.c">

--- a/Quetoo.vs15/cgame_common.props
+++ b/Quetoo.vs15/cgame_common.props
@@ -67,6 +67,8 @@
     <ClInclude Include="..\src\cgame\common\cg_ui.h" />
     <ClCompile Include="..\src\cgame\common\cg_view.c" />
     <ClInclude Include="..\src\cgame\common\cg_view.h" />
+    <ClCompile Include="..\src\cgame\common\cg_intermission.c" />
+    <ClInclude Include="..\src\cgame\common\cg_intermission.h" />
     <ClCompile Include="..\src\cgame\common\cg_vote.c" />
     <ClInclude Include="..\src\cgame\common\cg_vote.h" />
     <ClCompile Include="..\src\cgame\common\cg_weapon.c" />
@@ -141,6 +143,8 @@
     <ClInclude Include="..\src\cgame\common\ui\hud\PowerupView.h" />
     <ClCompile Include="..\src\cgame\common\ui\hud\ScoreView.c" />
     <ClInclude Include="..\src\cgame\common\ui\hud\ScoreView.h" />
+    <ClCompile Include="..\src\cgame\common\ui\hud\IntermissionView.c" />
+    <ClInclude Include="..\src\cgame\common\ui\hud\IntermissionView.h" />
     <ClCompile Include="..\src\cgame\common\ui\hud\ScoreboardView.c" />
     <ClInclude Include="..\src\cgame\common\ui\hud\ScoreboardView.h" />
     <ClCompile Include="..\src\cgame\common\ui\hud\SpectatorView.c" />

--- a/Quetoo.vs15/game-ctf.vcxproj.filters
+++ b/Quetoo.vs15/game-ctf.vcxproj.filters
@@ -54,6 +54,9 @@
     <ClInclude Include="..\src\game\common\bg_pmove.h">
       <Filter>src\common</Filter>
     </ClInclude>
+    <ClInclude Include="..\src\game\common\bg_intermission.h">
+      <Filter>src\common</Filter>
+    </ClInclude>
     <ClInclude Include="..\src\game\common\bg_vote.h">
       <Filter>src\common</Filter>
     </ClInclude>
@@ -121,6 +124,9 @@
       <Filter>src\common</Filter>
     </ClInclude>
     <ClInclude Include="..\src\game\common\g_hook.h">
+      <Filter>src\common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\game\common\g_intermission.h">
       <Filter>src\common</Filter>
     </ClInclude>
     <ClInclude Include="..\src\game\common\g_vote.h">
@@ -213,6 +219,9 @@
       <Filter>src\common</Filter>
     </ClCompile>
     <ClCompile Include="..\src\game\common\g_rules.c">
+      <Filter>src\common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\game\common\g_intermission.c">
       <Filter>src\common</Filter>
     </ClCompile>
     <ClCompile Include="..\src\game\common\g_vote.c">

--- a/Quetoo.vs15/game-lithium.vcxproj.filters
+++ b/Quetoo.vs15/game-lithium.vcxproj.filters
@@ -51,6 +51,9 @@
     <ClInclude Include="..\src\game\common\bg_pmove.h">
       <Filter>src\common</Filter>
     </ClInclude>
+    <ClInclude Include="..\src\game\common\bg_intermission.h">
+      <Filter>src\common</Filter>
+    </ClInclude>
     <ClInclude Include="..\src\game\common\bg_vote.h">
       <Filter>src\common</Filter>
     </ClInclude>
@@ -118,6 +121,9 @@
       <Filter>src\common</Filter>
     </ClInclude>
     <ClInclude Include="..\src\game\common\g_hook.h">
+      <Filter>src\common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\game\common\g_intermission.h">
       <Filter>src\common</Filter>
     </ClInclude>
     <ClInclude Include="..\src\game\common\g_vote.h">
@@ -207,6 +213,9 @@
       <Filter>src\common</Filter>
     </ClCompile>
     <ClCompile Include="..\src\game\common\g_rules.c">
+      <Filter>src\common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\game\common\g_intermission.c">
       <Filter>src\common</Filter>
     </ClCompile>
     <ClCompile Include="..\src\game\common\g_vote.c">

--- a/Quetoo.vs15/game-race.vcxproj.filters
+++ b/Quetoo.vs15/game-race.vcxproj.filters
@@ -54,6 +54,9 @@
     <ClInclude Include="..\src\game\common\bg_pmove.h">
       <Filter>src\common</Filter>
     </ClInclude>
+    <ClInclude Include="..\src\game\common\bg_intermission.h">
+      <Filter>src\common</Filter>
+    </ClInclude>
     <ClInclude Include="..\src\game\common\bg_vote.h">
       <Filter>src\common</Filter>
     </ClInclude>
@@ -121,6 +124,9 @@
       <Filter>src\common</Filter>
     </ClInclude>
     <ClInclude Include="..\src\game\common\g_hook.h">
+      <Filter>src\common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\game\common\g_intermission.h">
       <Filter>src\common</Filter>
     </ClInclude>
     <ClInclude Include="..\src\game\common\g_vote.h">
@@ -204,6 +210,9 @@
       <Filter>src\common</Filter>
     </ClCompile>
     <ClCompile Include="..\src\game\common\g_rules.c">
+      <Filter>src\common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\game\common\g_intermission.c">
       <Filter>src\common</Filter>
     </ClCompile>
     <ClCompile Include="..\src\game\common\g_vote.c">

--- a/Quetoo.vs15/game.vcxproj.filters
+++ b/Quetoo.vs15/game.vcxproj.filters
@@ -51,7 +51,13 @@
     <ClInclude Include="..\src\game\common\bg_pmove.h">
       <Filter>src\common</Filter>
     </ClInclude>
+    <ClInclude Include="..\src\game\common\bg_intermission.h">
+      <Filter>src\common</Filter>
+    </ClInclude>
     <ClInclude Include="..\src\game\common\bg_vote.h">
+      <Filter>src\common</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\game\common\g_intermission.h">
       <Filter>src\common</Filter>
     </ClInclude>
     <ClInclude Include="..\src\game\common\g_vote.h">
@@ -195,6 +201,9 @@
       <Filter>src\common</Filter>
     </ClCompile>
     <ClCompile Include="..\src\game\common\g_rules.c">
+      <Filter>src\common</Filter>
+    </ClCompile>
+    <ClCompile Include="..\src\game\common\g_intermission.c">
       <Filter>src\common</Filter>
     </ClCompile>
     <ClCompile Include="..\src\game\common\g_vote.c">

--- a/Quetoo.vs15/game_common.props
+++ b/Quetoo.vs15/game_common.props
@@ -20,7 +20,9 @@
     <ClCompile Include="..\src\game\common\bg_pmove_race.c" />
     <ClCompile Include="..\src\game\common\bg_pmove_quake3.c" />
     <ClInclude Include="..\src\game\common\bg_pmove.h" />
+    <ClInclude Include="..\src\game\common\bg_intermission.h" />
     <ClInclude Include="..\src\game\common\bg_vote.h" />
+    <ClInclude Include="..\src\game\common\g_intermission.h" />
     <ClInclude Include="..\src\game\common\g_vote.h" />
     <ClInclude Include="..\src\game\common\bg_pmove_local.h" />
     <ClCompile Include="..\src\game\common\g_ai_goal.c" />
@@ -58,6 +60,7 @@
     <ClInclude Include="..\src\game\common\g_entity_trigger.h" />
     <ClInclude Include="..\src\game\common\g_module.h" />
     <ClCompile Include="..\src\game\common\g_rules.c" />
+    <ClCompile Include="..\src\game\common\g_intermission.c" />
     <ClCompile Include="..\src\game\common\g_vote.c" />
     <ClCompile Include="..\src\game\common\g_main.c" />
     <ClInclude Include="..\src\game\common\g_main.h" />

--- a/Quetoo.xcodeproj/project.pbxproj
+++ b/Quetoo.xcodeproj/project.pbxproj
@@ -1131,12 +1131,19 @@
 		D1A5B0000000000000000002 /* bg_pmove_local.h in Headers */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000001 /* bg_pmove_local.h */; };
 		D1A5B0000000000000000003 /* bg_pmove_local.h in Headers */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000001 /* bg_pmove_local.h */; };
 		D1A5B0000000000000000102 /* g_vote.c in Sources */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000101 /* g_vote.c */; };
+		D1A5B0000000000000000301 /* g_intermission.c in Sources */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000300 /* g_intermission.c */; };
 		D1A5B0000000000000000103 /* g_vote.c in Sources */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000101 /* g_vote.c */; };
+		D1A5B0000000000000000302 /* g_intermission.c in Sources */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000300 /* g_intermission.c */; };
 		D1A5B0000000000000000104 /* g_vote.c in Sources */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000101 /* g_vote.c */; };
+		D1A5B0000000000000000303 /* g_intermission.c in Sources */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000300 /* g_intermission.c */; };
 		D1A5B0000000000000000106 /* bg_vote.h in Headers */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000105 /* bg_vote.h */; };
+		D1A5B0000000000000000305 /* bg_intermission.h in Headers */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000304 /* bg_intermission.h */; };
 		D1A5B0000000000000000107 /* bg_vote.h in Headers */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000105 /* bg_vote.h */; };
+		D1A5B0000000000000000306 /* bg_intermission.h in Headers */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000304 /* bg_intermission.h */; };
 		D1A5B0000000000000000110 /* g_vote.h in Headers */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000108 /* g_vote.h */; };
+		D1A5B0000000000000000308 /* g_intermission.h in Headers */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000307 /* g_intermission.h */; };
 		D1A5B0000000000000000111 /* g_vote.h in Headers */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000108 /* g_vote.h */; };
+		D1A5B0000000000000000309 /* g_intermission.h in Headers */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000307 /* g_intermission.h */; };
 		D1A5B0000000000000000202 /* cg_vote.c in Sources */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000201 /* cg_vote.c */; };
 		D1A5B0000000000000000203 /* cg_vote.c in Sources */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000201 /* cg_vote.c */; };
 		D1A5B0000000000000000204 /* cg_vote.c in Sources */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000201 /* cg_vote.c */; };
@@ -1174,6 +1181,7 @@
 		D2A5C100000000000000002A /* g_physics.c in Sources */ = {isa = PBXBuildFile; fileRef = CE12D66A1C5C58C300CD0B13 /* g_physics.c */; };
 		D2A5C100000000000000002B /* g_rules.c in Sources */ = {isa = PBXBuildFile; fileRef = CEFEEE00000000000000A101 /* g_rules.c */; };
 		D2A5C100000000000000002C /* g_vote.c in Sources */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000101 /* g_vote.c */; };
+		D1A5B000000000000000030A /* g_intermission.c in Sources */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000300 /* g_intermission.c */; };
 		D2A5C100000000000000002D /* g_sound.c in Sources */ = {isa = PBXBuildFile; fileRef = CEFF1296277D439B001E1500 /* g_sound.c */; };
 		D2A5C100000000000000002E /* g_util.c in Sources */ = {isa = PBXBuildFile; fileRef = CE12D66D1C5C58C300CD0B13 /* g_util.c */; };
 		D2A5C100000000000000002F /* g_weapon.c in Sources */ = {isa = PBXBuildFile; fileRef = CE12D66F1C5C58C300CD0B13 /* g_weapon.c */; };
@@ -1183,6 +1191,7 @@
 		D2A5C1000000000000000033 /* bg_item.h in Headers */ = {isa = PBXBuildFile; fileRef = D2A5C1000000000000000001 /* bg_item.h */; };
 		D2A5C1000000000000000034 /* bg_pmove.h in Headers */ = {isa = PBXBuildFile; fileRef = CE12D6421C5C58C300CD0B13 /* bg_pmove.h */; };
 		D2A5C1000000000000000035 /* bg_vote.h in Headers */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000105 /* bg_vote.h */; };
+		D1A5B000000000000000030B /* bg_intermission.h in Headers */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000304 /* bg_intermission.h */; };
 		D2A5C1000000000000000036 /* bg_pmove_local.h in Headers */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000001 /* bg_pmove_local.h */; };
 		D2A5C1000000000000000037 /* g_ai_goal.h in Headers */ = {isa = PBXBuildFile; fileRef = CE27E9F327BDA2AE003D56AC /* g_ai_goal.h */; };
 		D2A5C1000000000000000038 /* g_ai_grid.h in Headers */ = {isa = PBXBuildFile; fileRef = CE4E053F2FDAE2CE00B92C32 /* g_ai_grid.h */; };
@@ -1207,6 +1216,7 @@
 		D2A5C100000000000000004B /* g_entity_trigger.h in Headers */ = {isa = PBXBuildFile; fileRef = CE12D6601C5C58C300CD0B13 /* g_entity_trigger.h */; };
 		D2A5C100000000000000004C /* g_hook.h in Headers */ = {isa = PBXBuildFile; fileRef = CEC011002026010200000007 /* g_hook.h */; };
 		D2A5C100000000000000004D /* g_vote.h in Headers */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000108 /* g_vote.h */; };
+		D1A5B000000000000000030C /* g_intermission.h in Headers */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000307 /* g_intermission.h */; };
 		D2A5C100000000000000004E /* g_item.h in Headers */ = {isa = PBXBuildFile; fileRef = CE12D6621C5C58C300CD0B13 /* g_item.h */; };
 		D2A5C100000000000000004F /* g_local.h in Headers */ = {isa = PBXBuildFile; fileRef = CE12D6631C5C58C300CD0B13 /* g_local.h */; };
 		D2A5C1000000000000000050 /* g_main.h in Headers */ = {isa = PBXBuildFile; fileRef = CE12D6651C5C58C300CD0B13 /* g_main.h */; };
@@ -2894,8 +2904,11 @@
 		D126FFD46C343DDC86C13E17 /* cm_manifest.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = cm_manifest.c; sourceTree = "<group>"; };
 		D1A5B0000000000000000001 /* bg_pmove_local.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = bg_pmove_local.h; sourceTree = "<group>"; };
 		D1A5B0000000000000000101 /* g_vote.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = g_vote.c; sourceTree = "<group>"; };
+		D1A5B0000000000000000300 /* g_intermission.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = g_intermission.c; sourceTree = "<group>"; };
 		D1A5B0000000000000000105 /* bg_vote.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = bg_vote.h; sourceTree = "<group>"; };
+		D1A5B0000000000000000304 /* bg_intermission.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = bg_intermission.h; sourceTree = "<group>"; };
 		D1A5B0000000000000000108 /* g_vote.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = g_vote.h; sourceTree = "<group>"; };
+		D1A5B0000000000000000307 /* g_intermission.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = g_intermission.h; sourceTree = "<group>"; };
 		D1A5B0000000000000000201 /* cg_vote.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = cg_vote.c; sourceTree = "<group>"; };
 		D1A5B0000000000000000205 /* VoteViewController.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = VoteViewController.c; sourceTree = "<group>"; };
 		D1A5B0000000000000000209 /* VoteViewController.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = VoteViewController.json; sourceTree = "<group>"; };
@@ -4679,6 +4692,7 @@
 				D6A5C10000000000000000A1 /* bg_pmove_race.c */,
 				CEFEEE0000000000000000C3 /* bg_tech.h */,
 				D1A5B0000000000000000105 /* bg_vote.h */,
+				D1A5B0000000000000000304 /* bg_intermission.h */,
 				CE27E9F327BDA2AE003D56AC /* g_ai_goal.h */,
 				CE27E9F127BDA2AE003D56AC /* g_ai_goal.c */,
 				CE4E053F2FDAE2CE00B92C32 /* g_ai_grid.h */,
@@ -4724,6 +4738,7 @@
 				CE12D65F1C5C58C300CD0B13 /* g_entity_trigger.c */,
 				CEC011002026010200000007 /* g_hook.h */,
 				D1A5B0000000000000000108 /* g_vote.h */,
+				D1A5B0000000000000000307 /* g_intermission.h */,
 				CEC011002026010200000005 /* g_hook.c */,
 				CE12D6621C5C58C300CD0B13 /* g_item.h */,
 				CE12D6611C5C58C300CD0B13 /* g_item.c */,
@@ -4734,6 +4749,7 @@
 				CE12D66A1C5C58C300CD0B13 /* g_physics.c */,
 				CEFEEE00000000000000A101 /* g_rules.c */,
 				D1A5B0000000000000000101 /* g_vote.c */,
+				D1A5B0000000000000000300 /* g_intermission.c */,
 				CE12D6631C5C58C300CD0B13 /* g_local.h */,
 				CEFF1295277D439B001E1500 /* g_sound.h */,
 				CEFF1296277D439B001E1500 /* g_sound.c */,
@@ -4876,6 +4892,7 @@
 				CE05B2F0302248070012F003 /* bg_item.h in Headers */,
 				CE05B2AE3022486E0012862B /* bg_pmove.h in Headers */,
 				D1A5B0000000000000000106 /* bg_vote.h in Headers */,
+				D1A5B0000000000000000305 /* bg_intermission.h in Headers */,
 				D1A5B0000000000000000002 /* bg_pmove_local.h in Headers */,
 				CE05B2CD3022486E0012862B /* bg_tech.h in Headers */,
 				CE05B2AF3022486E0012862B /* g_ai_goal.h in Headers */,
@@ -4901,6 +4918,7 @@
 				CE05B2C33022486E0012862B /* g_entity_trigger.h in Headers */,
 				CE05B2C53022486E0012862B /* g_hook.h in Headers */,
 				D1A5B0000000000000000110 /* g_vote.h in Headers */,
+				D1A5B0000000000000000308 /* g_intermission.h in Headers */,
 				CE05B2C73022486E0012862B /* g_item.h in Headers */,
 				CE05B2C83022486E0012862B /* g_local.h in Headers */,
 				CE05B2C93022486E0012862B /* g_main.h in Headers */,
@@ -5189,6 +5207,7 @@
 				CEC0FF00202601030000010A /* bg_item.h in Headers */,
 				CEC0FF002026010300000122 /* bg_pmove.h in Headers */,
 				D1A5B0000000000000000107 /* bg_vote.h in Headers */,
+				D1A5B0000000000000000306 /* bg_intermission.h in Headers */,
 				D1A5B0000000000000000003 /* bg_pmove_local.h in Headers */,
 				CEFEEE0000000000000000D3 /* bg_tech.h in Headers */,
 				CEC0FF00202601030000010B /* g_ai_goal.h in Headers */,
@@ -5215,6 +5234,7 @@
 				CEC0FF00202601030000011B /* g_entity_trigger.h in Headers */,
 				CEC0FF002026010300000127 /* g_hook.h in Headers */,
 				D1A5B0000000000000000111 /* g_vote.h in Headers */,
+				D1A5B0000000000000000309 /* g_intermission.h in Headers */,
 				CEC0FF00202601030000011C /* g_item.h in Headers */,
 				CEC0FF00202601030000011D /* g_local.h in Headers */,
 				CEC0FF00202601030000011E /* g_main.h in Headers */,
@@ -5323,6 +5343,7 @@
 				D2A5C1000000000000000033 /* bg_item.h in Headers */,
 				D2A5C1000000000000000034 /* bg_pmove.h in Headers */,
 				D2A5C1000000000000000035 /* bg_vote.h in Headers */,
+				D1A5B000000000000000030B /* bg_intermission.h in Headers */,
 				D2A5C1000000000000000036 /* bg_pmove_local.h in Headers */,
 				D2A5C1000000000000000037 /* g_ai_goal.h in Headers */,
 				D2A5C1000000000000000038 /* g_ai_grid.h in Headers */,
@@ -5347,6 +5368,7 @@
 				D2A5C100000000000000004B /* g_entity_trigger.h in Headers */,
 				D2A5C100000000000000004C /* g_hook.h in Headers */,
 				D2A5C100000000000000004D /* g_vote.h in Headers */,
+				D1A5B000000000000000030C /* g_intermission.h in Headers */,
 				D2A5C100000000000000004E /* g_item.h in Headers */,
 				D2A5C100000000000000004F /* g_local.h in Headers */,
 				D2A5C1000000000000000050 /* g_main.h in Headers */,
@@ -6448,6 +6470,7 @@
 				CE05B29A3022486E0012862B /* g_physics.c in Sources */,
 				CE05B2883022486E0012862B /* g_rules.c in Sources */,
 				D1A5B0000000000000000102 /* g_vote.c in Sources */,
+				D1A5B0000000000000000301 /* g_intermission.c in Sources */,
 				CE05B29B3022486E0012862B /* g_sound.c in Sources */,
 				CE05B29C3022486E0012862B /* g_tech.c in Sources */,
 				CE05B29D3022486E0012862B /* g_util.c in Sources */,
@@ -6603,6 +6626,7 @@
 				CE12D7E41C5C5D6A00CD0B13 /* g_physics.c in Sources */,
 				CEFEEE00000000000000A102 /* g_rules.c in Sources */,
 				D1A5B0000000000000000103 /* g_vote.c in Sources */,
+				D1A5B0000000000000000302 /* g_intermission.c in Sources */,
 				CEFF1298277D439B001E1500 /* g_sound.c in Sources */,
 				CE12D7E51C5C5D6A00CD0B13 /* g_util.c in Sources */,
 				CE12D7E61C5C5D6A00CD0B13 /* g_weapon.c in Sources */,
@@ -7062,6 +7086,7 @@
 				CEC0FF002026010300000108 /* g_physics.c in Sources */,
 				CEFEEE00000000000000A103 /* g_rules.c in Sources */,
 				D1A5B0000000000000000104 /* g_vote.c in Sources */,
+				D1A5B0000000000000000303 /* g_intermission.c in Sources */,
 				CEC0FF002026010300000109 /* g_sound.c in Sources */,
 				CEFEEE0000000000000000D1 /* g_tech.c in Sources */,
 				CEC0FF002026010300000101 /* g_util.c in Sources */,
@@ -7269,6 +7294,7 @@
 				D2A5C100000000000000002A /* g_physics.c in Sources */,
 				D2A5C100000000000000002B /* g_rules.c in Sources */,
 				D2A5C100000000000000002C /* g_vote.c in Sources */,
+				D1A5B000000000000000030A /* g_intermission.c in Sources */,
 				D2A5C100000000000000002D /* g_sound.c in Sources */,
 				D2A5C100000000000000002E /* g_util.c in Sources */,
 				D2A5C100000000000000002F /* g_weapon.c in Sources */,

--- a/Quetoo.xcodeproj/project.pbxproj
+++ b/Quetoo.xcodeproj/project.pbxproj
@@ -77,7 +77,9 @@
 		CEA4C0DE2F9800000087C003 /* hud.css in CopyFiles */ = {isa = PBXBuildFile; fileRef = CEA4C0DE2F9800000087C001 /* hud.css */; };
 		CEA4C0DE2F9800000087C004 /* hud.json in CopyFiles */ = {isa = PBXBuildFile; fileRef = CEA4C0DE2F9800000087C002 /* hud.json */; };
 		CEA4C0DE2F9800000087C008 /* scoreboard.css in CopyFiles */ = {isa = PBXBuildFile; fileRef = CEA4C0DE2F9800000087C006 /* scoreboard.css */; };
+		D1A5B0000000000000000506 /* intermission.css in CopyFiles */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000502 /* intermission.css */; };
 		CEA4C0DE2F9800000087C009 /* scoreboard.json in CopyFiles */ = {isa = PBXBuildFile; fileRef = CEA4C0DE2F9800000087C007 /* scoreboard.json */; };
+		D1A5B0000000000000000507 /* intermission.json in CopyFiles */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000503 /* intermission.json */; };
 		CEA4C0DE2F9800000087C00B /* scoreboard.json in CopyFiles */ = {isa = PBXBuildFile; fileRef = CEA4C0DE2F9800000087C00A /* scoreboard.json */; };
 		CEA4C0DE2F9800000087C011 /* hud.json in CopyFiles */ = {isa = PBXBuildFile; fileRef = CEA4C0DE2F9800000087C010 /* hud.json */; };
 		CEA4C0DE2F9800000087C014 /* hud.json in CopyFiles */ = {isa = PBXBuildFile; fileRef = CEA4C0DE2F9800000087C013 /* hud.json */; };
@@ -91,6 +93,7 @@
 		AC814FDD1291470DA9883B6C /* ChatView.c in Sources */ = {isa = PBXBuildFile; fileRef = 2EA8B25732BD4FBCA2BCECC4 /* ChatView.c */; };
 		2F75825314B0423B86868ACC /* TargetNameView.c in Sources */ = {isa = PBXBuildFile; fileRef = E6ACB2EEAD95B3757AE36A7A /* TargetNameView.c */; };
 		322BAB812EFDDA99BA25575E /* scoreboard.json in CopyFiles */ = {isa = PBXBuildFile; fileRef = 848E81C81F875F4403EAE1EE /* scoreboard.json */; };
+		D1A5B0000000000000000505 /* intermission.json in CopyFiles */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000501 /* intermission.json */; };
 		332CAA47FF0E8521C12DF852 /* SDL3.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = CE1643492FF5A12100863996 /* SDL3.xcframework */; };
 		368D384E998F7590EBCEB7EE /* hud.json in CopyFiles */ = {isa = PBXBuildFile; fileRef = 3487B5AD7D47E8DFBDDAE5C4 /* hud.json */; };
 		39FADC0544F1D2D0BAF1CF06 /* WeaponBarView.c in Sources */ = {isa = PBXBuildFile; fileRef = 7773870519E25AD88B29F618 /* WeaponBarView.c */; };
@@ -104,6 +107,7 @@
 		4E0DA0FBE7F88EC11A4CF033 /* SDL3.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = CE1643492FF5A12100863996 /* SDL3.xcframework */; };
 		50A618B627838A7F121E3DA9 /* SpectatorView.c in Sources */ = {isa = PBXBuildFile; fileRef = 94D1F06AFA9AE2182216CC46 /* SpectatorView.c */; };
 		50A656139CC3317E925D0231 /* ScoreboardView.c in Sources */ = {isa = PBXBuildFile; fileRef = 45969B731C08AA84C8D318F6 /* ScoreboardView.c */; };
+		D1A5B0000000000000000402 /* IntermissionView.c in Sources */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000401 /* IntermissionView.c */; };
 		522B158EA7384E83CD005789 /* cm_manifest.c in Sources */ = {isa = PBXBuildFile; fileRef = D126FFD46C343DDC86C13E17 /* cm_manifest.c */; };
 		52367ABAA22B6D5586284093 /* TeamBannerView.c in Sources */ = {isa = PBXBuildFile; fileRef = A73DD77B1D5B8231028B01FA /* TeamBannerView.c */; };
 		5353FBA06CC14AA034C4C9CD /* TargetNameView.c in Sources */ = {isa = PBXBuildFile; fileRef = E6ACB2EEAD95B3757AE36A7A /* TargetNameView.c */; };
@@ -123,6 +127,7 @@
 		A2E677309CBD4262ADCE7EA5 /* ConsoleViewController.c in Sources */ = {isa = PBXBuildFile; fileRef = 9352803A21064843A7D64A86 /* ConsoleViewController.c */; };
 		68157F8A4AF07ADDE8951670 /* SpectatorView.c in Sources */ = {isa = PBXBuildFile; fileRef = 94D1F06AFA9AE2182216CC46 /* SpectatorView.c */; };
 		68D440FA613EE2594A4D6DB6 /* ScoreboardView.c in Sources */ = {isa = PBXBuildFile; fileRef = 45969B731C08AA84C8D318F6 /* ScoreboardView.c */; };
+		D1A5B0000000000000000403 /* IntermissionView.c in Sources */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000401 /* IntermissionView.c */; };
 		68FBD5DEAC1FB3CC3C2322D5 /* CenterPrintView.c in Sources */ = {isa = PBXBuildFile; fileRef = 07C9A88ED1D718092FD62601 /* CenterPrintView.c */; };
 		6B31320926D77CB87B783BDD /* SDL3.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = CE1643492FF5A12100863996 /* SDL3.xcframework */; };
 		6B6C876AA822AB4DFB8D3158 /* OverlayText.c in Sources */ = {isa = PBXBuildFile; fileRef = 8238DE2CC5A406DE6DF84E71 /* OverlayText.c */; };
@@ -174,6 +179,7 @@
 		B8BC2CE87251BA0975026203 /* SDL3_image.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = CEF601C42FE711B7005C680C /* SDL3_image.xcframework */; };
 		B92B8EA5B4D9C775CF3C2541 /* SDL3.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = CE1643492FF5A12100863996 /* SDL3.xcframework */; };
 		BB08F021CF5059A8915C8DDF /* ScoreboardView.c in Sources */ = {isa = PBXBuildFile; fileRef = 45969B731C08AA84C8D318F6 /* ScoreboardView.c */; };
+		D1A5B0000000000000000404 /* IntermissionView.c in Sources */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000401 /* IntermissionView.c */; };
 		C1A592C4D259F42E82027392 /* BlendView.c in Sources */ = {isa = PBXBuildFile; fileRef = 4BF47DA7893C8563C1D59CDA /* BlendView.c */; };
 		C1B4D8275ABD425EB6C332C6 /* DiagnosticsView.c in Sources */ = {isa = PBXBuildFile; fileRef = 20A922B6551C4CA8A3DCF8D8 /* DiagnosticsView.c */; };
 		C24304F353C77693015A7736 /* ScoreView.c in Sources */ = {isa = PBXBuildFile; fileRef = 5B027972461629119D87F7A6 /* ScoreView.c */; };
@@ -1145,8 +1151,11 @@
 		D1A5B0000000000000000111 /* g_vote.h in Headers */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000108 /* g_vote.h */; };
 		D1A5B0000000000000000309 /* g_intermission.h in Headers */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000307 /* g_intermission.h */; };
 		D1A5B0000000000000000202 /* cg_vote.c in Sources */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000201 /* cg_vote.c */; };
+		D1A5B0000000000000000406 /* cg_intermission.c in Sources */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000405 /* cg_intermission.c */; };
 		D1A5B0000000000000000203 /* cg_vote.c in Sources */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000201 /* cg_vote.c */; };
+		D1A5B0000000000000000407 /* cg_intermission.c in Sources */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000405 /* cg_intermission.c */; };
 		D1A5B0000000000000000204 /* cg_vote.c in Sources */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000201 /* cg_vote.c */; };
+		D1A5B0000000000000000408 /* cg_intermission.c in Sources */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000405 /* cg_intermission.c */; };
 		D1A5B0000000000000000206 /* VoteViewController.c in Sources */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000205 /* VoteViewController.c */; };
 		D1A5B0000000000000000207 /* VoteViewController.c in Sources */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000205 /* VoteViewController.c */; };
 		D1A5B0000000000000000208 /* VoteViewController.c in Sources */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000205 /* VoteViewController.c */; };
@@ -1283,6 +1292,7 @@
 		D2A5C1000000000000000099 /* cg_predict.c in Sources */ = {isa = PBXBuildFile; fileRef = CE12D5771C5C58C300CD0B13 /* cg_predict.c */; };
 		D2A5C100000000000000009A /* cg_score.c in Sources */ = {isa = PBXBuildFile; fileRef = CE12D5791C5C58C300CD0B13 /* cg_score.c */; };
 		D2A5C100000000000000009B /* cg_vote.c in Sources */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000201 /* cg_vote.c */; };
+		D1A5B000000000000000040A /* cg_intermission.c in Sources */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000405 /* cg_intermission.c */; };
 		D2A5C100000000000000009C /* cg_sound.c in Sources */ = {isa = PBXBuildFile; fileRef = CEBDD1B525A0C2710055860E /* cg_sound.c */; };
 		D2A5C100000000000000009D /* cg_sprite.c in Sources */ = {isa = PBXBuildFile; fileRef = CEAC32B7242124BB007E1253 /* cg_sprite.c */; };
 		D2A5C100000000000000009E /* cg_module.c in Sources */ = {isa = PBXBuildFile; fileRef = D2A5C1000000000000000056 /* cg_module.c */; };
@@ -1394,6 +1404,7 @@
 		D9A5C10000000000000000D3 /* libcommon.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CE80FDE31C5E3E1100A21A51 /* libcommon.a */; };
 		D9A5C10000000000000000D4 /* libcollision.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CE80FE381C5E421900A21A51 /* libcollision.a */; };
 		DD006E4E558F9346D79447E5 /* scoreboard.css in CopyFiles */ = {isa = PBXBuildFile; fileRef = E0F247635165E5338AAD8494 /* scoreboard.css */; };
+		D1A5B0000000000000000504 /* intermission.css in CopyFiles */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000500 /* intermission.css */; };
 		DD02E1ABB673209C4A8D0EFC /* WeaponBarView.c in Sources */ = {isa = PBXBuildFile; fileRef = 7773870519E25AD88B29F618 /* WeaponBarView.c */; };
 		DD69DC98B2588BCF788647E3 /* hud.css in CopyFiles */ = {isa = PBXBuildFile; fileRef = 2D140F08524DA0679A7DB117 /* hud.css */; };
 		E10D01F620BB74E4166A8E7F /* WeaponBarView.c in Sources */ = {isa = PBXBuildFile; fileRef = 7773870519E25AD88B29F618 /* WeaponBarView.c */; };
@@ -1401,6 +1412,7 @@
 		E16A533FF7C34A2BA65E1BFF /* PickupView.c in Sources */ = {isa = PBXBuildFile; fileRef = E106ACFB28FF47443FB3C9FE /* PickupView.c */; };
 		E613CE6B3A9634DB694DA689 /* TeamBannerView.c in Sources */ = {isa = PBXBuildFile; fileRef = A73DD77B1D5B8231028B01FA /* TeamBannerView.c */; };
 		E70AD75417615E311748DB70 /* ScoreboardView.c in Sources */ = {isa = PBXBuildFile; fileRef = 45969B731C08AA84C8D318F6 /* ScoreboardView.c */; };
+		D1A5B000000000000000040B /* IntermissionView.c in Sources */ = {isa = PBXBuildFile; fileRef = D1A5B0000000000000000401 /* IntermissionView.c */; };
 		E7A9F8759B856BBB62D69C03 /* PowerupView.c in Sources */ = {isa = PBXBuildFile; fileRef = 755F8C8CBA7F7C48E79A578C /* PowerupView.c */; };
 		EAC91DBE5BFAA686873683E8 /* TargetNameView.c in Sources */ = {isa = PBXBuildFile; fileRef = E6ACB2EEAD95B3757AE36A7A /* TargetNameView.c */; };
 		EC45E0FA2A80403C8FEA3834 /* cg_inventory.c in Sources */ = {isa = PBXBuildFile; fileRef = FCD76A809F00440F99BC0068 /* cg_inventory.c */; };
@@ -2036,7 +2048,9 @@
 				CEA4C0DE2F9800000087C003 /* hud.css in CopyFiles */,
 				CEA4C0DE2F9800000087C004 /* hud.json in CopyFiles */,
 				CEA4C0DE2F9800000087C008 /* scoreboard.css in CopyFiles */,
+				D1A5B0000000000000000506 /* intermission.css in CopyFiles */,
 				CEA4C0DE2F9800000087C009 /* scoreboard.json in CopyFiles */,
+				D1A5B0000000000000000507 /* intermission.json in CopyFiles */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2048,7 +2062,9 @@
 			files = (
 				DD69DC98B2588BCF788647E3 /* hud.css in CopyFiles */,
 				DD006E4E558F9346D79447E5 /* scoreboard.css in CopyFiles */,
+				D1A5B0000000000000000504 /* intermission.css in CopyFiles */,
 				322BAB812EFDDA99BA25575E /* scoreboard.json in CopyFiles */,
+				D1A5B0000000000000000505 /* intermission.json in CopyFiles */,
 				20BE76382F981DD4B7F43A11 /* hud.json in CopyFiles */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -2072,7 +2088,9 @@
 		CEA4C0DE2F9800000087C001 /* hud.css */ = {isa = PBXFileReference; lastKnownFileType = text.css; path = chrome/hud.css; sourceTree = "<group>"; };
 		CEA4C0DE2F9800000087C002 /* hud.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = chrome/hud.json; sourceTree = "<group>"; };
 		CEA4C0DE2F9800000087C006 /* scoreboard.css */ = {isa = PBXFileReference; lastKnownFileType = text.css; path = chrome/scoreboard.css; sourceTree = "<group>"; };
+		D1A5B0000000000000000502 /* intermission.css */ = {isa = PBXFileReference; lastKnownFileType = text.css; path = chrome/intermission.css; sourceTree = "<group>"; };
 		CEA4C0DE2F9800000087C007 /* scoreboard.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = chrome/scoreboard.json; sourceTree = "<group>"; };
+		D1A5B0000000000000000503 /* intermission.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = chrome/intermission.json; sourceTree = "<group>"; };
 		CEA4C0DE2F9800000087C00A /* scoreboard.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = chrome/scoreboard.json; sourceTree = "<group>"; };
 		CEA4C0DE2F9800000087C010 /* hud.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = chrome/hud.json; sourceTree = "<group>"; };
 		CEA4C0DE2F9800000087C013 /* hud.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = chrome/hud.json; sourceTree = "<group>"; };
@@ -2080,7 +2098,9 @@
 		30FC7C9F9B24C6966D749398 /* NavEditView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NavEditView.h; sourceTree = "<group>"; };
 		3487B5AD7D47E8DFBDDAE5C4 /* hud.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = default/hud.json; sourceTree = "<group>"; };
 		40A40999BE66FAEBBBCCD450 /* ScoreboardView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ScoreboardView.h; sourceTree = "<group>"; };
+		D1A5B0000000000000000400 /* IntermissionView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = IntermissionView.h; sourceTree = "<group>"; };
 		45969B731C08AA84C8D318F6 /* ScoreboardView.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = ScoreboardView.c; sourceTree = "<group>"; };
+		D1A5B0000000000000000401 /* IntermissionView.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = IntermissionView.c; sourceTree = "<group>"; };
 		491F54CD554D0F550B000B4E /* NavEditView.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = NavEditView.c; sourceTree = "<group>"; };
 		4BF47DA7893C8563C1D59CDA /* BlendView.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = BlendView.c; sourceTree = "<group>"; };
 		4CA3522A5AE19B0F18CF79C6 /* TargetNameView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TargetNameView.h; sourceTree = "<group>"; };
@@ -2104,6 +2124,7 @@
 		7966EA6596003F9303BC00FA /* bg_item.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = bg_item.c; sourceTree = "<group>"; };
 		8238DE2CC5A406DE6DF84E71 /* OverlayText.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = OverlayText.c; sourceTree = "<group>"; };
 		848E81C81F875F4403EAE1EE /* scoreboard.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = default/scoreboard.json; sourceTree = "<group>"; };
+		D1A5B0000000000000000501 /* intermission.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = default/intermission.json; sourceTree = "<group>"; };
 		8542813678DB3B7BECEEF939 /* box.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = box.c; sourceTree = "<group>"; };
 		92AA3129971ABAAB21EE5BAD /* scoreboard.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = default/scoreboard.json; sourceTree = "<group>"; };
 		94D1F06AFA9AE2182216CC46 /* SpectatorView.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = SpectatorView.c; sourceTree = "<group>"; };
@@ -2910,10 +2931,12 @@
 		D1A5B0000000000000000108 /* g_vote.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = g_vote.h; sourceTree = "<group>"; };
 		D1A5B0000000000000000307 /* g_intermission.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = g_intermission.h; sourceTree = "<group>"; };
 		D1A5B0000000000000000201 /* cg_vote.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = cg_vote.c; sourceTree = "<group>"; };
+		D1A5B0000000000000000405 /* cg_intermission.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = cg_intermission.c; sourceTree = "<group>"; };
 		D1A5B0000000000000000205 /* VoteViewController.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = VoteViewController.c; sourceTree = "<group>"; };
 		D1A5B0000000000000000209 /* VoteViewController.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = VoteViewController.json; sourceTree = "<group>"; };
 		D1A5B0000000000000000211 /* VoteViewController.css */ = {isa = PBXFileReference; lastKnownFileType = text.css; path = VoteViewController.css; sourceTree = "<group>"; };
 		D1A5B0000000000000000213 /* cg_vote.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = cg_vote.h; sourceTree = "<group>"; };
+		D1A5B0000000000000000409 /* cg_intermission.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = cg_intermission.h; sourceTree = "<group>"; };
 		D1A5B0000000000000000214 /* VoteViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = VoteViewController.h; sourceTree = "<group>"; };
 		D2A5C1000000000000000001 /* bg_item.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = bg_item.h; sourceTree = "<group>"; };
 		D2A5C1000000000000000002 /* bg_item.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = bg_item.c; sourceTree = "<group>"; };
@@ -2944,6 +2967,7 @@
 		DADE6340BDB64D222B75CD99 /* Rajdhani-OFL.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = "Rajdhani-OFL.txt"; sourceTree = "<group>"; };
 		DF0B9374573E39DECA0D8E4C /* manifest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = manifest.h; sourceTree = "<group>"; };
 		E0F247635165E5338AAD8494 /* scoreboard.css */ = {isa = PBXFileReference; lastKnownFileType = text.css; path = default/scoreboard.css; sourceTree = "<group>"; };
+		D1A5B0000000000000000500 /* intermission.css */ = {isa = PBXFileReference; lastKnownFileType = text.css; path = default/intermission.css; sourceTree = "<group>"; };
 		E106ACFB28FF47443FB3C9FE /* PickupView.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = PickupView.c; sourceTree = "<group>"; };
 		E6ACB2EEAD95B3757AE36A7A /* TargetNameView.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = TargetNameView.c; sourceTree = "<group>"; };
 		EA8FE4E62B47061B1ADBD908 /* FpsView.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = FpsView.c; sourceTree = "<group>"; };
@@ -3418,7 +3442,9 @@
 				CEA4C0DE2F9800000087C001 /* hud.css */,
 				CEA4C0DE2F9800000087C002 /* hud.json */,
 				CEA4C0DE2F9800000087C006 /* scoreboard.css */,
+				D1A5B0000000000000000502 /* intermission.css */,
 				CEA4C0DE2F9800000087C007 /* scoreboard.json */,
+				D1A5B0000000000000000503 /* intermission.json */,
 				FC6374C1D47393EA62C8EC20 /* CounterView.h */,
 				A59EB892C12DF10ACA8253DD /* CounterView.c */,
 				C8249BF99F0E4A2D77D37865 /* CrosshairView.h */,
@@ -3446,9 +3472,13 @@
 				C853849AF0A2CC2F7C531245 /* PowerupView.h */,
 				755F8C8CBA7F7C48E79A578C /* PowerupView.c */,
 				E0F247635165E5338AAD8494 /* scoreboard.css */,
+				D1A5B0000000000000000500 /* intermission.css */,
 				848E81C81F875F4403EAE1EE /* scoreboard.json */,
+				D1A5B0000000000000000501 /* intermission.json */,
 				40A40999BE66FAEBBBCCD450 /* ScoreboardView.h */,
+				D1A5B0000000000000000400 /* IntermissionView.h */,
 				45969B731C08AA84C8D318F6 /* ScoreboardView.c */,
+				D1A5B0000000000000000401 /* IntermissionView.c */,
 				671265A640259697D1AA363E /* ScoreView.h */,
 				5B027972461629119D87F7A6 /* ScoreView.c */,
 				9C56DC135154CED4C2498031 /* SpectatorView.h */,
@@ -4638,6 +4668,7 @@
 				CE12D56D1C5C58C300CD0B13 /* cg_hud.h */,
 				CE12D5791C5C58C300CD0B13 /* cg_score.c */,
 				D1A5B0000000000000000201 /* cg_vote.c */,
+				D1A5B0000000000000000405 /* cg_intermission.c */,
 				CE12D57A1C5C58C300CD0B13 /* cg_score.h */,
 				CEC0FD002026010500000009 /* cg_hud_draw.c */,
 				CEB8D6241E00B72100043814 /* cg_input.h */,
@@ -4653,6 +4684,7 @@
 				CE12D5721C5C58C300CD0D01 /* cg_ctf.c */,
 				CE12D5721C5C58C300CD0D02 /* cg_ctf.h */,
 				D1A5B0000000000000000213 /* cg_vote.h */,
+				D1A5B0000000000000000409 /* cg_intermission.h */,
 				CE12D5721C5C58C300CD0D03 /* cg_tech.c */,
 				CE12D5721C5C58C300CD0D04 /* cg_tech.h */,
 				CE12D5721C5C58C300CD0C21 /* cg_module.h */,
@@ -6503,6 +6535,7 @@
 				E7A9F8759B856BBB62D69C03 /* PowerupView.c in Sources */,
 				C24304F353C77693015A7736 /* ScoreView.c in Sources */,
 				BB08F021CF5059A8915C8DDF /* ScoreboardView.c in Sources */,
+				D1A5B0000000000000000404 /* IntermissionView.c in Sources */,
 				D8F2715333902B56A81AC28C /* StatView.c in Sources */,
 				52367ABAA22B6D5586284093 /* TeamBannerView.c in Sources */,
 				D3D2558FB099A325883FDB27 /* NavEditView.c in Sources */,
@@ -6571,6 +6604,7 @@
 				CE05B3F030224900C0DE0016 /* cg_predict.c in Sources */,
 				CE05B3F030224900C0DE0017 /* cg_score.c in Sources */,
 				D1A5B0000000000000000202 /* cg_vote.c in Sources */,
+				D1A5B0000000000000000406 /* cg_intermission.c in Sources */,
 				CE05B3F030224900C0DE0018 /* cg_sound.c in Sources */,
 				CE05B3F030224900C0DE0019 /* cg_sprite.c in Sources */,
 				CE05B3FC30224E3E0012870B /* cg_module.c in Sources */,
@@ -6658,6 +6692,7 @@
 				F956F2A93BABE228BC99C9E4 /* PowerupView.c in Sources */,
 				0BF82540ADD285E5DF358C72 /* ScoreView.c in Sources */,
 				E70AD75417615E311748DB70 /* ScoreboardView.c in Sources */,
+				D1A5B000000000000000040B /* IntermissionView.c in Sources */,
 				1D9F8ACA8B6EBADDC9A571F5 /* StatView.c in Sources */,
 				537E3B2A605E2005BA5F4928 /* TeamBannerView.c in Sources */,
 				65A8C761AE5D68358CDDE601 /* NavEditView.c in Sources */,
@@ -6725,6 +6760,7 @@
 				CE12D7FB1C5C5E0200CD0B13 /* cg_predict.c in Sources */,
 				CE12D7FC1C5C5E0200CD0B13 /* cg_score.c in Sources */,
 				D1A5B0000000000000000203 /* cg_vote.c in Sources */,
+				D1A5B0000000000000000407 /* cg_intermission.c in Sources */,
 				CEBDD1B725A0C2710055860E /* cg_sound.c in Sources */,
 				CEAC32B9242124BB007E1253 /* cg_sprite.c in Sources */,
 				CE12D55D1C5C58C300CD0C12 /* cg_module.c in Sources */,
@@ -7119,6 +7155,7 @@
 				665046BB6961C443C731A077 /* PowerupView.c in Sources */,
 				9EBBE79D07E30BB784FC188F /* ScoreView.c in Sources */,
 				68D440FA613EE2594A4D6DB6 /* ScoreboardView.c in Sources */,
+				D1A5B0000000000000000403 /* IntermissionView.c in Sources */,
 				18831DC74740CDF73E54CF63 /* StatView.c in Sources */,
 				E613CE6B3A9634DB694DA689 /* TeamBannerView.c in Sources */,
 				0789D5943ABEDA1B53B205E2 /* NavEditView.c in Sources */,
@@ -7188,6 +7225,7 @@
 				CEC0FF0020260103000001F1 /* cg_predict.c in Sources */,
 				CEC0FD002026010500000006 /* cg_score.c in Sources */,
 				D1A5B0000000000000000204 /* cg_vote.c in Sources */,
+				D1A5B0000000000000000408 /* cg_intermission.c in Sources */,
 				CEC0FF0020260103000001F3 /* cg_sound.c in Sources */,
 				CEC0FF0020260103000001F4 /* cg_sprite.c in Sources */,
 				CEC0FF0020260103000000A2 /* cg_module.c in Sources */,
@@ -7326,6 +7364,7 @@
 				D36054C7E2858790984E15E0 /* PowerupView.c in Sources */,
 				9F948D38BAB2AE44F4A87F61 /* ScoreView.c in Sources */,
 				50A656139CC3317E925D0231 /* ScoreboardView.c in Sources */,
+				D1A5B0000000000000000402 /* IntermissionView.c in Sources */,
 				3B497D93EA892C673165469D /* StatView.c in Sources */,
 				C55D95D65959615823A138F8 /* TeamBannerView.c in Sources */,
 				F0D2694D4DD29796B8BB5639 /* NavEditView.c in Sources */,
@@ -7393,6 +7432,7 @@
 				D2A5C1000000000000000099 /* cg_predict.c in Sources */,
 				D2A5C100000000000000009A /* cg_score.c in Sources */,
 				D2A5C100000000000000009B /* cg_vote.c in Sources */,
+				D1A5B000000000000000040A /* cg_intermission.c in Sources */,
 				D2A5C100000000000000009C /* cg_sound.c in Sources */,
 				D2A5C100000000000000009D /* cg_sprite.c in Sources */,
 				D2A5C100000000000000009E /* cg_module.c in Sources */,

--- a/src/cgame/common/cg_input.c
+++ b/src/cgame/common/cg_input.c
@@ -40,6 +40,10 @@ static cg_kick_t cg_kick;
  */
 void Cg_HandleEvent(const SDL_Event *event) {
 
+  if (Cg_Intermission_HandleEvent(event)) {
+    return;
+  }
+
   switch (event->type) {
     case SDL_EVENT_WINDOW_EXPOSED:
     case SDL_EVENT_WINDOW_RESIZED:

--- a/src/cgame/common/cg_intermission.c
+++ b/src/cgame/common/cg_intermission.c
@@ -1,0 +1,168 @@
+/*
+ * Copyright(c) 1997-2001 id Software, Inc.
+ * Copyright(c) 2002 The Quakeforge Project.
+ * Copyright(c) 2006 Quetoo.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+#include "cg_local.h"
+#include "bg_intermission.h"
+
+static struct {
+  ParseConfigString ParseConfigString;
+  StateDidClear StateDidClear;
+} previous;
+
+/**
+ * @brief Bumped whenever the candidates change, never reset, so that a view comparing
+ * against it sees a change even across a level.
+ */
+static uint32_t cg_next_map_generation;
+
+/**
+ * @brief Reads `CS_NEXT_MAP` into `cg_state.next_map`.
+ */
+static bool Cg_ParseConfigString_Intermission(int32_t index) {
+
+  if (index != CS_NEXT_MAP) {
+    return previous.ParseConfigString(index);
+  }
+
+  cg_next_map_state_t *next_map = &cg_state.next_map;
+
+  char was[MAX_NEXT_MAPS][MAX_QPATH];
+  memcpy(was, next_map->maps, sizeof(was));
+  const int32_t num_was = next_map->num_maps;
+
+  const char *s = cgi.ConfigString(index);
+
+  memset(next_map, 0, sizeof(*next_map));
+
+  if (!*s) {
+    next_map->generation = num_was ? ++cg_next_map_generation : cg_next_map_generation;
+    return true;
+  }
+
+  char buf[MAX_STRING_CHARS];
+  q_strlcpy(buf, s, sizeof(buf));
+
+  // split positionally, since the count of candidates is what the string carries
+  char *fields[NEXT_MAP_CS_FIELDS_FOR(MAX_NEXT_MAPS)] = { NULL };
+  size_t count = 0;
+
+  for (char *c = buf; count < lengthof(fields); ) {
+    fields[count++] = c;
+
+    char *sep = strchr(c, '\\');
+    if (!sep) {
+      break;
+    }
+    *sep = '\0';
+    c = sep + 1;
+  }
+
+  if (count < NEXT_MAP_CS_FIELDS_FOR(1) || (count - NEXT_MAP_CS_MAPS) % 2) {
+    Cg_Warn("Invalid next map: %s\n", s);
+    return true;
+  }
+
+  next_map->active = true;
+  next_map->voting = *fields[NEXT_MAP_CS_VOTING] == '1';
+  next_map->num_maps = (int32_t) (count - NEXT_MAP_CS_MAPS) / 2;
+
+  for (int32_t i = 0; i < next_map->num_maps; i++) {
+    q_strlcpy(next_map->maps[i], fields[NEXT_MAP_CS_MAPS + i * 2], MAX_QPATH);
+    next_map->votes[i] = (int32_t) strtol(fields[NEXT_MAP_CS_MAPS + i * 2 + 1], NULL, 10);
+  }
+
+  // only the names cost anything to show, so the tally moving is not a redraw
+  if (next_map->num_maps != num_was || memcmp(was, next_map->maps, sizeof(was))) {
+    cg_next_map_generation++;
+  }
+
+  next_map->generation = cg_next_map_generation;
+
+  return true;
+}
+
+/**
+ * @see cg_intermission.h
+ */
+void Cg_Intermission_Vote(int32_t map) {
+  cgi.Cbuf(va("vote_map %d\n", map + 1));
+}
+
+/**
+ * @see cg_intermission.h
+ */
+bool Cg_Intermission_HandleEvent(const SDL_Event *event) {
+
+  if (event->type != SDL_EVENT_KEY_DOWN) {
+    return false;
+  }
+
+  if (!cg_state.next_map.active || !cg_state.next_map.voting) {
+    return false;
+  }
+
+  // the client hands us every event, so the console and the chat would otherwise
+  // cast a ballot for anyone typing a digit
+  if (cgi.GetKeyDest() != KEY_GAME) {
+    return false;
+  }
+
+  const int32_t map = (int32_t) (event->key.key - SDLK_1);
+
+  if (map < 0 || map >= cg_state.next_map.num_maps) {
+    return false;
+  }
+
+  Cg_Intermission_Vote(map);
+
+  return true;
+}
+
+/**
+ * @brief An intermission does not outlive its level.
+ */
+static void Cg_StateDidClear_Intermission(void) {
+
+  memset(&cg_state.next_map, 0, sizeof(cg_state.next_map));
+
+  previous.StateDidClear();
+}
+
+/**
+ * @brief Installs the intermission over the hooks it needs, once per module image.
+ */
+void Cg_Intermission_Init(void) {
+  static bool installed;
+
+  cgi.AddCmd("vote_map", NULL, CMD_CGAME, "Vote for a map during the intermission: vote_map <number>");
+
+  if (installed) {
+    return;
+  }
+
+  previous.ParseConfigString = Cg_ParseConfigString;
+  Cg_ParseConfigString = Cg_ParseConfigString_Intermission;
+
+  previous.StateDidClear = Cg_StateDidClear;
+  Cg_StateDidClear = Cg_StateDidClear_Intermission;
+
+  installed = true;
+}

--- a/src/cgame/common/cg_intermission.h
+++ b/src/cgame/common/cg_intermission.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright(c) 1997-2001 id Software, Inc.
+ * Copyright(c) 2002 The Quakeforge Project.
+ * Copyright(c) 2006 Quetoo.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+#pragma once
+
+#include "cg_types.h"
+
+#if defined(__CG_LOCAL_H__)
+void Cg_Intermission_Init(void);
+
+void Cg_Intermission_Vote(int32_t map);
+bool Cg_Intermission_HandleEvent(const SDL_Event *event);
+#endif

--- a/src/cgame/common/cg_local.h
+++ b/src/cgame/common/cg_local.h
@@ -63,5 +63,6 @@
 #include "cg_types.h"
 #include "cg_ui.h"
 #include "cg_view.h"
+#include "cg_intermission.h"
 #include "cg_vote.h"
 #include "cg_weapon.h"

--- a/src/cgame/common/cg_main.c
+++ b/src/cgame/common/cg_main.c
@@ -207,6 +207,7 @@ static void Cg_Init(void) {
 #endif
 
   Cg_Vote_Init();
+  Cg_Intermission_Init();
 
   Cg_Module_Init();
 

--- a/src/cgame/common/cg_types.h
+++ b/src/cgame/common/cg_types.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include "cgame/cgame.h"
+#include "bg_intermission.h"
 #include "g_types.h"
 
 #if defined(__CG_LOCAL_H__)
@@ -86,6 +87,36 @@ typedef struct {
    */
   uint32_t deadline;
 } cg_vote_state_t;
+
+/**
+ * @brief The intermission's map candidates, as `CS_NEXT_MAP` describes them.
+ */
+typedef struct {
+
+  /**
+   * @brief Whether an intermission is under way. The maps are published only for one,
+   * so their absence is what says the level is still being played.
+   */
+  bool active;
+
+  /**
+   * @brief Whether ballots are being taken, or the next map is simply being announced.
+   */
+  bool voting;
+
+  /**
+   * @brief The candidates, and the tally each has drawn.
+   */
+  char maps[MAX_NEXT_MAPS][MAX_QPATH];
+  int32_t votes[MAX_NEXT_MAPS];
+  int32_t num_maps;
+
+  /**
+   * @brief Bumped whenever the candidates change, so that a view redraws the thumbnails
+   * only when it must; resolving one enumerates the filesystem.
+   */
+  uint32_t generation;
+} cg_next_map_state_t;
 
 /**
  * @brief The client game representation of clients (players).
@@ -248,6 +279,11 @@ typedef struct {
    * @brief The vote in progress, from `CS_VOTE`.
    */
   cg_vote_state_t vote;
+
+  /**
+   * @brief The intermission's map candidates, from `CS_NEXT_MAP`.
+   */
+  cg_next_map_state_t next_map;
 } cg_state_t;
 
 extern cg_state_t cg_state;

--- a/src/cgame/common/ui/hud/HudViewController.c
+++ b/src/cgame/common/ui/hud/HudViewController.c
@@ -57,6 +57,7 @@ static void dealloc(Object *self) {
 
   release(this->hud);
   release(this->scoreboard);
+  release(this->intermission);
   release(this->navEdit);
   release(this->notify);
   release(this->chat);
@@ -184,7 +185,10 @@ static void checkHud(const char *hud) {
     return;
   }
 
-  const char *files[] = { "hud.json", "hud.css", "scoreboard.json", "scoreboard.css" };
+  const char *files[] = {
+    "hud.json", "hud.css", "scoreboard.json", "scoreboard.css",
+    "intermission.json", "intermission.css"
+  };
 
   for (size_t i = 0; i < lengthof(files); i++) {
     if (cgi.StatFile(va("ui/hud/%s/%s", hud, files[i]), NULL)) {
@@ -245,6 +249,30 @@ static ScoreboardView *loadScoreboard(const char *hud) {
 }
 
 /**
+ * @brief Loads the hud's intermission, which a module MAY name an IntermissionView subclass in.
+ */
+static IntermissionView *loadIntermission(const char *hud) {
+
+  const char *json = hudResource(hud, "intermission.json");
+
+  View *intermission = $$(View, viewWithResourceName, json, NULL);
+  if (intermission == NULL || !$((Object *) intermission, isKindOfClass, _IntermissionView())) {
+    Cg_Warn("%s did not yield an IntermissionView\n", json);
+    release(intermission);
+    intermission = $((View *) alloc(IntermissionView), init);
+  }
+
+  const char *css = hudResource(hud, "intermission.css");
+
+  intermission->stylesheet = $$(Stylesheet, stylesheetWithResourceName, css);
+  if (intermission->stylesheet == NULL) {
+    Cg_Warn("Failed to load %s\n", css);
+  }
+
+  return (IntermissionView *) intermission;
+}
+
+/**
  * @fn void HudViewController::reload(HudViewController *self)
  * @memberof HudViewController
  */
@@ -264,8 +292,16 @@ static void reload(HudViewController *self) {
     self->scoreboard = release(self->scoreboard);
   }
 
+  if (self->intermission) {
+    $((View *) self->intermission, removeFromSuperview);
+    self->intermission = release(self->intermission);
+  }
+
   self->scoreboard = loadScoreboard(cg_hud->string);
   $(self->viewController.view, addSubview, (View *) self->scoreboard);
+
+  self->intermission = loadIntermission(cg_hud->string);
+  $(self->viewController.view, addSubview, (View *) self->intermission);
 
   View *hud = loadHud(cg_hud->string);
   if (hud == NULL && q_strcmp(cg_hud->string, HUD_DEFAULT)) {
@@ -283,6 +319,7 @@ static void reload(HudViewController *self) {
   $(self->viewController.view, bringSubviewToFront, (View *) self->notify);
   $(self->viewController.view, bringSubviewToFront, (View *) self->chat);
   $(self->viewController.view, bringSubviewToFront, (View *) self->scoreboard);
+  $(self->viewController.view, bringSubviewToFront, (View *) self->intermission);
   $(self->viewController.view, bringSubviewToFront, (View *) self->navEdit);
   self->hud = hud;
 
@@ -370,6 +407,17 @@ static void updateWithFrame(HudViewController *self, const cl_frame_t *frame) {
 
   if (scores) {
     $((View *) self->scoreboard, updateBindings, (ident) frame);
+  }
+
+  // The maps are published only during the intermission, so their presence is what says
+  // there is one; like the scoreboard, this shows when the hud does not
+  const bool intermission = cg_state.next_map.active && !cg_state.nav_edit;
+
+  $((View *) self->intermission, setVisibility,
+    intermission ? ViewVisibilityVisible : ViewVisibilityHidden);
+
+  if (intermission) {
+    $((View *) self->intermission, updateBindings, (ident) frame);
   }
 
   const bool hidden = !cg_draw_hud->integer || !ps->stats[STAT_TIME] || cg_state.nav_edit;

--- a/src/cgame/common/ui/hud/HudViewController.h
+++ b/src/cgame/common/ui/hud/HudViewController.h
@@ -26,6 +26,7 @@
 
 #include "ChatView.h"
 #include "DiagnosticsView.h"
+#include "IntermissionView.h"
 #include "NavEditView.h"
 #include "NotifyView.h"
 #include "ScoreboardView.h"
@@ -102,6 +103,11 @@ struct HudViewController {
    * @brief The scoreboard, a sibling of `hud`.
    */
   ScoreboardView *scoreboard;
+
+  /**
+   * @brief What follows this level, a sibling of `hud` shown through the intermission.
+   */
+  IntermissionView *intermission;
 };
 
 struct HudViewControllerInterface {

--- a/src/cgame/common/ui/hud/IntermissionView.c
+++ b/src/cgame/common/ui/hud/IntermissionView.c
@@ -1,0 +1,241 @@
+/*
+ * Copyright(c) 1997-2001 id Software, Inc.
+ * Copyright(c) 2002 The Quakeforge Project.
+ * Copyright(c) 2006 Quetoo.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+#include <ObjectivelyMVC/ImageView.h>
+
+#include "cg_local.h"
+
+#include "IntermissionView.h"
+
+#define _Class _IntermissionView
+
+#pragma mark - Object
+
+/**
+ * @see Object::dealloc(Object *)
+ */
+static void dealloc(Object *self) {
+
+  IntermissionView *this = (IntermissionView *) self;
+
+  release(this->maps);
+  release(this->countdown);
+
+  super(Object, self, dealloc);
+}
+
+#pragma mark - Tiles
+
+/**
+ * @brief The map's thumbnail, or a placeholder for a map this client does not have.
+ * @remarks Resolving a mapshot enumerates the filesystem, so this runs only when the
+ * candidates change, never per frame.
+ */
+static Image *thumbnail(const char *map) {
+
+  List *mapshots = cgi.Mapshots(map);
+
+  // the first, deterministically: a different one each frame would flicker
+  const char *path = mapshots->count ? mapshots->head->element : NULL;
+
+  Image *image = NULL;
+
+  if (path) {
+    SDL_Surface *surface = cgi.LoadSurface(path);
+    if (surface) {
+      image = $$(Image, imageWithSurface, surface);
+      SDL_DestroySurface(surface);
+    }
+  }
+
+  release(mapshots);
+
+  if (image == NULL) {
+    image = Cg_LoadImage(va("ui/backgrounds/%u", (uint32_t) (q_strlen(map) % 6)));
+  }
+
+  return image;
+}
+
+/**
+ * @brief Appends the tile for the candidate at `index`.
+ */
+static void addMap(IntermissionView *self, int32_t index) {
+
+  const cg_next_map_state_t *next_map = &cg_state.next_map;
+
+  StackView *tile = $(alloc(StackView), initWithFrame, NULL);
+  assert(tile);
+
+  $((View *) tile, addClassName, "map");
+
+  ImageView *mapshot = $(alloc(ImageView), initWithFrame, NULL);
+  assert(mapshot);
+
+  Image *image = thumbnail(next_map->maps[index]);
+  $(mapshot, setImage, image);
+  release(image);
+
+  $((View *) mapshot, addClassName, "mapshot");
+  $((View *) tile, addSubview, (View *) mapshot);
+  release(mapshot);
+
+  // the key that picks it, which is the only way to pick one: the HUD layer is drawn
+  // beneath the menus and never sees the mouse
+  Text *name = $(alloc(Text), initWithText,
+                 next_map->voting ? va("%d  %s", index + 1, next_map->maps[index])
+                                  : next_map->maps[index], NULL);
+  assert(name);
+
+  $((View *) name, addClassName, "name");
+  $((View *) tile, addSubview, (View *) name);
+  release(name);
+
+  if (next_map->voting) {
+    self->votes[index] = $(alloc(Text), initWithText, "", NULL);
+    assert(self->votes[index]);
+
+    $((View *) self->votes[index], addClassName, "votes");
+    $((View *) tile, addSubview, (View *) self->votes[index]);
+    release(self->votes[index]);
+  }
+
+  $((View *) self->maps, addSubview, (View *) tile);
+  release(tile);
+}
+
+#pragma mark - IntermissionView
+
+/**
+ * @fn void IntermissionView::rebuild(IntermissionView *self)
+ * @memberof IntermissionView
+ */
+static void rebuild(IntermissionView *self) {
+
+  $((View *) self->maps, removeAllSubviews);
+
+  memset(self->votes, 0, sizeof(self->votes));
+
+  for (int32_t i = 0; i < cg_state.next_map.num_maps; i++) {
+    addMap(self, i);
+  }
+}
+
+#pragma mark - View
+
+/**
+ * @see View::init(View *)
+ */
+static View *init(View *self) {
+
+  self = super(View, self, init);
+  if (self) {
+    IntermissionView *this = (IntermissionView *) self;
+
+    this->maps = $(alloc(StackView), initWithFrame, NULL);
+    assert(this->maps);
+
+    $((View *) this->maps, addClassName, "maps");
+    $(self, addSubview, (View *) this->maps);
+
+    this->countdown = $(alloc(Text), initWithText, "", NULL);
+    assert(this->countdown);
+
+    $((View *) this->countdown, addClassName, "countdown");
+    $(self, addSubview, (View *) this->countdown);
+  }
+
+  return self;
+}
+
+/**
+ * @see View::updateBindings(View *, ident)
+ */
+static void updateBindings(View *self, ident data) {
+
+  IntermissionView *this = (IntermissionView *) self;
+
+  const cg_next_map_state_t *next_map = &cg_state.next_map;
+
+  if (data) {
+
+    // rebuilt before the recursion, so that new tiles take this frame too
+    if (next_map->generation != this->generation) {
+      this->generation = next_map->generation;
+
+      $(this, rebuild);
+    }
+
+    for (int32_t i = 0; i < next_map->num_maps; i++) {
+      if (this->votes[i]) {
+        $(this->votes[i], setText, va("%d", next_map->votes[i]));
+      }
+    }
+
+    // the server publishes the intermission's clock here once the match clock stops
+    const char *time = cgi.ConfigString(CS_TIME);
+    if (!q_strncmp(time, "^7", 2)) {
+      time += 2;
+    }
+
+    $(this->countdown, setText, time);
+  }
+
+  super(View, self, updateBindings, data);
+}
+
+#pragma mark - Class lifecycle
+
+/**
+ * @see Class::initialize(Class *)
+ */
+static void initialize(Class *clazz) {
+
+  ((ObjectInterface *) clazz->interface)->dealloc = dealloc;
+
+  ((ViewInterface *) clazz->interface)->init = init;
+  ((ViewInterface *) clazz->interface)->updateBindings = updateBindings;
+
+  ((IntermissionViewInterface *) clazz->interface)->rebuild = rebuild;
+}
+
+/**
+ * @fn Class *IntermissionView::_IntermissionView(void)
+ * @memberof IntermissionView
+ */
+Class *_IntermissionView(void) {
+  static Class *clazz;
+  static Once once;
+
+  do_once(&once, {
+    clazz = _initialize(&(const ClassDef) {
+      .name = "IntermissionView",
+      .superclass = _View(),
+      .instanceSize = sizeof(IntermissionView),
+      .interfaceSize = sizeof(IntermissionViewInterface),
+      .initialize = initialize,
+    });
+  });
+
+  return clazz;
+}
+
+#undef _Class

--- a/src/cgame/common/ui/hud/IntermissionView.h
+++ b/src/cgame/common/ui/hud/IntermissionView.h
@@ -1,0 +1,95 @@
+/*
+ * Copyright(c) 1997-2001 id Software, Inc.
+ * Copyright(c) 2002 The Quakeforge Project.
+ * Copyright(c) 2006 Quetoo.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+#pragma once
+
+#include <ObjectivelyMVC/StackView.h>
+#include <ObjectivelyMVC/Text.h>
+
+#include "cg_types.h"
+
+/**
+ * @file
+ * @brief What follows this level: the countdown, and the map it is counting down to.
+ */
+
+typedef struct IntermissionView IntermissionView;
+typedef struct IntermissionViewInterface IntermissionViewInterface;
+
+/**
+ * @brief What follows this level: the countdown, and the map it is counting down to.
+ * @details One tile per candidate, each a thumbnail over the map's name. With a vote
+ * running the tiles carry the key that picks them and the tally they have drawn; with
+ * none, the single tile just says what is next.
+ * @remarks This shows when the HUD does not, so like the scoreboard it belongs to the
+ * HudViewController rather than to the hud.
+ * @extends View
+ */
+struct IntermissionView {
+
+  /**
+   * @brief The superclass.
+   */
+  View view;
+
+  /**
+   * @brief The interface type.
+   * @protected
+   */
+  IntermissionViewInterface *interface[0];
+
+  /**
+   * @brief The tiles, one per candidate.
+   */
+  StackView *maps;
+
+  /**
+   * @brief The tally beneath each tile, or `NULL` where no vote is running.
+   */
+  Text *votes[MAX_NEXT_MAPS];
+
+  /**
+   * @brief The countdown.
+   */
+  Text *countdown;
+
+  /**
+   * @brief The candidates the tiles were built for.
+   */
+  uint32_t generation;
+};
+
+struct IntermissionViewInterface {
+
+  /**
+   * @brief The superclass interface.
+   */
+  ViewInterface viewInterface;
+
+  /**
+   * @fn void IntermissionView::rebuild(IntermissionView *self)
+   * @brief Rebuilds the tiles for the candidates now published.
+   * @memberof IntermissionView
+   */
+  void (*rebuild)(IntermissionView *self);
+};
+
+CGAME_EXPORT Class *_IntermissionView(void);

--- a/src/cgame/common/ui/hud/chrome/intermission.css
+++ b/src/cgame/common/ui/hud/chrome/intermission.css
@@ -1,0 +1,55 @@
+/*
+ * The chrome variant's intermission strip: what follows this level, along the bottom of
+ * the screen with the countdown beneath it.
+ *
+ * It shares the screen with the scoreboard, which is anchored to the top and grows
+ * downward, so this is anchored to the bottom and kept to the height of one row of tiles.
+ */
+
+IntermissionView {
+  autoresizing-mask: fill;
+}
+
+IntermissionView Text {
+  font-family: Barlow Condensed;
+  font-style: regular;
+  font-size: 16;
+  color: #f2f5f6;
+}
+
+IntermissionView > .maps {
+  alignment: bottom-center;
+  autoresizing-mask: contain;
+  axis: horizontal;
+  spacing: 16;
+  padding-bottom: 44;
+}
+
+IntermissionView .map {
+  autoresizing-mask: contain;
+  axis: vertical;
+  spacing: 3;
+  padding: 5 5 5 5;
+}
+
+IntermissionView .mapshot {
+  width: 176;
+  height: 132;
+}
+
+IntermissionView .name {
+  alignment: top-center;
+  text-transform: uppercase;
+}
+
+IntermissionView .votes {
+  alignment: top-center;
+  color: #6fb3cc;
+}
+
+IntermissionView > .countdown {
+  alignment: bottom-center;
+  font-family: M PLUS U;
+  font-size: 28;
+  padding-bottom: 12;
+}

--- a/src/cgame/common/ui/hud/chrome/intermission.css
+++ b/src/cgame/common/ui/hud/chrome/intermission.css
@@ -33,8 +33,8 @@ IntermissionView .map {
 }
 
 IntermissionView .mapshot {
-  width: 176;
-  height: 132;
+  width: 208;
+  height: 117;
 }
 
 IntermissionView .name {
@@ -47,9 +47,11 @@ IntermissionView .votes {
   color: #6fb3cc;
 }
 
+/* the same face the match clock uses, since it is the same clock */
 IntermissionView > .countdown {
   alignment: bottom-center;
-  font-family: M PLUS U;
+  font-family: Rajdhani;
+  font-style: regular;
   font-size: 28;
   padding-bottom: 12;
 }

--- a/src/cgame/common/ui/hud/chrome/intermission.json
+++ b/src/cgame/common/ui/hud/chrome/intermission.json
@@ -1,0 +1,4 @@
+{
+  "class": "IntermissionView",
+  "identifier": "intermission"
+}

--- a/src/cgame/common/ui/hud/default/intermission.css
+++ b/src/cgame/common/ui/hud/default/intermission.css
@@ -1,0 +1,55 @@
+/*
+ * The default variant's intermission strip: what follows this level, along the bottom of
+ * the screen with the countdown beneath it.
+ *
+ * It shares the screen with the scoreboard, which is anchored to the top and grows
+ * downward, so this is anchored to the bottom and kept to the height of one row of tiles.
+ */
+
+IntermissionView {
+  autoresizing-mask: fill;
+}
+
+IntermissionView Text {
+  font-family: Share Tech Mono;
+  font-size: 14;
+  color: #ffffff;
+}
+
+IntermissionView > .maps {
+  alignment: bottom-center;
+  autoresizing-mask: contain;
+  axis: horizontal;
+  spacing: 12;
+  padding-bottom: 40;
+}
+
+IntermissionView .map {
+  autoresizing-mask: contain;
+  axis: vertical;
+  spacing: 2;
+  background-color: #08151a66;
+  border-radius: 4;
+  padding: 4 4 4 4;
+}
+
+IntermissionView .mapshot {
+  width: 160;
+  height: 120;
+  border-radius: 2;
+}
+
+IntermissionView .name {
+  alignment: top-center;
+}
+
+IntermissionView .votes {
+  alignment: top-center;
+  color: #8fc7dc;
+}
+
+IntermissionView > .countdown {
+  alignment: bottom-center;
+  font-size: 24;
+  padding-bottom: 12;
+}

--- a/src/cgame/common/ui/hud/default/intermission.css
+++ b/src/cgame/common/ui/hud/default/intermission.css
@@ -34,8 +34,8 @@ IntermissionView .map {
 }
 
 IntermissionView .mapshot {
-  width: 160;
-  height: 120;
+  width: 192;
+  height: 108;
   border-radius: 2;
 }
 
@@ -48,8 +48,11 @@ IntermissionView .votes {
   color: #8fc7dc;
 }
 
+/* the same face the match clock uses, since it is the same clock */
 IntermissionView > .countdown {
   alignment: bottom-center;
+  font-family: M PLUS U;
+  font-style: regular;
   font-size: 24;
   padding-bottom: 12;
 }

--- a/src/cgame/common/ui/hud/default/intermission.json
+++ b/src/cgame/common/ui/hud/default/intermission.json
@@ -1,0 +1,4 @@
+{
+  "class": "IntermissionView",
+  "identifier": "intermission"
+}

--- a/src/cgame/ctf/Makefile.am
+++ b/src/cgame/ctf/Makefile.am
@@ -76,6 +76,7 @@ cgame_la_SOURCES = \
 	cg_hud.c \
 	cg_hud_draw.c \
 	cg_input.c \
+	cg_intermission.c \
 	cg_inventory.c \
 	cg_light.c \
 	cg_main.c \
@@ -121,6 +122,7 @@ cgame_la_SOURCES = \
 	ui/hud/DiagnosticsView.c \
 	ui/hud/FpsView.c \
 	ui/hud/HudViewController.c \
+	ui/hud/IntermissionView.c \
 	ui/hud/NavEditView.c \
 	ui/hud/NotifyView.c \
 	ui/hud/OverlayText.c \

--- a/src/cgame/default/Makefile.am
+++ b/src/cgame/default/Makefile.am
@@ -109,6 +109,8 @@ cguihuddefaultdir = \
 cguihuddefault_DATA = \
 	$(CGUI_DIR)/hud/default/hud.css \
 	$(CGUI_DIR)/hud/default/hud.json \
+	$(CGUI_DIR)/hud/default/intermission.css \
+	$(CGUI_DIR)/hud/default/intermission.json \
 	$(CGUI_DIR)/hud/default/scoreboard.css \
 	$(CGUI_DIR)/hud/default/scoreboard.json
 
@@ -118,6 +120,8 @@ cguihudchromedir = \
 cguihudchrome_DATA = \
 	$(CGUI_DIR)/hud/chrome/hud.css \
 	$(CGUI_DIR)/hud/chrome/hud.json \
+	$(CGUI_DIR)/hud/chrome/intermission.css \
+	$(CGUI_DIR)/hud/chrome/intermission.json \
 	$(CGUI_DIR)/hud/chrome/scoreboard.css \
 	$(CGUI_DIR)/hud/chrome/scoreboard.json
 
@@ -204,6 +208,7 @@ cgame_la_SOURCES = \
 	cg_hud.c \
 	cg_hud_draw.c \
 	cg_input.c \
+	cg_intermission.c \
 	cg_inventory.c \
 	cg_light.c \
 	cg_main.c \
@@ -248,6 +253,7 @@ cgame_la_SOURCES = \
 	ui/hud/DiagnosticsView.c \
 	ui/hud/FpsView.c \
 	ui/hud/HudViewController.c \
+	ui/hud/IntermissionView.c \
 	ui/hud/NavEditView.c \
 	ui/hud/NotifyView.c \
 	ui/hud/OverlayText.c \

--- a/src/cgame/lithium/Makefile.am
+++ b/src/cgame/lithium/Makefile.am
@@ -74,6 +74,7 @@ cgame_la_SOURCES = \
 	cg_hud.c \
 	cg_hud_draw.c \
 	cg_input.c \
+	cg_intermission.c \
 	cg_inventory.c \
 	cg_light.c \
 	cg_main.c \
@@ -119,6 +120,7 @@ cgame_la_SOURCES = \
 	ui/hud/DiagnosticsView.c \
 	ui/hud/FpsView.c \
 	ui/hud/HudViewController.c \
+	ui/hud/IntermissionView.c \
 	ui/hud/NavEditView.c \
 	ui/hud/NotifyView.c \
 	ui/hud/OverlayText.c \

--- a/src/cgame/race/Makefile.am
+++ b/src/cgame/race/Makefile.am
@@ -75,6 +75,7 @@ cgame_la_SOURCES = \
 	cg_hud.c \
 	cg_hud_draw.c \
 	cg_input.c \
+	cg_intermission.c \
 	cg_inventory.c \
 	cg_light.c \
 	cg_main.c \
@@ -122,6 +123,7 @@ cgame_la_SOURCES = \
 	ui/hud/DiagnosticsView.c \
 	ui/hud/FpsView.c \
 	ui/hud/HudViewController.c \
+	ui/hud/IntermissionView.c \
 	ui/hud/NavEditView.c \
 	ui/hud/NotifyView.c \
 	ui/hud/OverlayText.c \

--- a/src/game/common/bg_intermission.h
+++ b/src/game/common/bg_intermission.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright(c) 1997-2001 id Software, Inc.
+ * Copyright(c) 2002 The Quakeforge Project.
+ * Copyright(c) 2006 Quetoo.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+#pragma once
+
+#include "shared/shared.h"
+
+/**
+ * @file
+ * @brief What the intermission is offering, shared by the game and the client game so that
+ * the screen that shows the maps and the server that serves one agree.
+ */
+
+/**
+ * @brief The most maps an intermission offers, which is what the number keys reach.
+ */
+#define MAX_NEXT_MAPS 4
+
+/**
+ * @brief The `CS_NEXT_MAP` config string: empty outside the intermission, else these
+ * fields separated by `\`.
+ * @details The first field says whether ballots are being taken. The rest are one
+ * `name`, `votes` pair per candidate, so the count of candidates is what the string
+ * carries rather than something both sides have to agree on in advance.
+ */
+typedef enum {
+  NEXT_MAP_CS_VOTING, // "1" while ballots are being taken, else "0"
+  NEXT_MAP_CS_MAPS, // the first name; from here the fields alternate name, votes
+  NEXT_MAP_CS_FIELDS
+} next_map_cs_field_t;
+
+/**
+ * @brief The number of `\`-separated fields a `CS_NEXT_MAP` string with `count` maps has.
+ */
+#define NEXT_MAP_CS_FIELDS_FOR(count) (NEXT_MAP_CS_MAPS + (count) * 2)

--- a/src/game/common/g_intermission.c
+++ b/src/game/common/g_intermission.c
@@ -32,6 +32,7 @@ static struct {
   bool active;
   bool voting;
   char maps[MAX_NEXT_MAPS][MAX_QPATH];
+  int32_t indices[MAX_NEXT_MAPS];
   int32_t num_maps;
   int32_t ballots[MAX_CLIENTS];
   int32_t published[MAX_NEXT_MAPS];
@@ -66,7 +67,7 @@ static bool G_Intermission_Offers(const char *name) {
  * offered. A rotation may name maps that were never installed; `next_map` does not check,
  * but a vote would let clients elect one.
  */
-static void G_Intermission_Offer(const char *name) {
+static void G_Intermission_Offer(const char *name, int32_t index) {
 
   if (g_intermission_state.num_maps == MAX_NEXT_MAPS) {
     return;
@@ -83,6 +84,7 @@ static void G_Intermission_Offer(const char *name) {
     return;
   }
 
+  g_intermission_state.indices[g_intermission_state.num_maps] = index;
   q_strlcpy(g_intermission_state.maps[g_intermission_state.num_maps++], name, MAX_QPATH);
 }
 
@@ -105,8 +107,9 @@ static const char *G_Intermission_MapAt(const List *list, int32_t index) {
 
 /**
  * @brief Fills the candidates from the server's rotation.
- * @details The rotation is matched by name, which is how the server resolves the map we
- * hand back to it, so the two agree on which entry a name means.
+ * @details Where we are is the server's index rather than our name, since a rotation
+ * may name this map more than once, and the occurrences are different places to
+ * resume from.
  */
 static void G_Intermission_SelectMaps(void) {
 
@@ -115,30 +118,25 @@ static void G_Intermission_SelectMaps(void) {
   const int32_t wanted = g_intermission_state.voting ? MAX_NEXT_MAPS : 1;
 
   List *list = gi.MapList();
-  if (list) {
+  if (list && list->count) {
     const int32_t length = (int32_t) list->count;
 
-    int32_t current = -1;
-    for (int32_t i = 0; i < length; i++) {
-      if (!q_strcmp(G_Intermission_MapAt(list, i) ?: "", g_level.name)) {
-        current = i;
-        break;
-      }
-    }
+    // -1 when this level did not come from the rotation, which starts us at its head
+    const int32_t current = gi.MapIndex();
 
     if (gi.GetCvarInteger("sv_map_list_shuffle")) {
       // a shuffled rotation has no next, so offer a sample of it instead; the ordered
       // pass below tops up whatever the draws duplicated
       for (int32_t i = 0; i < length && g_intermission_state.num_maps < wanted; i++) {
-        G_Intermission_Offer(G_Intermission_MapAt(list, (int32_t) RandomRangeu(0, (uint32_t) length)));
+        const int32_t index = (int32_t) RandomRangeu(0, (uint32_t) length);
+        G_Intermission_Offer(G_Intermission_MapAt(list, index), index);
       }
     }
 
-    // in order from wherever we are, which is what the rotation would have played;
-    // `current` is -1 when this map is not in the rotation at all, which starts us
-    // at its head
+    // in order from wherever we are, which is what the rotation would have played
     for (int32_t i = 1; i <= length && g_intermission_state.num_maps < wanted; i++) {
-      G_Intermission_Offer(G_Intermission_MapAt(list, (current + i) % length));
+      const int32_t index = (current + i) % length;
+      G_Intermission_Offer(G_Intermission_MapAt(list, index), index);
     }
 
     for (const ListNode *node = list->head; node; node = node->next) {
@@ -149,7 +147,9 @@ static void G_Intermission_SelectMaps(void) {
   }
 
   if (g_intermission_state.num_maps == 0) {
-    // no rotation, or nothing in it we can serve: the server replays this map
+    // no rotation, or nothing in it we can serve: the server replays this map, which
+    // is what `next_map` falls back to on its own, so we leave it to do that
+    g_intermission_state.indices[0] = -1;
     q_strlcpy(g_intermission_state.maps[0], g_level.name, MAX_QPATH);
     g_intermission_state.num_maps = 1;
   }
@@ -202,18 +202,35 @@ static void G_Intermission_Publish(void) {
 }
 
 /**
+ * @brief Publishes the intermission's countdown.
+ * @remarks The match clock stops at the intermission, so its config string is free to
+ * carry this one instead; the HUD that reads it is hidden by then.
+ */
+static void G_Intermission_PublishTime(void) {
+
+  const uint32_t end = g_level.intermission_time + INTERMISSION;
+
+  gi.SetConfigString(CS_TIME, G_FormatTime(end > g_level.time ? end - g_level.time : 0));
+}
+
+/**
  * @brief Opens the intermission, choosing what it offers.
  */
 static void G_Intermission_Begin(void) {
 
   g_intermission_state.active = true;
-  g_intermission_state.voting = g_vote_next_map->integer && g_vote->integer;
+  g_intermission_state.voting = g_vote_next_map->integer;
 
   for (int32_t i = 0; i < MAX_CLIENTS; i++) {
     g_intermission_state.ballots[i] = BALLOT_NONE;
   }
 
   G_Intermission_SelectMaps();
+
+  // before the maps, since publishing those is what shows the view, and the clock it
+  // reads still holds the match time until the next tick
+  G_Intermission_PublishTime();
+
   G_Intermission_Publish();
 
   if (g_intermission_state.voting) {
@@ -247,7 +264,9 @@ static void G_Intermission_End(void) {
                       g_intermission_state.maps[winner], votes[winner], cast);
   }
 
-  gi.SetNextMap(g_intermission_state.maps[winner]);
+  if (g_intermission_state.indices[winner] >= 0) {
+    gi.SetNextMap(g_intermission_state.indices[winner]);
+  }
 
   g_intermission_state.active = false;
   g_intermission_state.voting = false;
@@ -317,11 +336,8 @@ static void G_FrameDidEnd_Intermission(void) {
       G_Intermission_Begin();
     }
 
-    // the match clock stops at the intermission, so the config string is free to carry
-    // this one instead; the HUD that reads it is hidden by then
     if (g_level.frame_num % QUETOO_TICK_RATE == 0) {
-      const uint32_t end = g_intermission_state.active ? g_level.intermission_time + INTERMISSION : 0;
-      gi.SetConfigString(CS_TIME, G_FormatTime(end > g_level.time ? end - g_level.time : 0));
+      G_Intermission_PublishTime();
     }
 
     int32_t votes[MAX_NEXT_MAPS];

--- a/src/game/common/g_intermission.c
+++ b/src/game/common/g_intermission.c
@@ -72,7 +72,9 @@ static void G_Intermission_Offer(const char *name) {
     return;
   }
 
-  if (!name || !*name || G_Intermission_Offers(name)) {
+  // by name rather than by position, since a rotation may list either the map we are
+  // on or a candidate more than once, and neither is a second thing to vote for
+  if (!name || !*name || !q_strcmp(name, g_level.name) || G_Intermission_Offers(name)) {
     return;
   }
 
@@ -128,19 +130,15 @@ static void G_Intermission_SelectMaps(void) {
       // a shuffled rotation has no next, so offer a sample of it instead; the ordered
       // pass below tops up whatever the draws duplicated
       for (int32_t i = 0; i < length && g_intermission_state.num_maps < wanted; i++) {
-        const int32_t index = (int32_t) RandomRangeu(0, (uint32_t) length);
-        if (index != current) {
-          G_Intermission_Offer(G_Intermission_MapAt(list, index));
-        }
+        G_Intermission_Offer(G_Intermission_MapAt(list, (int32_t) RandomRangeu(0, (uint32_t) length)));
       }
     }
 
-    // in order from wherever we are, which is what the rotation would have played
+    // in order from wherever we are, which is what the rotation would have played;
+    // `current` is -1 when this map is not in the rotation at all, which starts us
+    // at its head
     for (int32_t i = 1; i <= length && g_intermission_state.num_maps < wanted; i++) {
-      const int32_t index = (current + i) % length;
-      if (index != current) {
-        G_Intermission_Offer(G_Intermission_MapAt(list, index));
-      }
+      G_Intermission_Offer(G_Intermission_MapAt(list, (current + i) % length));
     }
 
     for (const ListNode *node = list->head; node; node = node->next) {

--- a/src/game/common/g_intermission.c
+++ b/src/game/common/g_intermission.c
@@ -198,6 +198,8 @@ static void G_Intermission_Publish(void) {
     q_strlcat(string, va("\\%s\\%d", g_intermission_state.maps[i], votes[i]), sizeof(string));
   }
 
+  G_Debug("%s\n", string);
+
   gi.SetConfigString(CS_NEXT_MAP, string);
 }
 

--- a/src/game/common/g_intermission.c
+++ b/src/game/common/g_intermission.c
@@ -1,0 +1,393 @@
+/*
+ * Copyright(c) 1997-2001 id Software, Inc.
+ * Copyright(c) 2002 The Quakeforge Project.
+ * Copyright(c) 2006 Quetoo.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+#include <Objectively/List.h>
+
+#include "g_local.h"
+#include "bg_intermission.h"
+
+cvar_t *g_vote_next_map;
+
+#define BALLOT_NONE -1
+
+static struct {
+  bool active;
+  bool voting;
+  char maps[MAX_NEXT_MAPS][MAX_QPATH];
+  int32_t num_maps;
+  int32_t ballots[MAX_CLIENTS];
+  int32_t published[MAX_NEXT_MAPS];
+} g_intermission_state;
+
+static struct {
+  HandleClientCommand HandleClientCommand;
+  FrameDidEnd FrameDidEnd;
+  ClientWillDisconnect ClientWillDisconnect;
+  ConfigureLevel ConfigureLevel;
+} previous;
+
+static bool installed;
+
+/**
+ * @brief Whether `name` is already offered, so that a rotation listing a map twice does
+ * not offer it twice and split its own vote.
+ */
+static bool G_Intermission_Offers(const char *name) {
+
+  for (int32_t i = 0; i < g_intermission_state.num_maps; i++) {
+    if (!q_strcmp(g_intermission_state.maps[i], name)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+/**
+ * @brief Offers `name`, if it is a map this server can actually serve and is not already
+ * offered. A rotation may name maps that were never installed; `next_map` does not check,
+ * but a vote would let clients elect one.
+ */
+static void G_Intermission_Offer(const char *name) {
+
+  if (g_intermission_state.num_maps == MAX_NEXT_MAPS) {
+    return;
+  }
+
+  if (!name || !*name || G_Intermission_Offers(name)) {
+    return;
+  }
+
+  if (!gi.FileExists(va("maps/%s.bsp", name))) {
+    G_Debug("Skipping %s, which is not installed\n", name);
+    return;
+  }
+
+  q_strlcpy(g_intermission_state.maps[g_intermission_state.num_maps++], name, MAX_QPATH);
+}
+
+/**
+ * @brief The `name` of the rotation entry at `index`, or `NULL`.
+ */
+static const char *G_Intermission_MapAt(const List *list, int32_t index) {
+
+  const ListNode *node = list->head;
+  for (int32_t i = 0; i < index && node; i++) {
+    node = node->next;
+  }
+
+  if (node == NULL) {
+    return NULL;
+  }
+
+  return gi.EntityValue((const cm_entity_t *) node->element, "name")->string;
+}
+
+/**
+ * @brief Fills the candidates from the server's rotation.
+ * @details The rotation is matched by name, which is how the server resolves the map we
+ * hand back to it, so the two agree on which entry a name means.
+ */
+static void G_Intermission_SelectMaps(void) {
+
+  g_intermission_state.num_maps = 0;
+
+  const int32_t wanted = g_intermission_state.voting ? MAX_NEXT_MAPS : 1;
+
+  List *list = gi.MapList();
+  if (list) {
+    const int32_t length = (int32_t) list->count;
+
+    int32_t current = -1;
+    for (int32_t i = 0; i < length; i++) {
+      if (!q_strcmp(G_Intermission_MapAt(list, i) ?: "", g_level.name)) {
+        current = i;
+        break;
+      }
+    }
+
+    if (gi.GetCvarInteger("sv_map_list_shuffle")) {
+      // a shuffled rotation has no next, so offer a sample of it instead; the ordered
+      // pass below tops up whatever the draws duplicated
+      for (int32_t i = 0; i < length && g_intermission_state.num_maps < wanted; i++) {
+        const int32_t index = (int32_t) RandomRangeu(0, (uint32_t) length);
+        if (index != current) {
+          G_Intermission_Offer(G_Intermission_MapAt(list, index));
+        }
+      }
+    }
+
+    // in order from wherever we are, which is what the rotation would have played
+    for (int32_t i = 1; i <= length && g_intermission_state.num_maps < wanted; i++) {
+      const int32_t index = (current + i) % length;
+      if (index != current) {
+        G_Intermission_Offer(G_Intermission_MapAt(list, index));
+      }
+    }
+
+    for (const ListNode *node = list->head; node; node = node->next) {
+      gi.FreeEntity((cm_entity_t *) node->element);
+    }
+
+    release(list);
+  }
+
+  if (g_intermission_state.num_maps == 0) {
+    // no rotation, or nothing in it we can serve: the server replays this map
+    q_strlcpy(g_intermission_state.maps[0], g_level.name, MAX_QPATH);
+    g_intermission_state.num_maps = 1;
+  }
+
+  // one candidate is not a choice
+  g_intermission_state.voting &= g_intermission_state.num_maps > 1;
+}
+
+/**
+ * @brief Counts the ballots cast for each candidate.
+ */
+static void G_Intermission_Count(int32_t *votes) {
+
+  memset(votes, 0, sizeof(int32_t) * MAX_NEXT_MAPS);
+
+  G_ForEachClient(cl, {
+    const int32_t ballot = g_intermission_state.ballots[cl->ps.client];
+
+    if (ballot != BALLOT_NONE && ballot < g_intermission_state.num_maps && G_Vote_Eligible(cl)) {
+      votes[ballot]++;
+    }
+  });
+}
+
+/**
+ * @brief Publishes the candidates and the tally to the clients, or their absence.
+ */
+static void G_Intermission_Publish(void) {
+
+  if (!g_intermission_state.active) {
+    gi.SetConfigString(CS_NEXT_MAP, "");
+    return;
+  }
+
+  int32_t votes[MAX_NEXT_MAPS];
+  G_Intermission_Count(votes);
+
+  memcpy(g_intermission_state.published, votes, sizeof(votes));
+
+  char string[MAX_STRING_CHARS];
+  q_snprintf(string, sizeof(string), "%d", g_intermission_state.voting ? 1 : 0);
+
+  for (int32_t i = 0; i < g_intermission_state.num_maps; i++) {
+    q_strlcat(string, va("\\%s\\%d", g_intermission_state.maps[i], votes[i]), sizeof(string));
+  }
+
+  gi.SetConfigString(CS_NEXT_MAP, string);
+}
+
+/**
+ * @brief Opens the intermission, choosing what it offers.
+ */
+static void G_Intermission_Begin(void) {
+
+  g_intermission_state.active = true;
+  g_intermission_state.voting = g_vote_next_map->integer && g_vote->integer;
+
+  for (int32_t i = 0; i < MAX_CLIENTS; i++) {
+    g_intermission_state.ballots[i] = BALLOT_NONE;
+  }
+
+  G_Intermission_SelectMaps();
+  G_Intermission_Publish();
+
+  if (g_intermission_state.voting) {
+    gi.BroadcastPrint(PRINT_HIGH, "Press 1 - %d to vote for the next map\n",
+                      g_intermission_state.num_maps);
+  }
+}
+
+/**
+ * @brief Closes the intermission, naming the map the server should serve next.
+ * @details The winner is the candidate with the most ballots, ties going to the one the
+ * rotation would have played anyway. This runs in the frame that ends the intermission,
+ * before the queued `next_map` is executed.
+ */
+static void G_Intermission_End(void) {
+
+  int32_t votes[MAX_NEXT_MAPS];
+  G_Intermission_Count(votes);
+
+  int32_t winner = 0, cast = votes[0];
+  for (int32_t i = 1; i < g_intermission_state.num_maps; i++) {
+    cast += votes[i];
+
+    if (votes[i] > votes[winner]) {
+      winner = i;
+    }
+  }
+
+  if (g_intermission_state.voting) {
+    gi.BroadcastPrint(PRINT_HIGH, "%s wins the vote with %d of %d\n",
+                      g_intermission_state.maps[winner], votes[winner], cast);
+  }
+
+  gi.SetNextMap(g_intermission_state.maps[winner]);
+
+  g_intermission_state.active = false;
+  g_intermission_state.voting = false;
+  g_intermission_state.num_maps = 0;
+
+  G_Intermission_Publish();
+}
+
+/**
+ * @brief Records a ballot, which a client may change until the intermission ends.
+ */
+static void G_Intermission_Cast(g_client_t *cl, int32_t map) {
+
+  if (!g_intermission_state.active || !g_intermission_state.voting) {
+    gi.ClientPrint(cl, PRINT_HIGH, "No map vote is in progress\n");
+    return;
+  }
+
+  if (map < 0 || map >= g_intermission_state.num_maps) {
+    gi.ClientPrint(cl, PRINT_HIGH, "Usage: vote_map 1 - %d\n", g_intermission_state.num_maps);
+    return;
+  }
+
+  if (!G_Vote_Eligible(cl)) {
+    return;
+  }
+
+  if (g_intermission_state.ballots[cl->ps.client] == map) {
+    return;
+  }
+
+  g_intermission_state.ballots[cl->ps.client] = map;
+
+  gi.ClientPrint(cl, PRINT_HIGH, "You voted for %s\n", g_intermission_state.maps[map]);
+
+  G_Intermission_Publish();
+}
+
+/**
+ * @brief `vote_map <n>`, where `n` is the candidate as the client game numbers them.
+ */
+static bool G_HandleClientCommand_Intermission(g_client_t *cl, const char *cmd) {
+
+  if (q_strcmp(cmd, "vote_map")) {
+    return previous.HandleClientCommand(cl, cmd);
+  }
+
+  if (gi.Argc() < 2) {
+    gi.ClientPrint(cl, PRINT_HIGH, "Usage: vote_map <number>\n");
+    return true;
+  }
+
+  G_Intermission_Cast(cl, (int32_t) strtol(gi.Argv(1), NULL, 10) - 1);
+
+  return true;
+}
+
+/**
+ * @brief Opens and closes the intermission around the level's own clock, and keeps the
+ * countdown and the tally published while it runs.
+ */
+static void G_FrameDidEnd_Intermission(void) {
+
+  if (g_level.intermission_time) {
+
+    if (!g_intermission_state.active) {
+      G_Intermission_Begin();
+    }
+
+    // the match clock stops at the intermission, so the config string is free to carry
+    // this one instead; the HUD that reads it is hidden by then
+    if (g_level.frame_num % QUETOO_TICK_RATE == 0) {
+      const uint32_t end = g_intermission_state.active ? g_level.intermission_time + INTERMISSION : 0;
+      gi.SetConfigString(CS_TIME, G_FormatTime(end > g_level.time ? end - g_level.time : 0));
+    }
+
+    int32_t votes[MAX_NEXT_MAPS];
+    G_Intermission_Count(votes);
+
+    if (memcmp(votes, g_intermission_state.published, sizeof(votes))) {
+      G_Intermission_Publish();
+    }
+
+  } else if (g_intermission_state.active) {
+    G_Intermission_End();
+  }
+
+  previous.FrameDidEnd();
+}
+
+/**
+ * @brief A leaving client's ballot leaves with them, so that it can neither decide the
+ * vote nor be inherited by whoever takes their slot.
+ */
+static void G_ClientWillDisconnect_Intermission(g_client_t *cl) {
+
+  if (g_intermission_state.ballots[cl->ps.client] != BALLOT_NONE) {
+    g_intermission_state.ballots[cl->ps.client] = BALLOT_NONE;
+
+    G_Intermission_Publish();
+  }
+
+  previous.ClientWillDisconnect(cl);
+}
+
+/**
+ * @brief An intermission does not outlive its level.
+ */
+static void G_ConfigureLevel_Intermission(void) {
+
+  g_intermission_state.active = false;
+  g_intermission_state.voting = false;
+  g_intermission_state.num_maps = 0;
+
+  G_Intermission_Publish();
+
+  previous.ConfigureLevel();
+}
+
+/**
+ * @brief Installs the intermission over the hooks it needs, once per module image.
+ */
+void G_Intermission_Init(void) {
+
+  g_vote_next_map = gi.AddCvar("g_vote_next_map", "0", CVAR_SERVER_INFO,
+                               "Whether clients vote for the next map during the intermission.");
+
+  if (!installed) {
+    installed = true;
+
+    previous.HandleClientCommand = G_HandleClientCommand;
+    G_HandleClientCommand = G_HandleClientCommand_Intermission;
+
+    previous.FrameDidEnd = G_FrameDidEnd;
+    G_FrameDidEnd = G_FrameDidEnd_Intermission;
+
+    previous.ClientWillDisconnect = G_ClientWillDisconnect;
+    G_ClientWillDisconnect = G_ClientWillDisconnect_Intermission;
+
+    previous.ConfigureLevel = G_ConfigureLevel;
+    G_ConfigureLevel = G_ConfigureLevel_Intermission;
+  }
+}

--- a/src/game/common/g_intermission.h
+++ b/src/game/common/g_intermission.h
@@ -24,11 +24,7 @@
 #include "g_types.h"
 
 #if defined(__G_LOCAL_H__)
-extern cvar_t *g_vote;
-extern cvar_t *g_vote_time;
-extern cvar_t *g_vote_threshold;
-extern cvar_t *g_vote_cooldown;
+extern cvar_t *g_vote_next_map;
 
-bool G_Vote_Eligible(const g_client_t *cl);
-void G_Vote_Init(void);
+void G_Intermission_Init(void);
 #endif

--- a/src/game/common/g_local.h
+++ b/src/game/common/g_local.h
@@ -63,5 +63,6 @@
 #endif
 #include "g_types.h"
 #include "g_util.h"
+#include "g_intermission.h"
 #include "g_vote.h"
 #include "g_weapon.h"

--- a/src/game/common/g_main.c
+++ b/src/game/common/g_main.c
@@ -545,7 +545,7 @@ static void G_EndLevel(void) {
  * @brief Formats a millisecond time value as a "MM:SS" string, highlighting countdowns.
  * @return A static formatted time string.
  */
-static char *G_FormatTime(uint32_t time) {
+char *G_FormatTime(uint32_t time) {
   static char formatted_time[MAX_QPATH];
   static uint32_t last_time = 0xffffffff;
   const uint32_t m = (time / 1000) / 60;
@@ -904,8 +904,6 @@ static void G_CheckRules(void) {
   }
 }
 
-#define INTERMISSION (10.0 * 1000) // intermission duration
-
 /**
  * @brief The tail of the `G_FrameWillBegin` chain: a notification, so it does nothing.
  */
@@ -1022,6 +1020,7 @@ void G_Init(void) {
 #endif
 
   G_Vote_Init();
+  G_Intermission_Init();
 
   G_Module_Init();
 

--- a/src/game/common/g_main.h
+++ b/src/game/common/g_main.h
@@ -36,6 +36,12 @@ extern g_media_t g_media;
 #define G_MOVEMENT_DEFAULT PM_MOVEMENT_QUETOO
 #endif
 
+/**
+ * @brief How long the intermission runs before the level advances.
+ */
+#define INTERMISSION (10.0 * 1000)
+
+char *G_FormatTime(uint32_t time);
 pm_params_t G_MovementParams(void);
 float G_LevelGravity(void);
 pm_movement_t G_ResolveMovement(const char *name);

--- a/src/game/common/g_vote.c
+++ b/src/game/common/g_vote.c
@@ -58,7 +58,7 @@ static bool installed;
 /**
  * @brief Connected human players and spectators may vote; bots may not.
  */
-static bool G_Vote_Eligible(const g_client_t *cl) {
+bool G_Vote_Eligible(const g_client_t *cl) {
   return cl->in_use && !cl->ai;
 }
 

--- a/src/game/ctf/Makefile.am
+++ b/src/game/ctf/Makefile.am
@@ -53,6 +53,7 @@ game_la_SOURCES = \
 	g_entity_target.c \
 	g_entity_trigger.c \
 	g_hook.c \
+	g_intermission.c \
 	g_item.c \
 	g_main.c \
 	g_module.c \

--- a/src/game/ctf/g_types.h
+++ b/src/game/ctf/g_types.h
@@ -87,6 +87,7 @@ typedef enum {
 #define CS_ITEM_SET        (CS_GAME + 7)  // active item set (g_items_t)
 #define CS_HOOK_PULL_SPEED (CS_GAME + 8)  // hook speed
 #define CS_VOTE            (CS_GAME + 9)  // the vote in progress (bg_vote.h)
+#define CS_NEXT_MAP        (CS_GAME + 10) // the intermission's map candidates and tally (bg_intermission.h)
 
 
 /**

--- a/src/game/default/Makefile.am
+++ b/src/game/default/Makefile.am
@@ -48,6 +48,7 @@ game_la_SOURCES = \
 	g_entity_misc.c \
 	g_entity_target.c \
 	g_entity_trigger.c \
+	g_intermission.c \
 	g_item.c \
 	g_main.c \
 	g_module.c \

--- a/src/game/default/g_types.h
+++ b/src/game/default/g_types.h
@@ -84,6 +84,7 @@ typedef enum {
 #define CS_NAV_EDIT        (CS_GAME + 6)  // nav edit mode
 #define CS_ITEM_SET        (CS_GAME + 7)  // active item set (g_items_t)
 #define CS_VOTE            (CS_GAME + 8)  // the vote in progress (bg_vote.h)
+#define CS_NEXT_MAP        (CS_GAME + 9)  // the intermission's map candidates and tally (bg_intermission.h)
 
 /**
  * @brief Player state statistics (inventory, score, etc).

--- a/src/game/game.h
+++ b/src/game/game.h
@@ -576,12 +576,22 @@ typedef struct g_import_s {
   List *(*MapList)(void);
 
   /**
-   * @brief Names the map that the next `next_map` serves, in place of the rotation's pick.
-   * @param name The map name, which must name a map the server has.
-   * @remarks The override is consumed by that one map change, so that it can not survive
-   * to decide a later one.
+   * @return The index in `MapList` the running level was served from, or `-1` if it
+   * was not served from the rotation.
+   * @remarks This is what identifies the level when a rotation names the same map
+   * twice, which its name can not.
    */
-  void (*SetNextMap)(const char *name);
+  int32_t (*MapIndex)(void);
+
+  /**
+   * @brief Chooses the entry of `MapList` that the next `next_map` serves, in place of
+   * the rotation's own pick.
+   * @param index The index in `MapList`.
+   * @remarks An index rather than a name, so that a rotation naming the same map twice
+   * serves, and resumes from, the occurrence that was actually chosen. The override is
+   * consumed by that one map change, so that it can not survive to decide a later one.
+   */
+  void (*SetNextMap)(int32_t index);
 
   /**
    * @return The contents mask at the specific point. The point is tested

--- a/src/game/game.h
+++ b/src/game/game.h
@@ -25,7 +25,7 @@
 #include "collision/cm_types.h"
 #include <Objectively/Vector.h>
 
-#define GAME_API_VERSION 36
+#define GAME_API_VERSION 37
 
 /**
  * @brief Server flags for `g_entity_t`.
@@ -565,6 +565,23 @@ typedef struct g_import_s {
    * @brief Frees an entity definition from `LoadEntities`.
    */
   void (*FreeEntity)(cm_entity_t *entity);
+
+  /**
+   * @brief Returns the server's map rotation, as configured by `sv_map_list`.
+   * @return A list of `cm_entity_t *`, each to be freed with `FreeEntity`, or `NULL`
+   * if no rotation is configured.
+   * @remarks The list is a copy, so a `sv_map_list` edit can not free entries from
+   * underneath the caller.
+   */
+  List *(*MapList)(void);
+
+  /**
+   * @brief Names the map that the next `next_map` serves, in place of the rotation's pick.
+   * @param name The map name, which must name a map the server has.
+   * @remarks The override is consumed by that one map change, so that it can not survive
+   * to decide a later one.
+   */
+  void (*SetNextMap)(const char *name);
 
   /**
    * @return The contents mask at the specific point. The point is tested

--- a/src/game/lithium/Makefile.am
+++ b/src/game/lithium/Makefile.am
@@ -51,6 +51,7 @@ game_la_SOURCES = \
 	g_entity_target.c \
 	g_entity_trigger.c \
 	g_hook.c \
+	g_intermission.c \
 	g_item.c \
 	g_main.c \
 	g_module.c \

--- a/src/game/lithium/g_types.h
+++ b/src/game/lithium/g_types.h
@@ -87,6 +87,7 @@ typedef enum {
 #define CS_ITEM_SET        (CS_GAME + 7)  // active item set (g_items_t)
 #define CS_HOOK_PULL_SPEED (CS_GAME + 8)  // hook speed
 #define CS_VOTE            (CS_GAME + 9)  // the vote in progress (bg_vote.h)
+#define CS_NEXT_MAP        (CS_GAME + 10) // the intermission's map candidates and tally (bg_intermission.h)
 
 /**
  * @brief Player state statistics (inventory, score, etc).

--- a/src/game/race/Makefile.am
+++ b/src/game/race/Makefile.am
@@ -50,6 +50,7 @@ game_la_SOURCES = \
 	g_entity_target.c \
 	g_entity_trigger.c \
 	g_hook.c \
+	g_intermission.c \
 	g_item.c \
 	g_main.c \
 	g_module.c \

--- a/src/game/race/g_types.h
+++ b/src/game/race/g_types.h
@@ -92,6 +92,7 @@ typedef enum {
 #define CS_RACE_COURSE     (CS_GAME + 10) // checkpoints\finishes\valid, for the HUD
 #define CS_RACE_RECORDS    (CS_GAME + 11) // the top times under this movement, name\time pairs
 #define CS_RACE_GHOST      (CS_GAME + 12) // the course record holder as a CS_CLIENTS string, for the ghost's skin
+#define CS_NEXT_MAP        (CS_GAME + 13) // the intermission's map candidates and tally (bg_intermission.h)
 
 /**
  * @brief Player state statistics (inventory, score, etc).

--- a/src/server/sv_admin.c
+++ b/src/server/sv_admin.c
@@ -137,6 +137,17 @@ static void Sv_Map_f(void) {
  */
 void Sv_NextMap_f(void) {
 
+  // an override is consumed by this one map change, whether or not it is in the
+  // rotation, so that it can not survive to decide a later one
+  char next[MAX_QPATH];
+  q_strlcpy(next, svs.maps.next, sizeof(next));
+  svs.maps.next[0] = '\0';
+
+  if (*next) {
+    Sv_InitServer(next, Sv_SelectMap(next), SV_ACTIVE_GAME);
+    return;
+  }
+
   const cm_entity_t *props = Sv_NextMap();
   if (props) {
     const char *name = Cm_EntityValue(props, "name")->string;

--- a/src/server/sv_admin.c
+++ b/src/server/sv_admin.c
@@ -137,17 +137,6 @@ static void Sv_Map_f(void) {
  */
 void Sv_NextMap_f(void) {
 
-  // an override is consumed by this one map change, whether or not it is in the
-  // rotation, so that it can not survive to decide a later one
-  char next[MAX_QPATH];
-  q_strlcpy(next, svs.maps.next, sizeof(next));
-  svs.maps.next[0] = '\0';
-
-  if (*next) {
-    Sv_InitServer(next, Sv_SelectMap(next), SV_ACTIVE_GAME);
-    return;
-  }
-
   const cm_entity_t *props = Sv_NextMap();
   if (props) {
     const char *name = Cm_EntityValue(props, "name")->string;

--- a/src/server/sv_game.c
+++ b/src/server/sv_game.c
@@ -370,6 +370,7 @@ void Sv_InitGame(void) {
   import.LoadEntities = Cm_LoadEntities;
   import.FreeEntity = Cm_FreeEntity;
   import.MapList = Sv_MapList;
+  import.MapIndex = Sv_MapIndex;
   import.SetNextMap = Sv_SetNextMap;
   import.PointContents = Sv_PointContents;
   import.BoxContents = Sv_BoxContents;

--- a/src/server/sv_game.c
+++ b/src/server/sv_game.c
@@ -369,6 +369,8 @@ void Sv_InitGame(void) {
   import.EntityBrushes = Cm_EntityBrushes;
   import.LoadEntities = Cm_LoadEntities;
   import.FreeEntity = Cm_FreeEntity;
+  import.MapList = Sv_MapList;
+  import.SetNextMap = Sv_SetNextMap;
   import.PointContents = Sv_PointContents;
   import.BoxContents = Sv_BoxContents;
   import.PointInsideBrush = Cm_PointInsideBrush;

--- a/src/server/sv_init.c
+++ b/src/server/sv_init.c
@@ -334,6 +334,15 @@ void Sv_InitServer(const char *name, const cm_entity_t *props, sv_state_t state)
 
   Com_Debug(DEBUG_SERVER, "Sv_InitServer: %s (%d)\n", name, state);
 
+  // any override belongs to the map change that consumed it; whatever brought us here,
+  // it must not survive to decide the next one. A level served from outside the
+  // rotation has no position in it to resume from.
+  svs.maps.next = -1;
+
+  if (props == NULL) {
+    svs.maps.current = -1;
+  }
+
   Cbuf_CopyToDefer();
 
   // inform any connected clients to reconnect to us

--- a/src/server/sv_map_list.c
+++ b/src/server/sv_map_list.c
@@ -22,9 +22,9 @@
 #include "sv_local.h"
 
 /**
- * @brief Returns the next map from the configured list, or `NULL` if unavailable.
+ * @brief Re-parses the map list if the configured file has changed since it was loaded.
  */
-const cm_entity_t *Sv_NextMap(void) {
+static void Sv_RefreshMapList(void) {
 
   if (strlen(sv_map_list->string)) {
     if (q_strcmp(svs.maps.filename, sv_map_list->string) ||
@@ -32,6 +32,77 @@ const cm_entity_t *Sv_NextMap(void) {
       Sv_InitMapList();
     }
   }
+}
+
+/**
+ * @brief The list entry naming `name`, or `NULL`.
+ * @remarks The rotation resumes from whatever this returns, so that a map served out of
+ * turn does not leave `index` pointing at a position the server never actually reached.
+ */
+const cm_entity_t *Sv_SelectMap(const char *name) {
+
+  Sv_RefreshMapList();
+
+  if (svs.maps.list == NULL) {
+    return NULL;
+  }
+
+  int32_t i = 0;
+  for (const ListNode *node = svs.maps.list->head; node; node = node->next, i++) {
+    const cm_entity_t *props = (const cm_entity_t *) node->element;
+
+    if (!q_strcmp(Cm_EntityValue(props, "name")->string, name)) {
+      svs.maps.index = i;
+      return props;
+    }
+  }
+
+  return NULL;
+}
+
+/**
+ * @brief Returns a copy of the configured map list, or `NULL` if there is none.
+ * @return A list of `cm_entity_t *`, each to be freed with `Cm_FreeEntity`.
+ * @remarks The copy is the caller's, so that a `sv_map_list` edit which re-parses the
+ * list underneath them does not free entries they still hold.
+ */
+List *Sv_MapList(void) {
+
+  Sv_RefreshMapList();
+
+  if (svs.maps.list == NULL) {
+    return NULL;
+  }
+
+  List *copy = $(alloc(List), init);
+
+  for (const ListNode *node = svs.maps.list->head; node; node = node->next) {
+    $(copy, append, Cm_CopyEntity((const cm_entity_t *) node->element));
+  }
+
+  return copy;
+}
+
+/**
+ * @brief Names the map the next `next_map` serves, in place of the rotation's pick.
+ * @remarks The override is consumed by that one map change, so that it can not survive
+ * to decide a later one.
+ */
+void Sv_SetNextMap(const char *name) {
+
+  if (name && *name && Fs_Exists(va("maps/%s.bsp", name))) {
+    q_strlcpy(svs.maps.next, name, sizeof(svs.maps.next));
+  } else {
+    Com_Warn("Ignoring next map %s\n", name ? name : "(null)");
+  }
+}
+
+/**
+ * @brief Returns the next map from the configured list, or `NULL` if unavailable.
+ */
+const cm_entity_t *Sv_NextMap(void) {
+
+  Sv_RefreshMapList();
 
   if (svs.maps.list == NULL) {
     return NULL;
@@ -98,6 +169,7 @@ void Sv_InitMapList(void) {
 
   svs.maps.length = (int32_t) svs.maps.list->count;
   svs.maps.index = -1;
+  svs.maps.next[0] = '\0';
 
   Fs_Free(buffer);
 
@@ -114,4 +186,5 @@ void Sv_ShutdownMapList(void) {
   svs.maps.index = -1;
   svs.maps.modtime = 0;
   svs.maps.filename[0] = '\0';
+  svs.maps.next[0] = '\0';
 }

--- a/src/server/sv_map_list.c
+++ b/src/server/sv_map_list.c
@@ -23,41 +23,32 @@
 
 /**
  * @brief Re-parses the map list if the configured file has changed since it was loaded.
+ * @remarks The filename is compared even when `sv_map_list` is empty, so that clearing
+ * it drops the rotation rather than leaving the last one loaded.
  */
 static void Sv_RefreshMapList(void) {
 
-  if (strlen(sv_map_list->string)) {
-    if (q_strcmp(svs.maps.filename, sv_map_list->string) ||
-        (Fs_LastModTime(sv_map_list->string) != svs.maps.modtime)) {
-      Sv_InitMapList();
-    }
+  if (q_strcmp(svs.maps.filename, sv_map_list->string) ||
+      (*sv_map_list->string && Fs_LastModTime(sv_map_list->string) != svs.maps.modtime)) {
+    Sv_InitMapList();
   }
 }
 
 /**
- * @brief The list entry naming `name`, or `NULL`.
- * @remarks The rotation resumes from whatever this returns, so that a map served out of
- * turn does not leave `index` pointing at a position the server never actually reached.
+ * @brief The rotation entry at `index`, or `NULL`.
  */
-const cm_entity_t *Sv_SelectMap(const char *name) {
+static const cm_entity_t *Sv_MapAt(int32_t index) {
 
-  Sv_RefreshMapList();
-
-  if (svs.maps.list == NULL) {
+  if (svs.maps.list == NULL || index < 0 || index >= svs.maps.length) {
     return NULL;
   }
 
-  int32_t i = 0;
-  for (const ListNode *node = svs.maps.list->head; node; node = node->next, i++) {
-    const cm_entity_t *props = (const cm_entity_t *) node->element;
-
-    if (!q_strcmp(Cm_EntityValue(props, "name")->string, name)) {
-      svs.maps.index = i;
-      return props;
-    }
+  const ListNode *node = svs.maps.list->head;
+  for (int32_t i = 0; i < index && node; i++) {
+    node = node->next;
   }
 
-  return NULL;
+  return node ? (const cm_entity_t *) node->element : NULL;
 }
 
 /**
@@ -84,16 +75,31 @@ List *Sv_MapList(void) {
 }
 
 /**
- * @brief Names the map the next `next_map` serves, in place of the rotation's pick.
- * @remarks The override is consumed by that one map change, so that it can not survive
- * to decide a later one.
+ * @brief Returns the rotation index the running level was served from, or `-1` if it
+ * was not served from the rotation.
+ * @remarks This is what identifies the level when a list names the same map twice,
+ * which its name can not.
  */
-void Sv_SetNextMap(const char *name) {
+int32_t Sv_MapIndex(void) {
 
-  if (name && *name && Fs_Exists(va("maps/%s.bsp", name))) {
-    q_strlcpy(svs.maps.next, name, sizeof(svs.maps.next));
+  Sv_RefreshMapList();
+
+  return svs.maps.current;
+}
+
+/**
+ * @brief Chooses the rotation index the next `next_map` serves, in place of the
+ * rotation's own pick.
+ * @remarks An index rather than a name, so that a list naming the same map twice
+ * serves, and resumes from, the occurrence that was actually chosen. The override is
+ * consumed by that one map change, so that it can not survive to decide a later one.
+ */
+void Sv_SetNextMap(int32_t index) {
+
+  if (index >= 0 && index < svs.maps.length) {
+    svs.maps.next = index;
   } else {
-    Com_Warn("Ignoring next map %s\n", name ? name : "(null)");
+    Com_Warn("Ignoring next map %d\n", index);
   }
 }
 
@@ -104,11 +110,18 @@ const cm_entity_t *Sv_NextMap(void) {
 
   Sv_RefreshMapList();
 
+  // consumed whether or not it can be served, so that it can not survive to decide
+  // a later map change
+  const int32_t next = svs.maps.next;
+  svs.maps.next = -1;
+
   if (svs.maps.list == NULL) {
     return NULL;
   }
 
-  if (sv_map_list_shuffle->value && svs.maps.length > 1) {
+  if (next >= 0 && next < svs.maps.length) {
+    svs.maps.index = next;
+  } else if (sv_map_list_shuffle->value && svs.maps.length > 1) {
     const int32_t index = svs.maps.index;
     do {
       svs.maps.index = (int32_t) RandomRangeu(0, (uint32_t) svs.maps.length);
@@ -117,12 +130,9 @@ const cm_entity_t *Sv_NextMap(void) {
     svs.maps.index = (svs.maps.index + 1) % svs.maps.length;
   }
 
-  const ListNode *node = svs.maps.list->head;
-  for (int32_t i = 0; i < svs.maps.index && node; i++) {
-    node = node->next;
-  }
+  svs.maps.current = svs.maps.index;
 
-  return node ? (const cm_entity_t *) node->element : NULL;
+  return Sv_MapAt(svs.maps.index);
 }
 
 /**
@@ -169,7 +179,8 @@ void Sv_InitMapList(void) {
 
   svs.maps.length = (int32_t) svs.maps.list->count;
   svs.maps.index = -1;
-  svs.maps.next[0] = '\0';
+  svs.maps.current = -1;
+  svs.maps.next = -1;
 
   Fs_Free(buffer);
 
@@ -184,7 +195,8 @@ void Sv_ShutdownMapList(void) {
   svs.maps.list = release(svs.maps.list);
   svs.maps.length = 0;
   svs.maps.index = -1;
+  svs.maps.current = -1;
   svs.maps.modtime = 0;
   svs.maps.filename[0] = '\0';
-  svs.maps.next[0] = '\0';
+  svs.maps.next = -1;
 }

--- a/src/server/sv_map_list.h
+++ b/src/server/sv_map_list.h
@@ -26,6 +26,9 @@
 #if defined(__SV_LOCAL_H__)
 
 const cm_entity_t *Sv_NextMap(void);
+const cm_entity_t *Sv_SelectMap(const char *name);
+List *Sv_MapList(void);
+void Sv_SetNextMap(const char *name);
 void Sv_InitMapList(void);
 void Sv_ShutdownMapList(void);
 

--- a/src/server/sv_map_list.h
+++ b/src/server/sv_map_list.h
@@ -26,9 +26,9 @@
 #if defined(__SV_LOCAL_H__)
 
 const cm_entity_t *Sv_NextMap(void);
-const cm_entity_t *Sv_SelectMap(const char *name);
 List *Sv_MapList(void);
-void Sv_SetNextMap(const char *name);
+int32_t Sv_MapIndex(void);
+void Sv_SetNextMap(int32_t index);
 void Sv_InitMapList(void);
 void Sv_ShutdownMapList(void);
 

--- a/src/server/sv_types.h
+++ b/src/server/sv_types.h
@@ -367,6 +367,12 @@ typedef struct {
    * @brief The modification time of the file when it was last loaded.
    */
   int64_t modtime;
+
+  /**
+   * @brief The map `Sv_SetNextMap` named, which the next `Sv_NextMap` returns in
+   * place of the rotation's pick, or empty. Consumed as soon as it is read.
+   */
+  char next[MAX_QPATH];
 } sv_map_list_t;
 
 /**

--- a/src/server/sv_types.h
+++ b/src/server/sv_types.h
@@ -364,15 +364,23 @@ typedef struct {
   int32_t index;
 
   /**
+   * @brief The index the running level was served from, or `-1` if it did not come
+   * from the rotation. This is not `index`, which is only where the rotation has
+   * reached: a list may name the same map more than once, and the two occurrences
+   * are different positions to resume from.
+   */
+  int32_t current;
+
+  /**
    * @brief The modification time of the file when it was last loaded.
    */
   int64_t modtime;
 
   /**
-   * @brief The map `Sv_SetNextMap` named, which the next `Sv_NextMap` returns in
-   * place of the rotation's pick, or empty. Consumed as soon as it is read.
+   * @brief The index `Sv_SetNextMap` chose, which the next `Sv_NextMap` returns in
+   * place of the rotation's pick, or `-1`. Consumed as soon as it is read.
    */
-  char next[MAX_QPATH];
+  int32_t next;
 } sv_map_list_t;
 
 /**


### PR DESCRIPTION
Closes #1035.

The intermission showed the scoreboard and nothing else: no sense of how long was left, and no say in what came next. This gives it a countdown and a strip of map tiles along the bottom, and — with `g_vote_next_map` set — lets players pick what follows by pressing `1`–`4`.

On `campgrounds` against the stock 25-entry `maps.lst`, the strip shows `1 edge`, `2 tokays`, `3 fragpipe`, `4 hallways`: the four entries following the current map in rotation order, each a 16:9 mapshot over its name and tally, with the countdown beneath.

## How it fits together

**The server gains two accessors.** `Sv_NextMap()` reads `svs`, which the game module never sees, and advances the rotation as a side effect, so there was no way to ask what is next without committing to it. `Sv_MapList()` returns a *copy* of the rotation — ownership matching `gi.LoadEntities` beside it — so a `sv_map_list` edit that re-parses the list cannot free entries a caller still holds. `Sv_SetNextMap()` names the map the next `next_map` serves, consumed by that one map change so it cannot survive to decide a later one, and resolving it writes `svs.maps.index` back so the rotation resumes from what was actually served.

**The game decides.** `g_intermission.c` installs over the same chainable hooks `g_vote.c` uses, and always calls `gi.SetNextMap` — voting or not. Candidates come only from `gi.MapList()`: find the current map, walk forward with `% length` wrapping, take the first four that survive filtering. Entries whose `.bsp` is missing are skipped (`next_map` never checked, so a vote could otherwise *elect* a broken entry), and entries are de-duplicated by name so a rotation listing a map twice neither splits its vote nor offers the map already being played.

**The client draws it.** `IntermissionView` belongs to the `HudViewController` rather than to the hud, as the scoreboard does, because the hud hides itself for the intermission and this is exactly when it must show. The scoreboard is top-anchored and grows down, so the strip takes the bottom and the two do not meet.

## Notable choices

- **There is no `g_level.vote` to hijack**, as #1035 suggested. Vote state is a file-static in `g_vote.c`, binary yes/no with a threshold — the wrong shape for N-way plurality. This is a sibling mechanism instead; the two never overlap, since `G_Vote_Check` already cancels a running vote at intermission.
- **Voting is by number key, not by clicking.** `Ui_HandleEvent` drops mouse events unless key dest is `KEY_UI`, and `Ui_Draw` makes the HUD layer and the menu layer mutually exclusive — `KEY_UI` also skips `cgame->UpdateScreen`, so clicking would have cost the intermission camera *and* the scoreboard. The client hands cgame every event unconditionally, so the handler is gated on `cgi.GetKeyDest() == KEY_GAME`; without that, typing a digit into the console would vote.
- **`CS_TIME` carries the countdown.** The match clock stops at the intermission and the HUD that reads it is hidden by then. `STAT_TIME` stays zero, which is what hides the HUD.
- `G_FormatTime` and `INTERMISSION` moved to `g_main.h`, and `G_Vote_Eligible` is no longer static so both votes share one definition of who may vote. `g_main.c` carries no intermission-vote logic.
- `GAME_API_VERSION` 36 → 37 for the two new imports. `PROTOCOL_*` is untouched; config string indices are game-module private, and `CS_NEXT_MAP` is appended to each module's block rather than inserted, since recorded demos replay against those positions.

## Verified

Driven against a sandbox search path so nothing in the live game dir was touched.

- **A real keypress decides the map.** Tally moves, `hallways wins the vote with 1 of 1`, `hallways` loads.
- **The key-destination guard holds.** Instrumented, events arriving with `KEY_CONSOLE` reach the handler and produce no ballot; `KEY_GAME` votes normally.
- **Only the rotation is offered.** 25 entries, 26 maps installed; maps installed but absent from `maps.lst` were never offered.
- **The rotation stays honest.** Three intermissions back to back advanced `campgrounds → miner → claustrophobopolis`; without the index write-back the override would have frozen it.
- **Degenerate rotations.** A missing `.bsp` and a duplicated entry collapse to one candidate and the vote turns itself off — one candidate is not a choice. An empty `sv_map_list` publishes the current map and replays it, matching the existing fallback. A rotation naming the current map twice no longer offers it.

Only the autotools build has been run locally. The Xcode and MSVC project files are updated and validate structurally, with the three new sources present in all four game and cgame targets and the four json/css resources in the right copy phases, but neither has been compiled here — CI covers that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
